### PR TITLE
fix(accelerator): quit menu blocked by unconditional prevent_exit

### DIFF
--- a/packages/accelerator/src-tauri/src/main.rs
+++ b/packages/accelerator/src-tauri/src/main.rs
@@ -455,8 +455,12 @@ fn main() {
         .expect("error while building Aztec Accelerator")
         .run(|_app, event| {
             // Tray-only app — keep running when Settings or auth popup windows are closed.
-            if let tauri::RunEvent::ExitRequested { api, .. } = event {
-                api.prevent_exit();
+            // Only prevent automatic exit (code=None, triggered by last window closing).
+            // Explicit app.exit(0) from the "Quit" menu sets code=Some(0) and must go through.
+            if let tauri::RunEvent::ExitRequested { api, code, .. } = event {
+                if code.is_none() {
+                    api.prevent_exit();
+                }
             }
         });
 }


### PR DESCRIPTION
## Summary

The `ExitRequested` handler added in #32 to prevent the app from closing when Settings is dismissed was unconditionally blocking ALL exits — including the explicit `app.exit(0)` from the "Quit" tray menu item.

Fix: check the exit `code` field. `None` = automatic exit (last window closed, should be prevented). `Some(0)` = explicit quit (should go through).

## Test plan
- [ ] Manual: click "Quit" in tray menu — app exits
- [ ] Manual: open Settings, close it — app stays running
- [x] `cargo test` — 52 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)