### PR TITLE
fix(accelerator): settings scroll, origin list container, docs update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 - **Repo**: `alejoamiras/aztec-accelerator` (GitHub)
 - **SDK** (`/packages/sdk`): TypeScript package `@alejoamiras/aztec-accelerator` — AcceleratorProver for native proving via localhost bb binary. Extends `BBLazyPrivateKernelProver`, auto-detects accelerator on port 59833, falls back to WASM if unavailable. Dual HTTP/HTTPS probe for Safari compatibility.
-- **Accelerator** (`/packages/accelerator`): Tauri desktop app — system tray, multi-version bb cache, optional HTTPS (Safari), crash recovery. Rebranded from tee-rex to aztec-accelerator.
+- **Accelerator** (`/packages/accelerator`): Tauri desktop app — system tray, multi-version bb cache, optional HTTPS (Safari), crash recovery, site authorization (MetaMask-style origin approval), Settings window, speed control, signed auto-update (Ed25519 via tauri-plugin-updater).
 - **Playground** (`/packages/playground`): Vite + vanilla TS frontend — local WASM vs accelerated mode comparison, embedded wallet, ASCII animation. Deployed at `playground.aztec-accelerator.dev`.
 - **Landing** (`/packages/landing`): Static landing page at `aztec-accelerator.dev`.
 - **Build system**: Bun workspaces (`packages/sdk`, `packages/accelerator`, `packages/playground`, `packages/landing`)

--- a/packages/accelerator/README.md
+++ b/packages/accelerator/README.md
@@ -129,10 +129,22 @@ Click **Settings** in the tray menu to open the Settings window. From here you c
 
 - **Approved Sites** — view and remove origins that have been granted access
 - **Start on Login** — auto-launch at login (LaunchAgent on macOS, autostart on Linux)
+- **Auto-Update** — toggle automatic updates on or off
 - **Safari Support** (macOS only) — toggle HTTPS mode for Safari compatibility
 - **Proving Speed** — control CPU usage with a 5-level slider (Low / Light / Balanced / High / Full)
 
 Speed changes take effect immediately on the next prove request — no restart needed.
+
+### Auto-Update
+
+The accelerator checks for updates on launch and every 12 hours. Updates are signed with Ed25519 and verified before installation.
+
+On the first update, you'll see a prompt:
+- **Update Now** — downloads, installs, and restarts immediately
+- **Remind Me Later** — dismisses the prompt (it returns next launch)
+- **Keep me updated automatically** — checkbox that enables silent future updates
+
+With auto-update enabled, new versions are downloaded and installed in the background — the app restarts seamlessly. You can change this anytime in Settings.
 
 ### Safari Support (macOS only)
 

--- a/packages/accelerator/src-tauri/frontend/style.css
+++ b/packages/accelerator/src-tauri/frontend/style.css
@@ -25,6 +25,7 @@ body {
   font-size: 13px;
   line-height: 1.5;
   padding: 20px;
+  overflow: hidden;
   -webkit-user-select: none;
   user-select: none;
 }
@@ -105,9 +106,22 @@ h2 {
   opacity: 0.5;
 }
 
-/* Origin list */
+/* Origin list — scrollable, max ~3 rows */
 .origin-list {
   list-style: none;
+  max-height: 108px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+.origin-list::-webkit-scrollbar {
+  width: 4px;
+}
+
+.origin-list::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 2px;
 }
 
 .origin-item {

--- a/packages/accelerator/src-tauri/src/main.rs
+++ b/packages/accelerator/src-tauri/src/main.rs
@@ -511,7 +511,7 @@ fn open_settings_window(app: &AppHandle) {
     if let Ok(window) =
         WebviewWindowBuilder::new(app, "settings", WebviewUrl::App("settings.html".into()))
             .title("Aztec Accelerator Settings")
-            .inner_size(500.0, 450.0)
+            .inner_size(500.0, 520.0)
             .resizable(false)
             .center()
             .build()


### PR DESCRIPTION
## Summary

### UI fixes
- Settings window height 450→520px to accommodate all controls
- `overflow: hidden` on body — kills the outer scrollbar
- Approved Sites list: scrollable container (max 3 rows) with thin scrollbar, so a long list doesn't push controls off-screen

### Docs
- Accelerator README: new Auto-Update section
- CLAUDE.md: updated accelerator description with site auth, settings, speed, auto-update

## Test plan
- [x] `cargo test` — 52 tests pass
- [x] `bun run test` — 73 tests pass
- [ ] Manual: open Settings with 5+ approved sites, verify scrollable list

🤖 Generated with [Claude Code](https://claude.com/claude-code)