### PR TITLE
fix: migrate AztecAddress.ZERO to NO_FROM for 4.2.0-nightly

### DIFF
--- a/packages/playground/scripts/batch-fund-fpc.ts
+++ b/packages/playground/scripts/batch-fund-fpc.ts
@@ -15,6 +15,7 @@
  *   L1_RPC_URL=https://... Sepolia RPC endpoint
  */
 
+import { NO_FROM } from "@aztec/aztec.js/account";
 import { AztecAddress } from "@aztec/aztec.js/addresses";
 import { L1FeeJuicePortalManager } from "@aztec/aztec.js/ethereum";
 import { FeeJuicePaymentMethodWithClaim } from "@aztec/aztec.js/fee";
@@ -261,7 +262,7 @@ const feeMethod = new FeeJuicePaymentMethodWithClaim(deployerAddress, {
   messageLeafIndex: deployerClaim.messageLeafIndex,
 });
 const { receipt: deployReceipt } = await deployMethod.send({
-  from: AztecAddress.ZERO,
+  from: NO_FROM,
   fee: { paymentMethod: feeMethod },
   wait: { returnReceipt: true },
 });

--- a/packages/playground/scripts/deploy-sponsored-fpc.ts
+++ b/packages/playground/scripts/deploy-sponsored-fpc.ts
@@ -23,6 +23,7 @@
  */
 
 import { execSync } from "node:child_process";
+import { NO_FROM } from "@aztec/aztec.js/account";
 import { AztecAddress } from "@aztec/aztec.js/addresses";
 import { L1FeeJuicePortalManager } from "@aztec/aztec.js/ethereum";
 import { FeeJuicePaymentMethodWithClaim } from "@aztec/aztec.js/fee";
@@ -149,7 +150,7 @@ async function bootstrapAccount(): Promise<{
     messageLeafIndex: claim.messageLeafIndex,
   });
   const { receipt } = await deployMethod.send({
-    from: AztecAddress.ZERO,
+    from: NO_FROM,
     fee: { paymentMethod: feeMethod },
     wait: { returnReceipt: true },
   });

--- a/packages/playground/src/aztec.ts
+++ b/packages/playground/src/aztec.ts
@@ -4,7 +4,8 @@ import {
   AcceleratorProver,
 } from "@alejoamiras/aztec-accelerator";
 import { getInitialTestAccountsData } from "@aztec/accounts/testing/lazy";
-import { AztecAddress } from "@aztec/aztec.js/addresses";
+import { NO_FROM } from "@aztec/aztec.js/account";
+import type { AztecAddress } from "@aztec/aztec.js/addresses";
 import { NO_WAIT } from "@aztec/aztec.js/contracts";
 import { SponsoredFeePaymentMethod } from "@aztec/aztec.js/fee";
 import { Fr } from "@aztec/aztec.js/fields";
@@ -480,7 +481,7 @@ export async function deployTestAccount(
     log(`Account: ${accountManager.address.toString()}`);
 
     const sendOpts = {
-      from: state.proofsRequired ? AztecAddress.ZERO : state.registeredAddresses[0],
+      from: state.proofsRequired ? NO_FROM : state.registeredAddresses[0],
       skipClassPublication: true,
       fee: { paymentMethod: state.feePaymentMethod! },
       // Account constructor initializes private storage — needs its own nullifier key in scope.
@@ -488,7 +489,7 @@ export async function deployTestAccount(
     };
 
     // Step 2: Simulate (captures witness gen timing)
-    // Simulate may fail with AztecAddress.ZERO (first deploy on live networks)
+    // Simulate may fail with NO_FROM (first deploy on live networks)
     onStep("simulating deploy");
     log("Simulating deploy...");
     stepStart = Date.now();
@@ -648,7 +649,7 @@ export async function runTokenFlow(
       const bobDeploy = await bobManager.getDeployMethod();
       // Account constructor initializes private storage — needs its own nullifier key in scope.
       const bobSendOpts = {
-        from: AztecAddress.ZERO,
+        from: NO_FROM,
         skipClassPublication: true,
         fee,
         additionalScopes: [bobManager.address],

--- a/packages/sdk/e2e/e2e-helpers.ts
+++ b/packages/sdk/e2e/e2e-helpers.ts
@@ -5,7 +5,7 @@
  * via EmbeddedWallet + Sponsored FPC.
  */
 
-import { AztecAddress } from "@aztec/aztec.js/addresses";
+import { NO_FROM } from "@aztec/aztec.js/account";
 import type { SponsoredFeePaymentMethod } from "@aztec/aztec.js/fee";
 import { Fr } from "@aztec/aztec.js/fields";
 import type { EmbeddedWallet } from "@aztec/wallets/embedded";
@@ -29,7 +29,7 @@ export async function deploySchnorrAccount(
   const startTime = Date.now();
   const deployMethod = await accountManager.getDeployMethod();
   const { contract: deployedContract } = await deployMethod.send({
-    from: AztecAddress.ZERO,
+    from: NO_FROM,
     skipClassPublication: true,
     fee: { paymentMethod: feePaymentMethod },
   });

--- a/packages/sdk/e2e/proving.test.ts
+++ b/packages/sdk/e2e/proving.test.ts
@@ -6,7 +6,7 @@
  *   - Accelerated: real accelerator desktop app (skipped when ACCELERATOR_URL not set)
  *   - Local (WASM): fallback via unreachable port
  *
- * Network-agnostic: always uses Sponsored FPC + from: AztecAddress.ZERO.
+ * Network-agnostic: always uses Sponsored FPC + from: NO_FROM.
  * Services must be running before tests start (asserted by e2e-setup.ts preload).
  */
 


### PR DESCRIPTION
## Summary

- Aztec 4.2.0-nightly replaced `AztecAddress.ZERO` with `NO_FROM` string constant for sender-less transactions
- `EmbeddedWallet.getAccountFromAddress` no longer has a zero-address guard — it crashes trying to look up `0x000...` in the wallet DB
- Updated all 5 files: SDK e2e helpers, playground aztec.ts, deploy-sponsored-fpc script, batch-fund-fpc script

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run test` — 90 unit tests pass
- [ ] CI e2e tests with 4.2.0-nightly (the real validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)