### PR TITLE
fix: scope workflow secrets to minimum required

### DIFF
--- a/.github/workflows/_aztec-update.yml
+++ b/.github/workflows/_aztec-update.yml
@@ -30,6 +30,9 @@ on:
         required: false
         default: ""
         type: string
+    secrets:
+      PAT_TOKEN:
+        required: true
 
 jobs:
   # ── Job 1: Check if a newer version exists ─────────────────────────

--- a/.github/workflows/_e2e-app.yml
+++ b/.github/workflows/_e2e-app.yml
@@ -18,6 +18,9 @@ on:
         required: false
         type: string
         default: "http://localhost:8080"
+    secrets:
+      SPONSORED_FPC_SALT:
+        required: false
 
 jobs:
   e2e-app:

--- a/.github/workflows/_e2e.yml
+++ b/.github/workflows/_e2e.yml
@@ -18,6 +18,9 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      SPONSORED_FPC_SALT:
+        required: false
 
 jobs:
   e2e-sdk:

--- a/.github/workflows/_publish-sdk.yml
+++ b/.github/workflows/_publish-sdk.yml
@@ -24,6 +24,9 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      NPM_TOKEN:
+        required: true
 
 jobs:
   publish:

--- a/.github/workflows/accelerator.yml
+++ b/.github/workflows/accelerator.yml
@@ -127,7 +127,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.relevant == 'true'
     uses: ./.github/workflows/_e2e.yml
-    secrets: inherit
+    secrets:
+      SPONSORED_FPC_SALT: ${{ secrets.SPONSORED_FPC_SALT }}
     with:
       build_accelerator: true
 

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -98,7 +98,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.relevant == 'true'
     uses: ./.github/workflows/_e2e-app.yml
-    secrets: inherit
+    secrets:
+      SPONSORED_FPC_SALT: ${{ secrets.SPONSORED_FPC_SALT }}
     with:
       test_script: "test:e2e:local-network"
 

--- a/.github/workflows/aztec-nightlies.yml
+++ b/.github/workflows/aztec-nightlies.yml
@@ -21,7 +21,8 @@ permissions:
 jobs:
   update:
     uses: ./.github/workflows/_aztec-update.yml
-    secrets: inherit
+    secrets:
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
     with:
       dist_tag: nightly
       target_branch: nightlies

--- a/.github/workflows/aztec-stable.yml
+++ b/.github/workflows/aztec-stable.yml
@@ -21,7 +21,8 @@ permissions:
 jobs:
   update:
     uses: ./.github/workflows/_aztec-update.yml
-    secrets: inherit
+    secrets:
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
     with:
       dist_tag: rc
       target_branch: main

--- a/.github/workflows/publish-nightlies.yml
+++ b/.github/workflows/publish-nightlies.yml
@@ -41,7 +41,8 @@ jobs:
     uses: ./.github/workflows/_publish-sdk.yml
     with:
       dist_tag: nightlies
-    secrets: inherit
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   deploy-app:
     needs: e2e

--- a/.github/workflows/publish-testnet.yml
+++ b/.github/workflows/publish-testnet.yml
@@ -42,7 +42,8 @@ jobs:
     with:
       dist_tag: testnet
       latest: true
-    secrets: inherit
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   deploy-app:
     needs: e2e

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -95,7 +95,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.relevant == 'true'
     uses: ./.github/workflows/_e2e.yml
-    secrets: inherit
+    secrets:
+      SPONSORED_FPC_SALT: ${{ secrets.SPONSORED_FPC_SALT }}
 
   sdk-status:
     name: SDK Status


### PR DESCRIPTION
## Summary

Replaces `secrets: inherit` (passes ALL repo secrets) with explicit per-workflow secret declarations:

| Reusable workflow | Secret it receives | Previously received |
|---|---|---|
| `_e2e.yml` | `SPONSORED_FPC_SALT` | ALL (NPM_TOKEN, PAT_TOKEN, APPLE_CERTIFICATE, AWS_ROLE_ARN, etc.) |
| `_e2e-app.yml` | `SPONSORED_FPC_SALT` | ALL |
| `_publish-sdk.yml` | `NPM_TOKEN` | ALL |
| `_aztec-update.yml` | `PAT_TOKEN` | ALL |

7 caller workflows updated.

## Test plan

- [x] `bun run lint:actions` — clean
- [ ] CI: all workflow checks pass (validates secret wiring works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)