### PR TITLE
test: regression guards for exit handler and SDK denied/403 path

### DIFF
--- a/packages/accelerator/src-tauri/src/main.rs
+++ b/packages/accelerator/src-tauri/src/main.rs
@@ -477,7 +477,7 @@ fn main() {
             // Only prevent automatic exit (code=None, triggered by last window closing).
             // Explicit app.exit(0) from the "Quit" menu sets code=Some(0) and must go through.
             if let tauri::RunEvent::ExitRequested { api, code, .. } = event {
-                if code.is_none() {
+                if should_prevent_exit(code) {
                     api.prevent_exit();
                 }
             }
@@ -560,6 +560,13 @@ fn show_auth_popup_window(app: &AppHandle, origin: &str, auth_manager: &Arc<Auth
         auth_manager.resolve(&origin_owned, AuthDecision::Deny);
         tracing::debug!(origin = %origin_owned, "Authorization timeout cleanup");
     });
+}
+
+/// Returns true if the exit should be prevented.
+/// Window-close events have code=None and should be prevented (tray-only app).
+/// Explicit exits (Quit menu, restart) have code=Some(_) and must go through.
+fn should_prevent_exit(code: Option<i32>) -> bool {
+    code.is_none()
 }
 
 // ── Auto-update ──────────────────────────────────────────────────────────
@@ -660,5 +667,28 @@ fn show_update_prompt_window(app: &AppHandle, current_version: &str, new_version
         .build()
     {
         activate_for_window(app, &window);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exit_prevented_for_window_close() {
+        // code=None is sent when the last window closes — must be prevented (tray-only app)
+        assert!(should_prevent_exit(None));
+    }
+
+    #[test]
+    fn exit_allowed_for_explicit_quit() {
+        // code=Some(0) is sent by app.exit(0) from the Quit menu
+        assert!(!should_prevent_exit(Some(0)));
+    }
+
+    #[test]
+    fn exit_allowed_for_restart() {
+        // code=Some(i32::MAX) is sent by app.restart() during auto-update
+        assert!(!should_prevent_exit(Some(i32::MAX)));
     }
 }

--- a/packages/sdk/src/lib/accelerator-prover.test.ts
+++ b/packages/sdk/src/lib/accelerator-prover.test.ts
@@ -155,6 +155,38 @@ describe("AcceleratorProver", () => {
       serializeSpy.mockRestore();
     });
 
+    test("falls back to WASM with denied phase on 403 (origin not authorized)", async () => {
+      mockFetch({
+        "/health": () =>
+          Response.json({
+            status: "ok",
+            aztec_version: SDK_AZTEC_VERSION,
+            available_versions: [SDK_AZTEC_VERSION],
+          }),
+        "/prove": () =>
+          Response.json({ error: "origin_denied", message: "Access denied" }, { status: 403 }),
+      });
+      const serializeSpy = mockSerializer();
+      const wasmSpy = mockWasmProver();
+      const phases: string[] = [];
+
+      const prover = new AcceleratorProver({
+        simulator: new WASMSimulator(),
+        onPhase: (phase) => phases.push(phase),
+      });
+
+      await expect(prover.createChonkProof([fakeStep])).rejects.toThrow(
+        "local prover not available in test",
+      );
+
+      // Should emit: detect → serialize → transmit → proving → denied → fallback → proving
+      expect(phases).toContain("denied");
+      expect(phases).toContain("fallback");
+      expect(wasmSpy).toHaveBeenCalled();
+      wasmSpy.mockRestore();
+      serializeSpy.mockRestore();
+    });
+
     test("multi-version accelerator always proceeds (no WASM fallback on version mismatch)", async () => {
       mockFetch({
         "/health": () =>


### PR DESCRIPTION
## Summary

Steps 1+2 of the e2e testing plan. Unit-level regression guards for bugs we shipped.

### ExitRequested logic test (Rust)
- Extracts `should_prevent_exit()` from inline closure for testability
- 3 assertions: `None`=prevent (window close), `Some(0)`=allow (quit), `Some(i32::MAX)`=allow (restart)
- Catches the class of bug from PR #41 where `prevent_exit()` blocked all exits

### SDK denied/403 phase test (TypeScript)
- Mocks `/prove` returning 403 with `origin_denied` error
- Verifies SDK emits `"denied"` and `"fallback"` phases then falls back to WASM
- Covers the auth feature from PR #26 that had zero unit test coverage on the SDK side

## Test plan
- [x] `cargo test` — 55 tests pass (52 lib + 3 bin)
- [x] `bun run --cwd packages/sdk test:unit` — 18 tests pass (was 17)
- [x] `bun run test` — full workspace green

🤖 Generated with [Claude Code](https://claude.com/claude-code)