### PR TITLE
fix(playground): downgrade Vite 8 → 7 to fix production Buffer crash

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -50,7 +50,7 @@
         "tailwindcss": "^4.2.2",
         "typescript": "^5.9.3",
         "viem": "npm:@aztec/viem@2.38.2",
-        "vite": "^8.0.1",
+        "vite": "^7.3.1",
         "vite-plugin-node-polyfills": "^0.25.0",
       },
     },
@@ -1710,6 +1710,8 @@
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@alejoamiras/aztec-accelerator-playground/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -40,7 +40,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^5.9.3",
     "viem": "npm:@aztec/viem@2.38.2",
-    "vite": "^8.0.1",
+    "vite": "^7.3.1",
     "vite-plugin-node-polyfills": "^0.25.0"
   }
 }


### PR DESCRIPTION
## Summary

The playground production build has been broken since March 21 with:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'utf8Write')
```

**Root cause**: Vite 8 uses Rolldown instead of Rollup. Rolldown's CJS interop wrapper breaks `vite-plugin-node-polyfills`' Buffer injection — the import resolves to the exports object instead of the Buffer constructor. Dev mode was unaffected (uses esbuild banners).

**Fix**: Downgrade Vite from 8.0.1 to 7.3.1. The polyfill plugin's peer dep only lists up to `^7.0.0`.

## Test plan
- [x] `bun run build && npx vite preview` — no `utf8Write` error
- [x] `bun run test` — 90 tests pass
- [x] `bun run lint` — clean
- [ ] Deploy to playground.aztec-accelerator.dev — verify it loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)