### PR TITLE
chore(accelerator): bump source version to 1.0.0-rc.16

### DIFF
--- a/packages/accelerator/src-tauri/Cargo.toml
+++ b/packages/accelerator/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aztec-accelerator"
-version = "1.0.0-rc.15"
+version = "1.0.0-rc.16"
 description = "Native proving accelerator for Aztec transactions"
 edition = "2021"
 rust-version = "1.77.2"

--- a/packages/accelerator/src-tauri/tauri.conf.json
+++ b/packages/accelerator/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "Aztec Accelerator",
-  "version": "1.0.0-rc.15",
+  "version": "1.0.0-rc.16",
   "identifier": "dev.aztec.accelerator",
   "build": {
     "frontendDist": "./frontend"


### PR DESCRIPTION
Automated post-release version bump after releasing 1.0.0-rc.15.