### PR TITLE
fix: remove merge-multiple to prevent macOS updater artifact collision

### DIFF
--- a/.github/workflows/release-accelerator.yml
+++ b/.github/workflows/release-accelerator.yml
@@ -148,7 +148,6 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           path: artifacts
-          merge-multiple: true
 
       - name: Flatten and rename artifacts
         env:
@@ -163,10 +162,9 @@ jobs:
           find artifacts -name '*_aarch64.dmg' -exec mv {} "release-files/Aztec-Accelerator-${VERSION}-macOS-Apple-Silicon.dmg" \;
           find artifacts -name '*_x64.dmg'     -exec mv {} "release-files/Aztec-Accelerator-${VERSION}-macOS-Intel.dmg" \;
 
-          # Updater .tar.gz (macOS — Tauri produces "Aztec Accelerator.app.tar.gz" per arch)
-          # The ARM and Intel builds produce identically-named files, so we match by parent dir
-          find artifacts/accelerator-macos-arm64 -name '*.app.tar.gz' -exec mv {} "release-files/Aztec-Accelerator-${VERSION}-macOS-Apple-Silicon.app.tar.gz" \; 2>/dev/null || true
-          find artifacts/accelerator-macos-x86_64 -name '*.app.tar.gz' -exec mv {} "release-files/Aztec-Accelerator-${VERSION}-macOS-Intel.app.tar.gz" \; 2>/dev/null || true
+          # Updater .tar.gz (macOS — each arch artifact is in its own subdirectory)
+          find artifacts/accelerator-macos-arm64 -name '*.app.tar.gz' -exec mv {} "release-files/Aztec-Accelerator-${VERSION}-macOS-Apple-Silicon.app.tar.gz" \;
+          find artifacts/accelerator-macos-x86_64 -name '*.app.tar.gz' -exec mv {} "release-files/Aztec-Accelerator-${VERSION}-macOS-Intel.app.tar.gz" \;
 
           # Linux
           find artifacts -name '*_amd64.deb'      -exec mv {} "release-files/Aztec-Accelerator-${VERSION}-Linux-x86_64.deb" \;


### PR DESCRIPTION
## Summary

Both macOS builds produce `Aztec Accelerator.app.tar.gz` (same filename, no arch suffix). With `merge-multiple: true`, the second overwrites the first. Result: only one `.app.tar.gz` in the release, empty macOS signatures in `latest.json`, broken auto-updater.

**Fix**: Remove `merge-multiple: true` from `download-artifact`. Without it, each artifact gets its own subdirectory (`accelerator-macos-arm64/`, `accelerator-macos-x86_64/`), which is exactly what the existing `find` commands already expect.

Also removed `|| true` so missing updater artifacts fail loudly instead of producing a silently broken release.

## Test plan
- [x] actionlint passes
- [ ] Trigger rc.13 release, verify both `.app.tar.gz` files in release assets
- [ ] Verify `latest.json` has non-empty macOS signatures
- [ ] Verify auto-updater works on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)