### PR TITLE
fix: decouple playground deployment from E2E test results

### DIFF
--- a/.github/workflows/publish-nightlies.yml
+++ b/.github/workflows/publish-nightlies.yml
@@ -45,6 +45,9 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   deploy-app:
+    # Deploy playground regardless of E2E outcome — it's a static site build
+    # that shouldn't be blocked by SDK test failures.
+    if: ${{ !cancelled() }}
     needs: e2e
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-testnet.yml
+++ b/.github/workflows/publish-testnet.yml
@@ -46,6 +46,9 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   deploy-app:
+    # Deploy playground regardless of E2E outcome — it's a static site build
+    # that shouldn't be blocked by SDK test failures.
+    if: ${{ !cancelled() }}
     needs: e2e
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

The nightly playground hasn't been deploying because SDK E2E tests fail on a nightly Aztec breaking change (`NO_FROM` export removed). Since `deploy-app` depended on `e2e`, the static site build was blocked by unrelated SDK test failures.

- Add `if: !cancelled()` to `deploy-app` in both `publish-testnet.yml` and `publish-nightlies.yml`
- SDK publishing still requires E2E to pass (correct — SDK quality gate)
- Playground deployment no longer blocked (correct — it's just a static build)

## Test plan
- [x] actionlint passes
- [ ] Next nightlies push triggers playground deployment even if E2E fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)