### PR TITLE
refactor(accelerator): replace std::sync locks with parking_lot

### DIFF
--- a/packages/accelerator/src-tauri/Cargo.lock
+++ b/packages/accelerator/src-tauri/Cargo.lock
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "aztec-accelerator"
-version = "1.0.0-rc.9"
+version = "1.0.0-rc.16"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -226,6 +226,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
+ "parking_lot",
  "rcgen",
  "reqwest 0.12.28",
  "rustls-pemfile",

--- a/packages/accelerator/src-tauri/Cargo.toml
+++ b/packages/accelerator/src-tauri/Cargo.toml
@@ -11,6 +11,7 @@ tauri = { version = "2", features = ["tray-icon", "image-png"] }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
+parking_lot = "0.12"
 serde_json = "1"
 base64 = "0.22"
 tempfile = "3"

--- a/packages/accelerator/src-tauri/src/authorization.rs
+++ b/packages/accelerator/src-tauri/src/authorization.rs
@@ -1,5 +1,5 @@
+use parking_lot::Mutex;
 use std::collections::HashMap;
-use std::sync::Mutex;
 use tokio::sync::oneshot;
 
 /// Decision from the user about whether to authorize an origin.
@@ -48,7 +48,7 @@ impl AuthorizationManager {
         origin: &str,
     ) -> Result<(oneshot::Receiver<AuthDecision>, bool), &'static str> {
         let (tx, rx) = oneshot::channel();
-        let mut pending = self.pending.lock().unwrap();
+        let mut pending = self.pending.lock();
         let is_first = !pending.contains_key(origin);
         if is_first && pending.len() >= MAX_PENDING_ORIGINS {
             return Err("too many pending authorization requests");
@@ -59,7 +59,7 @@ impl AuthorizationManager {
 
     /// Resolve all pending requests for `origin` with the given decision.
     pub fn resolve(&self, origin: &str, decision: AuthDecision) {
-        let mut pending = self.pending.lock().unwrap();
+        let mut pending = self.pending.lock();
         if let Some(senders) = pending.remove(origin) {
             for tx in senders {
                 let _ = tx.send(decision);

--- a/packages/accelerator/src-tauri/src/bin/accelerator-server.rs
+++ b/packages/accelerator/src-tauri/src/bin/accelerator-server.rs
@@ -9,7 +9,8 @@
 use aztec_accelerator::authorization::AuthorizationManager;
 use aztec_accelerator::config::AcceleratorConfig;
 use aztec_accelerator::server::{start, AppState};
-use std::sync::{Arc, RwLock};
+use parking_lot::RwLock;
+use std::sync::Arc;
 use tracing_subscriber::fmt;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;

--- a/packages/accelerator/src-tauri/src/commands.rs
+++ b/packages/accelerator/src-tauri/src/commands.rs
@@ -1,6 +1,7 @@
 use crate::authorization::{AuthDecision, AuthorizationManager};
 use crate::config::{self, AcceleratorConfig};
-use std::sync::{Arc, RwLock};
+use parking_lot::RwLock;
+use std::sync::Arc;
 use tauri::Manager;
 
 pub type ConfigState = Arc<RwLock<AcceleratorConfig>>;
@@ -11,7 +12,7 @@ pub type SharedAppState = Arc<crate::server::AppState>;
 
 #[tauri::command]
 pub fn get_config(config: tauri::State<'_, ConfigState>) -> AcceleratorConfig {
-    config.read().unwrap().clone()
+    config.read().clone()
 }
 
 #[tauri::command]
@@ -42,7 +43,7 @@ pub fn set_speed(config: tauri::State<'_, ConfigState>, speed: String) -> Result
             "Invalid speed: {speed}. Must be one of: full, high, balanced, light, low"
         ));
     }
-    let mut cfg = config.write().unwrap();
+    let mut cfg = config.write();
     cfg.speed = speed;
     config::save(&cfg).map_err(|e| e.to_string())?;
     Ok(())
@@ -53,7 +54,7 @@ pub fn remove_approved_origin(
     config: tauri::State<'_, ConfigState>,
     origin: String,
 ) -> Result<(), String> {
-    let mut cfg = config.write().unwrap();
+    let mut cfg = config.write();
     cfg.approved_origins.retain(|o| o != &origin);
     config::save(&cfg).map_err(|e| e.to_string())?;
     Ok(())
@@ -123,7 +124,7 @@ pub async fn enable_safari_support(
 
     // Save config
     {
-        let mut cfg = config.write().unwrap();
+        let mut cfg = config.write();
         cfg.safari_support = true;
         config::save(&cfg).map_err(|e| e.to_string())?;
     }
@@ -147,7 +148,7 @@ pub async fn enable_safari_support(
 #[cfg(target_os = "macos")]
 #[tauri::command]
 pub fn disable_safari_support(config: tauri::State<'_, ConfigState>) -> Result<(), String> {
-    let mut cfg = config.write().unwrap();
+    let mut cfg = config.write();
     cfg.safari_support = false;
     config::save(&cfg).map_err(|e| e.to_string())?;
     tracing::info!("Safari Support disabled via Settings (HTTPS stops on next restart)");
@@ -171,7 +172,7 @@ pub fn disable_safari_support() -> Result<(), String> {
 /// Toggle auto-update preference from Settings.
 #[tauri::command]
 pub fn set_auto_update(config: tauri::State<'_, ConfigState>, enabled: bool) -> Result<(), String> {
-    let mut cfg = config.write().unwrap();
+    let mut cfg = config.write();
     cfg.auto_update = Some(enabled);
     config::save(&cfg).map_err(|e| e.to_string())?;
     tracing::info!(enabled, "Auto-update preference changed via Settings");
@@ -192,7 +193,7 @@ pub fn respond_update_prompt(
         "update" => {
             // Save auto-update preference from the checkbox
             {
-                let mut cfg = config.write().unwrap();
+                let mut cfg = config.write();
                 cfg.auto_update = Some(auto_update);
                 if let Err(e) = config::save(&cfg) {
                     tracing::warn!("Failed to save auto-update preference: {e}");

--- a/packages/accelerator/src-tauri/src/main.rs
+++ b/packages/accelerator/src-tauri/src/main.rs
@@ -6,9 +6,10 @@ use aztec_accelerator::commands::{AuthState, ConfigState, SharedAppState};
 use aztec_accelerator::server::{AppState, HTTPS_PORT};
 use aztec_accelerator::versions;
 use aztec_accelerator::{certs, commands, config, log_dir};
+use parking_lot::RwLock;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::Duration;
 use tauri::menu::{MenuBuilder, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder};
 use tauri::tray::TrayIconBuilder;
@@ -116,7 +117,7 @@ fn try_start_https(state: &AppState) -> Option<u16> {
     if !certs::certs_exist() {
         tracing::warn!("Safari Support enabled but certs missing — resetting config");
         if let Some(ref cfg_lock) = state.config {
-            let mut cfg = cfg_lock.write().unwrap();
+            let mut cfg = cfg_lock.write();
             cfg.safari_support = false;
             let _ = config::save(&cfg);
         }
@@ -601,7 +602,7 @@ pub async fn check_for_update(app: &AppHandle, config_state: &ConfigState) {
     let current_version = env!("CARGO_PKG_VERSION").to_string();
     tracing::info!(current = %current_version, new = %new_version, "Update available");
 
-    let auto_update_pref = { config_state.read().unwrap().auto_update };
+    let auto_update_pref = { config_state.read().auto_update };
     tracing::info!(?auto_update_pref, "Auto-update preference");
 
     match auto_update_pref {

--- a/packages/accelerator/src-tauri/src/server.rs
+++ b/packages/accelerator/src-tauri/src/server.rs
@@ -18,7 +18,7 @@ use tower_http::set_header::SetResponseHeaderLayer;
 
 use crate::authorization::{AuthDecision, AuthorizationManager};
 use crate::{bb, config, versions};
-use std::sync::RwLock;
+use parking_lot::RwLock;
 use tokio::sync::Semaphore;
 
 const PORT: u16 = 59833;
@@ -153,7 +153,7 @@ async fn health(State(state): State<AppState>) -> impl IntoResponse {
     let safari_enabled = state
         .config
         .as_ref()
-        .is_some_and(|cfg| cfg.read().unwrap().safari_support);
+        .is_some_and(|cfg| cfg.read().safari_support);
     if state.https_port.is_some() || safari_enabled {
         body["https_port"] = json!(HTTPS_PORT);
     }
@@ -212,7 +212,7 @@ async fn prove(
 
         if let Some(origin) = origin {
             let approved = state.config.as_ref().is_some_and(|cfg| {
-                let cfg = cfg.read().unwrap();
+                let cfg = cfg.read();
                 AuthorizationManager::is_approved(&origin, &cfg.approved_origins)
             });
 
@@ -282,7 +282,7 @@ async fn prove(
                         tracing::info!(origin = %origin, remember, "Origin authorized");
                         if remember {
                             if let Some(ref cfg_lock) = state.config {
-                                let mut cfg = cfg_lock.write().unwrap();
+                                let mut cfg = cfg_lock.write();
                                 if !cfg.approved_origins.contains(&origin) {
                                     cfg.approved_origins.push(origin.clone());
                                     if let Err(e) = config::save(&cfg) {
@@ -402,7 +402,7 @@ async fn prove(
 
     // Only pass -t flag when speed isn't "full" — bb defaults to all cores already
     let threads = state.config.as_ref().and_then(|cfg| {
-        let cfg = cfg.read().unwrap();
+        let cfg = cfg.read();
         if cfg.speed == "full" {
             None
         } else {
@@ -692,7 +692,7 @@ mod tests {
         let cfg = crate::config::AcceleratorConfig::default();
         let state = AppState {
             auth_manager: Some(auth_for_state),
-            config: Some(Arc::new(std::sync::RwLock::new(cfg))),
+            config: Some(Arc::new(RwLock::new(cfg))),
             show_auth_popup: Some(Arc::new(move |origin: &str| {
                 let _ = popup_tx.send(origin.to_string());
             })),
@@ -833,7 +833,6 @@ mod tests {
         // Pre-approve the origin in config
         if let Some(ref cfg) = state.config {
             cfg.write()
-                .unwrap()
                 .approved_origins
                 .push("https://approved-site.com".to_string());
         }
@@ -866,7 +865,7 @@ mod tests {
         let cfg = crate::config::AcceleratorConfig::default();
         let state = AppState {
             auth_manager: Some(auth),
-            config: Some(Arc::new(std::sync::RwLock::new(cfg))),
+            config: Some(Arc::new(RwLock::new(cfg))),
             show_auth_popup: None, // headless
             ..Default::default()
         };


### PR DESCRIPTION
## Summary

Batch 1, Item 3 of the quality audit. Switch from `std::sync::{RwLock, Mutex}` to `parking_lot::{RwLock, Mutex}`.

**Why**: `parking_lot` locks don't poison. A panic in one thread while holding a lock won't cascade into panics for every subsequent lock acquisition. This eliminates ~15 `.unwrap()` calls in production paths.

**Before**: `config.read().unwrap()` — panics if lock is poisoned
**After**: `config.read()` — returns guard directly, no panic possible

Files changed: commands.rs, server.rs, main.rs, authorization.rs, accelerator-server.rs

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 61 tests pass (58 lib + 3 bin)
- [x] All existing behavior unchanged (drop-in replacement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)