### PR TITLE
test: expand mocked Playwright tests + console error listener

### DIFF
--- a/packages/playground/e2e/demo.mocked.spec.ts
+++ b/packages/playground/e2e/demo.mocked.spec.ts
@@ -14,6 +14,19 @@ async function mockServicesOnline(page: import("@playwright/test").Page) {
   await page.route("**/aztec/status", (route) => route.fulfill({ status: 200, body: "OK" }));
 }
 
+// ── JS error safety net — catches runtime errors across all mocked tests ──
+
+const jsErrors: string[] = [];
+
+test.beforeEach(async ({ page }) => {
+  jsErrors.length = 0;
+  page.on("pageerror", (err) => jsErrors.push(err.message));
+});
+
+test.afterEach(() => {
+  expect(jsErrors, "Unexpected JS runtime errors").toEqual([]);
+});
+
 // ── Tests ──
 
 test("page loads with correct initial state", async ({ page }) => {
@@ -92,4 +105,26 @@ test("accelerator status is shown in services panel", async ({ page }) => {
 
   await expect(page.locator("#accelerator-status")).toBeVisible();
   await expect(page.locator("#accelerator-label")).toBeVisible();
+});
+
+// ── Expanded coverage ──
+
+test("mode switch logs the change", async ({ page }) => {
+  await mockServicesOffline(page);
+  await page.goto("/");
+  await expect(page.locator("#log")).toContainText("Checking Aztec node");
+
+  // Switch to WASM mode
+  await page.click("#mode-local");
+  await expect(page.locator("#log")).toContainText("Proving mode");
+});
+
+test("node error appears in log panel", async ({ page }) => {
+  await mockServicesOffline(page);
+  await page.goto("/");
+
+  // The log should show an error about the Aztec node not being reachable
+  await expect(page.locator("#log")).toContainText("not reachable", {
+    timeout: 5000,
+  });
 });


### PR DESCRIPTION
## Summary

Step 7 of the e2e testing plan.

### New tests (2)
- **Mode switch logs the change** — switching to WASM mode shows "Proving mode" in log panel
- **Node error in log panel** — when Aztec node is offline, "not reachable" appears in log

### Console error listener
- `pageerror` event hooks in `beforeEach`/`afterEach` catch any JS runtime error across all tests
- Broad safety net — any future JS crash fails the relevant test

**Total: 8 mocked tests** (was 6). Note: accelerator detection tests (banner, CTA) were attempted but removed — the accelerator health check is a direct localhost fetch that Playwright can't intercept via route mocking.

## Test plan
- [x] `bun run --cwd packages/playground test:e2e` — 8 tests pass
- [x] `bun run test` — full workspace green

🤖 Generated with [Claude Code](https://claude.com/claude-code)