### PR TITLE
chore(accelerator): auto-bump source version after release, bump to rc.8

### DIFF
--- a/.github/workflows/release-accelerator.yml
+++ b/.github/workflows/release-accelerator.yml
@@ -12,13 +12,15 @@ concurrency:
   group: release-accelerator
   cancel-in-progress: false
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   tag:
     name: Create Git Tag
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions:
-      contents: write
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
       version: ${{ steps.tag.outputs.version }}
@@ -135,8 +137,6 @@ jobs:
     needs: [tag, build]
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions:
-      contents: write
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v8
@@ -215,3 +215,77 @@ jobs:
             --title "Aztec Accelerator $VERSION" \
             --notes-file /tmp/release-notes.md \
             "${FILES[@]}"
+
+  bump-source:
+    name: Bump source version
+    needs: [tag, release]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Compute next version
+        id: next
+        env:
+          RELEASED: ${{ needs.tag.outputs.version }}
+        run: |
+          # If rc release (1.0.0-rc.7), bump rc number (1.0.0-rc.8)
+          # If stable release (1.0.0), bump patch and start rc.1 (1.0.1-rc.1)
+          NEXT=$(bun -e "
+            const v = process.env.RELEASED;
+            const rcMatch = v.match(/^(.+)-rc\.(\d+)$/);
+            if (rcMatch) {
+              console.log(rcMatch[1] + '-rc.' + (Number(rcMatch[2]) + 1));
+            } else {
+              const parts = v.split('.');
+              parts[2] = String(Number(parts[2]) + 1);
+              console.log(parts.join('.') + '-rc.1');
+            }
+          ")
+          echo "version=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "Released $RELEASED → next source: $NEXT"
+
+      - name: Update source files
+        env:
+          NEXT_VERSION: ${{ steps.next.outputs.version }}
+        run: |
+          cd packages/accelerator/src-tauri
+
+          # Patch tauri.conf.json
+          bun -e "
+            const conf = JSON.parse(await Bun.file('tauri.conf.json').text());
+            conf.version = process.env.NEXT_VERSION;
+            await Bun.write('tauri.conf.json', JSON.stringify(conf, null, 2) + '\n');
+          "
+
+          # Patch Cargo.toml
+          sed -i "s/^version = \".*\"/version = \"$NEXT_VERSION\"/" Cargo.toml
+
+      - name: Create PR
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          NEXT_VERSION: ${{ steps.next.outputs.version }}
+          RELEASED: ${{ needs.tag.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          BRANCH="chore/bump-accelerator-${NEXT_VERSION}"
+          git checkout -b "$BRANCH"
+          git add packages/accelerator/src-tauri/tauri.conf.json packages/accelerator/src-tauri/Cargo.toml
+          git commit -m "chore(accelerator): bump source version to ${NEXT_VERSION}"
+          git push -u origin "$BRANCH"
+
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore(accelerator): bump source version to ${NEXT_VERSION}" \
+            --body "Automated post-release version bump after releasing ${RELEASED}."
+
+          gh pr merge "$BRANCH" --auto --squash --delete-branch

--- a/packages/accelerator/src-tauri/Cargo.toml
+++ b/packages/accelerator/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aztec-accelerator"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.8"
 description = "Native proving accelerator for Aztec transactions"
 edition = "2021"
 rust-version = "1.77.2"

--- a/packages/accelerator/src-tauri/tauri.conf.json
+++ b/packages/accelerator/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "Aztec Accelerator",
-  "version": "1.0.0-rc.6",
+  "version": "1.0.0-rc.8",
   "identifier": "dev.aztec.accelerator",
   "build": {
     "frontendDist": "./frontend"


### PR DESCRIPTION
## Summary

- Adds a `bump-source` job to `release-accelerator.yml` that runs after the GitHub Release is created
- Computes next version automatically: `rc.7` → `rc.8`, or `1.0.0` → `1.0.1-rc.1`
- Opens an auto-merge PR to bump `Cargo.toml` + `tauri.conf.json`
- Also bumps current source from `rc.6` to `rc.8` (since `rc.7` was already released)

## Test plan
- [x] actionlint passes
- [x] `bun run lint` passes
- [ ] Next release triggers the bump job automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)