### PR TITLE
fix(accelerator): validate version header, truncate errors, restrict log permissions

### DIFF
--- a/packages/accelerator/src-tauri/src/bb.rs
+++ b/packages/accelerator/src-tauri/src/bb.rs
@@ -107,7 +107,21 @@ pub async fn prove(
     }
 
     if !output.status.success() {
-        return Err(format!("bb prove failed (exit {}): {stderr}", output.status).into());
+        // Truncate stderr in error responses to avoid leaking unbounded output to HTTP clients
+        let truncated_stderr = if stderr.len() > 500 {
+            format!(
+                "{}... [truncated, {} bytes total]",
+                &stderr[..500],
+                stderr.len()
+            )
+        } else {
+            stderr.to_string()
+        };
+        return Err(format!(
+            "bb prove failed (exit {}): {truncated_stderr}",
+            output.status
+        )
+        .into());
     }
 
     let proof_path = output_dir.join("proof");

--- a/packages/accelerator/src-tauri/src/main.rs
+++ b/packages/accelerator/src-tauri/src/main.rs
@@ -180,6 +180,13 @@ fn main() {
     let log_path = log_dir();
     std::fs::create_dir_all(&log_path).ok();
 
+    // Restrict log directory permissions to owner-only on Unix (0o700)
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&log_path, std::fs::Permissions::from_mode(0o700));
+    }
+
     let file_appender = tracing_appender::rolling::RollingFileAppender::builder()
         .rotation(tracing_appender::rolling::Rotation::DAILY)
         .filename_prefix("accelerator")

--- a/packages/accelerator/src-tauri/src/server.rs
+++ b/packages/accelerator/src-tauri/src/server.rs
@@ -165,6 +165,16 @@ impl Drop for StatusGuard {
     }
 }
 
+/// Validate that a version string contains only safe characters for URL interpolation.
+/// Allows digits, ASCII letters, dots, hyphens, and underscores.
+fn is_valid_version(version: &str) -> bool {
+    !version.is_empty()
+        && version.len() <= 128
+        && version
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_')
+}
+
 async fn prove(
     State(state): State<AppState>,
     headers: axum::http::HeaderMap,
@@ -179,7 +189,18 @@ async fn prove(
         .and_then(|v| v.to_str().ok())
         .map(|v| v.to_string());
 
+    // Validate version string to prevent URL manipulation in download URLs.
+    // Only allows semver-like strings: digits, dots, hyphens, and ASCII letters.
     if let Some(ref v) = requested_version {
+        if !is_valid_version(v) {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!(
+                    "Invalid x-aztec-version header: version must match \
+                     ^[0-9a-zA-Z._-]+$ (got '{v}')"
+                ),
+            ));
+        }
         tracing::info!(version = %v, "Requested Aztec version");
     }
 
@@ -442,6 +463,45 @@ mod tests {
             runtime["available_parallelism"].as_u64().unwrap() > 0,
             "available_parallelism should be > 0"
         );
+    }
+
+    #[test]
+    fn valid_version_strings_accepted() {
+        assert!(is_valid_version("5.0.0"));
+        assert!(is_valid_version("5.0.0-nightly.20260307"));
+        assert!(is_valid_version("5.0.0-rc.1"));
+        assert!(is_valid_version("5.0.0-devnet.20260307"));
+        assert!(is_valid_version("1.2.3-alpha_beta"));
+    }
+
+    #[test]
+    fn invalid_version_strings_rejected() {
+        assert!(!is_valid_version(""));
+        assert!(!is_valid_version("5.0.0; rm -rf /"));
+        assert!(!is_valid_version("../../../etc/passwd"));
+        assert!(!is_valid_version("5.0.0\n"));
+        assert!(!is_valid_version("5.0.0 "));
+        assert!(!is_valid_version("v5.0.0/../../malicious"));
+        assert!(!is_valid_version(&"a".repeat(129)));
+    }
+
+    #[tokio::test]
+    async fn prove_rejects_invalid_version_header() {
+        let app = router(AppState::default());
+        let response: axum::http::Response<_> = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/prove")
+                    .header("content-type", "application/octet-stream")
+                    .header("x-aztec-version", "../../../etc/passwd")
+                    .body(Body::from(vec![0u8; 10]))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Security hardening for the accelerator server:

- **Validate `x-aztec-version` header**: Only allows ASCII alphanumeric + `.` + `-` + `_`, max 128 chars. Prevents URL manipulation in bb download URLs. Returns 400 on invalid input. Includes 3 new tests.
- **Truncate bb stderr in HTTP error responses**: Caps at 500 chars (matching log truncation) to avoid leaking temp paths and system info to HTTP clients.
- **Restrict log directory permissions**: Sets `0o700` on Unix after creation so other users can't read log files.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` — no warnings
- [x] `cargo test` — 39 tests pass (3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)