### PR TITLE
backport: test: add playground production build smoke test (#58)

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -93,6 +93,27 @@ jobs:
         run: bunx playwright install --with-deps chromium
       - run: bun run --cwd packages/playground test:e2e
 
+  production-smoke:
+    name: Production Build Smoke
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: ${{ runner.os }}-bun-
+      - run: bun install --frozen-lockfile
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+      - run: bun run --cwd packages/playground test:e2e:production-smoke
+
   local-network-e2e:
     name: Local Network E2E
     needs: changes
@@ -105,13 +126,13 @@ jobs:
   app-status:
     name: App Status
     if: always()
-    needs: [changes, lint, unit-tests, mocked-e2e, local-network-e2e]
+    needs: [changes, lint, unit-tests, mocked-e2e, production-smoke, local-network-e2e]
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
       - name: Check results
         run: |
-          results="${{ needs.changes.result }} ${{ needs.lint.result }} ${{ needs.unit-tests.result }} ${{ needs.mocked-e2e.result }} ${{ needs.local-network-e2e.result }}"
+          results="${{ needs.changes.result }} ${{ needs.lint.result }} ${{ needs.unit-tests.result }} ${{ needs.mocked-e2e.result }} ${{ needs.production-smoke.result }} ${{ needs.local-network-e2e.result }}"
           for r in $results; do
             if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
               echo "Job failed or was cancelled: $r"

--- a/packages/playground/e2e/demo.production-smoke.spec.ts
+++ b/packages/playground/e2e/demo.production-smoke.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Production build smoke test — runs against `vite build && vite preview`.
+ *
+ * Catches build-time breakage (polyfill issues, missing imports, bundler bugs)
+ * that don't appear in `vite dev` mode. This test would have caught PR #34
+ * where Vite 8 broke the Buffer polyfill in production builds.
+ *
+ * Usage: bun run --cwd packages/playground test:e2e:production-smoke
+ */
+import { expect, test } from "@playwright/test";
+
+test("production build loads without JS errors", async ({ page }) => {
+  const errors: string[] = [];
+  page.on("pageerror", (err) => errors.push(err.message));
+
+  await page.goto("/");
+
+  // Wait for the app to initialize — key UI elements should render
+  await expect(page.locator("#mode-local")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator("#mode-accelerated")).toBeVisible();
+  await expect(page.locator("#deploy-btn")).toBeVisible();
+
+  // Give async modules time to load (polyfills, lazy imports, etc.)
+  await page.waitForTimeout(3_000);
+
+  expect(errors).toEqual([]);
+});
+
+test("production build serves all static assets", async ({ page }) => {
+  const failedResources: string[] = [];
+  page.on("response", (response) => {
+    // Ignore proxy routes (Aztec node, accelerator) — they're expected to fail without services
+    const url = response.url();
+    if (
+      response.status() >= 400 &&
+      !url.includes("/aztec/") &&
+      !url.includes("localhost:59833") &&
+      !url.includes("localhost:59834")
+    ) {
+      failedResources.push(`${response.status()} ${url}`);
+    }
+  });
+
+  await page.goto("/");
+  await page.waitForTimeout(3_000);
+
+  expect(failedResources).toEqual([]);
+});

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -12,6 +12,7 @@
     "test:e2e": "bunx playwright test --project=mocked",
     "test:e2e:all": "bun run test:e2e && bun run test:e2e:local-network",
     "test:e2e:local-network": "bunx playwright test --project=local-network --workers=1",
+    "test:e2e:production-smoke": "bash scripts/test-production-smoke.sh",
     "test:e2e:smoke": "bunx playwright test --project=smoke --workers=1",
     "test:unit": "bun test"
   },

--- a/packages/playground/playwright.config.ts
+++ b/packages/playground/playwright.config.ts
@@ -18,6 +18,15 @@ export default defineConfig({
       timeout: 30_000,
     },
     {
+      name: "production-smoke",
+      testDir: "./e2e",
+      testMatch: "*.production-smoke.spec.ts",
+      timeout: 30_000,
+      use: {
+        baseURL: "http://localhost:4173",
+      },
+    },
+    {
       name: "local-network",
       testDir: "./e2e",
       testMatch: "*.local-network.spec.ts",

--- a/packages/playground/scripts/test-production-smoke.sh
+++ b/packages/playground/scripts/test-production-smoke.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Build the playground, start vite preview, run Playwright production smoke tests.
+# Properly captures the Playwright exit code and cleans up the preview server.
+set -euo pipefail
+
+echo "Building playground..."
+bun run build
+
+echo "Starting vite preview on port 4173..."
+npx vite preview --port 4173 &
+PREVIEW_PID=$!
+
+# Wait for the server to be ready
+sleep 3
+
+echo "Running production smoke tests..."
+RESULT=0
+bunx playwright test --project=production-smoke || RESULT=$?
+
+echo "Stopping preview server..."
+kill "$PREVIEW_PID" 2>/dev/null || true
+wait "$PREVIEW_PID" 2>/dev/null || true
+
+exit "$RESULT"


### PR DESCRIPTION
Automated backport of #58 from main to nightlies.