### PR TITLE
backport: test: config unit tests and mocked e2e console error listener (#59)

### DIFF
--- a/packages/accelerator/src-tauri/src/config.rs
+++ b/packages/accelerator/src-tauri/src/config.rs
@@ -143,4 +143,52 @@ mod tests {
         let config: AcceleratorConfig = serde_json::from_str("not json").unwrap_or_default();
         assert!(!config.safari_support);
     }
+
+    #[test]
+    fn speed_rejects_invalid_values() {
+        // speed_to_threads treats unknown values as "full" (all cores)
+        let unknown = speed_to_threads("turbo");
+        let full = speed_to_threads("full");
+        assert_eq!(unknown, full);
+    }
+
+    #[test]
+    fn auto_update_defaults_to_none() {
+        let config = AcceleratorConfig::default();
+        assert_eq!(config.auto_update, None);
+    }
+
+    #[test]
+    fn auto_update_none_not_serialized() {
+        // None should be omitted from JSON (skip_serializing_if)
+        let config = AcceleratorConfig::default();
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(!json.contains("auto_update"));
+    }
+
+    #[test]
+    fn auto_update_some_serialized() {
+        let config = AcceleratorConfig {
+            auto_update: Some(true),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(json.contains("\"auto_update\":true"));
+    }
+
+    #[test]
+    fn auto_update_missing_deserializes_as_none() {
+        let config: AcceleratorConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(config.auto_update, None);
+    }
+
+    #[test]
+    fn approved_origins_removal() {
+        let mut config = AcceleratorConfig {
+            approved_origins: vec!["https://a.com".to_string(), "https://b.com".to_string()],
+            ..Default::default()
+        };
+        config.approved_origins.retain(|o| o != "https://a.com");
+        assert_eq!(config.approved_origins, vec!["https://b.com"]);
+    }
 }

--- a/packages/playground/e2e/demo.mocked.spec.ts
+++ b/packages/playground/e2e/demo.mocked.spec.ts
@@ -14,6 +14,19 @@ async function mockServicesOnline(page: import("@playwright/test").Page) {
   await page.route("**/aztec/status", (route) => route.fulfill({ status: 200, body: "OK" }));
 }
 
+// ── JS error safety net — catches runtime errors across all mocked tests ──
+
+const jsErrors: string[] = [];
+
+test.beforeEach(async ({ page }) => {
+  jsErrors.length = 0;
+  page.on("pageerror", (err) => jsErrors.push(err.message));
+});
+
+test.afterEach(() => {
+  expect(jsErrors, "Unexpected JS runtime errors").toEqual([]);
+});
+
 // ── Tests ──
 
 test("page loads with correct initial state", async ({ page }) => {


### PR DESCRIPTION
Automated backport of #59 from main to nightlies.