### PR TITLE
fix: correct SDK build command in publish workflow

### DIFF
--- a/.github/workflows/_publish-sdk.yml
+++ b/.github/workflows/_publish-sdk.yml
@@ -57,7 +57,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build SDK
-        run: bun run sdk:build
+        run: bun run --cwd packages/sdk build
 
       - name: Read Aztec version
         id: aztec-version


### PR DESCRIPTION
## Summary

- `bun run sdk:build` doesn't exist in root package.json — fix to `bun run --cwd packages/sdk build`
- Already fixed on `nightlies` branch where it was caught during first nightly publish

## Test plan

- [x] `bun run lint:actions` — clean
- [x] Validated on nightlies: publish-nightlies succeeded with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)