### PR TITLE
fix(accelerator): auth popup window too short, buttons clipped

### DIFF
--- a/packages/accelerator/src-tauri/frontend/style.css
+++ b/packages/accelerator/src-tauri/frontend/style.css
@@ -255,25 +255,32 @@ h2 {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  min-height: calc(100vh - 40px);
+  height: calc(100vh - 40px);
   text-align: center;
+  padding: 0 20px;
+}
+
+.auth-container h2 {
+  font-size: 14px;
+  line-height: 1.4;
 }
 
 .auth-origin {
   font-family: monospace;
-  font-size: 14px;
+  font-size: 13px;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 6px;
   padding: 8px 16px;
-  margin: 16px 0;
+  margin: 14px 0;
   word-break: break-all;
+  max-width: 100%;
 }
 
 .auth-buttons {
   display: flex;
   gap: 10px;
-  margin-top: 16px;
+  margin-top: 14px;
 }
 
 .btn {

--- a/packages/accelerator/src-tauri/src/main.rs
+++ b/packages/accelerator/src-tauri/src/main.rs
@@ -510,7 +510,7 @@ fn show_auth_popup_window(app: &AppHandle, origin: &str, auth_manager: &Arc<Auth
     let url = format!("authorize.html?origin={}", urlencoding::encode(origin));
     if let Ok(window) = WebviewWindowBuilder::new(app, &label, WebviewUrl::App(url.into()))
         .title("Authorize Site")
-        .inner_size(400.0, 250.0)
+        .inner_size(400.0, 300.0)
         .resizable(false)
         .center()
         .always_on_top(true)


### PR DESCRIPTION
## Summary

The authorization popup (400x250) was too short — the Allow/Deny buttons were getting clipped at the bottom. The macOS title bar (~28px) + body padding (40px) left only ~182px for content.

- Window height: 250 → 300px
- CSS: `min-height` → `height` for proper flexbox centering within fixed window
- Tighter margins for breathing room

## Test plan
- [ ] Manual: trigger auth popup, verify buttons fully visible
- [x] `bun run test` + `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)