### PR TITLE
fix(accelerator): install rustls CryptoProvider to prevent startup crash

### DIFF
--- a/packages/accelerator/src-tauri/src/main.rs
+++ b/packages/accelerator/src-tauri/src/main.rs
@@ -155,6 +155,10 @@ fn try_start_https(state: &AppState) -> Option<u16> {
 }
 
 fn main() {
+    // Install a default rustls CryptoProvider. Both aws-lc-rs (from tauri-plugin-updater)
+    // and ring (from tokio-rustls) are available — rustls panics if it can't auto-detect.
+    let _ = tokio_rustls::rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     let log_path = log_dir();
     std::fs::create_dir_all(&log_path).ok();
 


### PR DESCRIPTION
## Summary

The rc.11 release crashes on launch with:
```
Could not automatically determine the process-level CryptoProvider
```

`tauri-plugin-updater` pulls in `aws-lc-rs` while `tokio-rustls` uses `ring`. With both backends, rustls panics. Fix: install `aws_lc_rs::default_provider()` at the start of `main()`.

Verified locally: `cargo tauri dev` starts successfully, update check runs, server listens.

## Test plan
- [x] `cargo tauri dev` — app starts, no crash
- [x] `cargo test` — 52 tests pass
- [ ] Release rc.12 and verify it launches from DMG

🤖 Generated with [Claude Code](https://claude.com/claude-code)