### PR TITLE
fix(accelerator): window lifecycle bugs + auth integration tests

### DIFF
--- a/packages/accelerator/src-tauri/src/commands.rs
+++ b/packages/accelerator/src-tauri/src/commands.rs
@@ -97,19 +97,13 @@ pub fn respond_auth(
     }
 }
 
-/// Sanitize an origin string for use as a Tauri window label.
-/// Window labels must be alphanumeric with hyphens/underscores.
+/// Create a unique, collision-free window label from an origin string.
+/// Uses a truncated SHA-256 hash to avoid collisions between similar origins
+/// (e.g. `example.com` vs `example_com` would collide with naive character replacement).
 pub fn sanitize_window_label(origin: &str) -> String {
-    origin
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect()
+    use sha2::{Digest, Sha256};
+    let hash = Sha256::digest(origin.as_bytes());
+    hash.iter().take(6).map(|b| format!("{b:02x}")).collect()
 }
 
 /// Enable Safari Support: generate certs, install trust, save config, start HTTPS.

--- a/packages/accelerator/src-tauri/src/main.rs
+++ b/packages/accelerator/src-tauri/src/main.rs
@@ -451,9 +451,33 @@ fn main() {
 
             Ok(())
         })
-        .run(tauri::generate_context!())
-        .expect("error while running Aztec Accelerator");
+        .build(tauri::generate_context!())
+        .expect("error while building Aztec Accelerator")
+        .run(|_app, event| {
+            // Tray-only app — keep running when Settings or auth popup windows are closed.
+            if let tauri::RunEvent::ExitRequested { api, .. } = event {
+                api.prevent_exit();
+            }
+        });
 }
+
+/// On macOS, switch to Regular activation policy so the window appears in Dock/Cmd+Tab.
+/// Registers a destroy listener on the window to switch back to Accessory when all windows close.
+#[cfg(target_os = "macos")]
+fn activate_for_window(app: &AppHandle, window: &tauri::WebviewWindow) {
+    let _ = app.set_activation_policy(tauri::ActivationPolicy::Regular);
+    let handle = app.clone();
+    window.on_window_event(move |event| {
+        if let tauri::WindowEvent::Destroyed = event {
+            if handle.webview_windows().is_empty() {
+                let _ = handle.set_activation_policy(tauri::ActivationPolicy::Accessory);
+            }
+        }
+    });
+}
+
+#[cfg(not(target_os = "macos"))]
+fn activate_for_window(_app: &AppHandle, _window: &tauri::WebviewWindow) {}
 
 /// Open or focus the Settings window.
 fn open_settings_window(app: &AppHandle) {
@@ -461,12 +485,16 @@ fn open_settings_window(app: &AppHandle) {
         let _ = window.set_focus();
         return;
     }
-    let _ = WebviewWindowBuilder::new(app, "settings", WebviewUrl::App("settings.html".into()))
-        .title("Aztec Accelerator Settings")
-        .inner_size(500.0, 450.0)
-        .resizable(false)
-        .center()
-        .build();
+    if let Ok(window) =
+        WebviewWindowBuilder::new(app, "settings", WebviewUrl::App("settings.html".into()))
+            .title("Aztec Accelerator Settings")
+            .inner_size(500.0, 450.0)
+            .resizable(false)
+            .center()
+            .build()
+    {
+        activate_for_window(app, &window);
+    }
 }
 
 /// Show the authorization popup for an unknown origin.
@@ -480,13 +508,16 @@ fn show_auth_popup_window(app: &AppHandle, origin: &str, auth_manager: &Arc<Auth
     }
 
     let url = format!("authorize.html?origin={}", urlencoding::encode(origin));
-    let _ = WebviewWindowBuilder::new(app, &label, WebviewUrl::App(url.into()))
+    if let Ok(window) = WebviewWindowBuilder::new(app, &label, WebviewUrl::App(url.into()))
         .title("Authorize Site")
         .inner_size(400.0, 250.0)
         .resizable(false)
         .center()
         .always_on_top(true)
-        .build();
+        .build()
+    {
+        activate_for_window(app, &window);
+    }
 
     // Spawn 60s timeout — always resolve with Deny if still pending.
     // This handles both: (a) user ignoring the popup, and (b) user closing the

--- a/packages/accelerator/src-tauri/src/server.rs
+++ b/packages/accelerator/src-tauri/src/server.rs
@@ -148,8 +148,14 @@ async fn health(State(state): State<AppState>) -> impl IntoResponse {
         "bb_available": bb::find_bb(None).is_ok(),
     });
 
-    if let Some(port) = state.https_port {
-        body["https_port"] = json!(port);
+    // Report HTTPS port if Safari Support is enabled (reads live config, not static state,
+    // so runtime enable_safari_support is reflected immediately without restart).
+    let safari_enabled = state
+        .config
+        .as_ref()
+        .is_some_and(|cfg| cfg.read().unwrap().safari_support);
+    if state.https_port.is_some() || safari_enabled {
+        body["https_port"] = json!(HTTPS_PORT);
     }
 
     // Runtime diagnostics only in debug builds — avoid leaking user hardware info in production
@@ -675,5 +681,211 @@ mod tests {
         assert!(versions
             .iter()
             .any(|v| v.as_str() == Some("5.0.0-nightly.20260307")));
+    }
+
+    /// Helper: build an AppState with auth enabled and a mock popup callback.
+    fn auth_state_with_popup(
+        popup_tx: std::sync::mpsc::Sender<String>,
+    ) -> (AppState, Arc<crate::authorization::AuthorizationManager>) {
+        let auth = Arc::new(crate::authorization::AuthorizationManager::new());
+        let auth_for_state = auth.clone();
+        let cfg = crate::config::AcceleratorConfig::default();
+        let state = AppState {
+            auth_manager: Some(auth_for_state),
+            config: Some(Arc::new(std::sync::RwLock::new(cfg))),
+            show_auth_popup: Some(Arc::new(move |origin: &str| {
+                let _ = popup_tx.send(origin.to_string());
+            })),
+            prove_semaphore: Some(Arc::new(Semaphore::new(1))),
+            ..Default::default()
+        };
+        (state, auth)
+    }
+
+    #[tokio::test]
+    async fn prove_auto_approves_localhost_origin() {
+        let (popup_tx, popup_rx) = std::sync::mpsc::channel();
+        let (state, _auth) = auth_state_with_popup(popup_tx);
+        let app = router(state);
+
+        let response: axum::http::Response<_> = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/prove")
+                    .header("content-type", "application/octet-stream")
+                    .header("origin", "http://localhost:5173")
+                    .body(Body::from(vec![0u8; 10]))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Localhost is auto-approved — should NOT trigger popup, should proceed to proving
+        // (which fails because bb is not available, but that's fine — we're testing the auth gate)
+        assert_ne!(response.status(), StatusCode::FORBIDDEN);
+        assert!(
+            popup_rx.try_recv().is_err(),
+            "popup should not fire for localhost"
+        );
+    }
+
+    #[tokio::test]
+    async fn prove_triggers_popup_for_unknown_origin() {
+        let (popup_tx, popup_rx) = std::sync::mpsc::channel();
+        let (state, auth) = auth_state_with_popup(popup_tx);
+        let app = router(state);
+
+        // Spawn a task that auto-approves after the popup fires
+        let auth_clone = auth.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            auth_clone.resolve(
+                "https://unknown-site.com",
+                crate::authorization::AuthDecision::Allow { remember: false },
+            );
+        });
+
+        let response: axum::http::Response<_> = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/prove")
+                    .header("content-type", "application/octet-stream")
+                    .header("origin", "https://unknown-site.com")
+                    .body(Body::from(vec![0u8; 10]))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Popup should have been triggered
+        assert_eq!(popup_rx.recv().unwrap(), "https://unknown-site.com");
+        // After approval, should proceed (not 403)
+        assert_ne!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn prove_returns_403_when_origin_denied() {
+        let (popup_tx, _popup_rx) = std::sync::mpsc::channel();
+        let (state, auth) = auth_state_with_popup(popup_tx);
+        let app = router(state);
+
+        // Auto-deny after popup fires
+        let auth_clone = auth.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            auth_clone.resolve("https://evil.com", crate::authorization::AuthDecision::Deny);
+        });
+
+        let response: axum::http::Response<_> = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/prove")
+                    .header("content-type", "application/octet-stream")
+                    .header("origin", "https://evil.com")
+                    .body(Body::from(vec![0u8; 10]))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"], "origin_denied");
+    }
+
+    #[tokio::test]
+    async fn prove_skips_auth_when_no_origin_header() {
+        let (popup_tx, popup_rx) = std::sync::mpsc::channel();
+        let (state, _auth) = auth_state_with_popup(popup_tx);
+        let app = router(state);
+
+        let response: axum::http::Response<_> = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/prove")
+                    .header("content-type", "application/octet-stream")
+                    .body(Body::from(vec![0u8; 10]))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // No Origin header = auto-approved (curl, same-origin)
+        assert_ne!(response.status(), StatusCode::FORBIDDEN);
+        assert!(
+            popup_rx.try_recv().is_err(),
+            "popup should not fire without Origin"
+        );
+    }
+
+    #[tokio::test]
+    async fn prove_approves_remembered_origin() {
+        let (popup_tx, popup_rx) = std::sync::mpsc::channel();
+        let (state, _auth) = auth_state_with_popup(popup_tx);
+
+        // Pre-approve the origin in config
+        if let Some(ref cfg) = state.config {
+            cfg.write()
+                .unwrap()
+                .approved_origins
+                .push("https://approved-site.com".to_string());
+        }
+
+        let app = router(state);
+        let response: axum::http::Response<_> = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/prove")
+                    .header("content-type", "application/octet-stream")
+                    .header("origin", "https://approved-site.com")
+                    .body(Body::from(vec![0u8; 10]))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_ne!(response.status(), StatusCode::FORBIDDEN);
+        assert!(
+            popup_rx.try_recv().is_err(),
+            "popup should not fire for approved origin"
+        );
+    }
+
+    #[tokio::test]
+    async fn prove_returns_403_without_popup_in_headless() {
+        // Headless mode: auth_manager is set but show_auth_popup is None
+        let auth = Arc::new(crate::authorization::AuthorizationManager::new());
+        let cfg = crate::config::AcceleratorConfig::default();
+        let state = AppState {
+            auth_manager: Some(auth),
+            config: Some(Arc::new(std::sync::RwLock::new(cfg))),
+            show_auth_popup: None, // headless
+            ..Default::default()
+        };
+        let app = router(state);
+
+        let response: axum::http::Response<_> = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/prove")
+                    .header("content-type", "application/octet-stream")
+                    .header("origin", "https://unknown.com")
+                    .body(Body::from(vec![0u8; 10]))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Headless with no popup = instant deny
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
 }


### PR DESCRIPTION
## Summary

Fixes 3 bugs introduced by the settings/auth windows PR, and adds integration tests that would have caught them.

### Bug fixes
- **App exit on window close**: Closing Settings or auth popup killed the entire app (Tauri exits when last window closes). Fixed with `ExitRequested` prevention.
- **Lost popup on macOS**: Auth popup invisible in Cmd+Tab/Dock because of `Accessory` activation policy. Now switches to `Regular` while windows are open, back to `Accessory` when all close.
- **`/health` stale `https_port`**: Runtime Safari enable didn't update the HTTP server's health response. Now reads live config.
- **Window label collisions**: `sanitize_window_label` used naive character replacement (`.` → `_`), causing `example.com` and `example_com` to collide. Now uses SHA-256 hash.

### Integration tests (6 new)
Tests the full `/prove` auth gate via Axum `oneshot()` with mock popup callbacks:
- Localhost auto-approved (no popup)
- Unknown origin triggers popup, approve → proceeds
- Unknown origin denied → 403
- No Origin header → auto-approved
- Pre-approved origin → no popup
- Headless mode (no popup) → instant 403

## Test plan
- [x] `cargo test` — 52 tests pass
- [x] `bun run test` — 90 tests pass
- [ ] Manual: open/close Settings, app stays running
- [ ] Manual: auth popup visible in Cmd+Tab on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)