### PR TITLE
fix: use PAT_TOKEN for backport workflow

### DIFF
--- a/.github/workflows/backport-nightlies.yml
+++ b/.github/workflows/backport-nightlies.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.PAT_TOKEN }}
 
       - uses: dorny/paths-filter@v3
         id: filter
@@ -33,7 +34,7 @@ jobs:
       - name: Cherry-pick to nightlies
         if: steps.filter.outputs.relevant == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
           MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Switch backport-nightlies workflow from `github.token` to `secrets.PAT_TOKEN`:

1. `github.token` can't create PRs without a repo settings toggle
2. PRs created by `github.token` don't trigger CI (GitHub prevents recursive triggers)
3. Consistent with `_aztec-update.yml` and `aztec-stable.yml` which already use `PAT_TOKEN`

## Test plan
- [x] actionlint passes
- [ ] Next backport-triggering merge creates the PR successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)