### PR TITLE
refactor: extract setup-accelerator composite action, deduplicate CI

### DIFF
--- a/.github/actions/setup-accelerator/action.yml
+++ b/.github/actions/setup-accelerator/action.yml
@@ -1,0 +1,36 @@
+name: Setup Accelerator
+description: Install system deps, Bun, Rust toolchain, copy bb sidecar — common setup for accelerator CI jobs.
+
+runs:
+  using: composite
+  steps:
+    - name: Install system dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libssl-dev libgtk-3-dev
+
+    - uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: latest
+
+    - uses: actions/cache@v5
+      with:
+        path: ~/.bun/install/cache
+        key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+        restore-keys: ${{ runner.os }}-bun-
+
+    - run: bun install --frozen-lockfile
+      shell: bash
+
+    - name: Copy bb sidecar
+      shell: bash
+      run: bun run --cwd packages/accelerator prebuild
+
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy, rustfmt
+
+    - uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: packages/accelerator/src-tauri -> target

--- a/.github/workflows/accelerator.yml
+++ b/.github/workflows/accelerator.yml
@@ -43,29 +43,7 @@ jobs:
         working-directory: packages/accelerator/src-tauri
     steps:
       - uses: actions/checkout@v6
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libssl-dev libgtk-3-dev
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-      - uses: actions/cache@v5
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
-          restore-keys: ${{ runner.os }}-bun-
-      - run: bun install --frozen-lockfile
-        working-directory: .
-      - name: Copy bb sidecar
-        run: bun run --cwd packages/accelerator prebuild
-        working-directory: .
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: packages/accelerator/src-tauri -> target
+      - uses: ./.github/actions/setup-accelerator
       - run: cargo fmt --check
       - run: cargo clippy --all-targets -- -D warnings
 
@@ -80,27 +58,7 @@ jobs:
         working-directory: packages/accelerator/src-tauri
     steps:
       - uses: actions/checkout@v6
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libssl-dev libgtk-3-dev
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-      - uses: actions/cache@v5
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
-          restore-keys: ${{ runner.os }}-bun-
-      - run: bun install --frozen-lockfile
-        working-directory: .
-      - name: Copy bb sidecar
-        run: bun run --cwd packages/accelerator prebuild
-        working-directory: .
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: packages/accelerator/src-tauri -> target
+      - uses: ./.github/actions/setup-accelerator
       - run: cargo test
 
   lint:
@@ -133,27 +91,7 @@ jobs:
         working-directory: packages/accelerator/src-tauri
     steps:
       - uses: actions/checkout@v6
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libssl-dev libgtk-3-dev
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-      - uses: actions/cache@v5
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
-          restore-keys: ${{ runner.os }}-bun-
-      - run: bun install --frozen-lockfile
-        working-directory: .
-      - name: Copy bb sidecar
-        run: bun run --cwd packages/accelerator prebuild
-        working-directory: .
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: packages/accelerator/src-tauri -> target
+      - uses: ./.github/actions/setup-accelerator
       - name: Build headless server
         run: cargo build --bin accelerator-server
       - name: Launch and health check


### PR DESCRIPTION
## Summary

Batch 1, Item 4 of the quality audit. Extracts the common 8-step setup sequence (system deps, Bun, npm cache, bb sidecar, Rust, Cargo cache) into a reusable composite action.

**Before**: 3 copies of the same setup in clippy, test, and smoke jobs (65 lines of duplication)
**After**: Each job does `checkout` → `uses: ./.github/actions/setup-accelerator` → actual command

The lint job keeps its own simpler setup (only needs Bun, not system deps or Rust).

## Test plan
- [x] actionlint — clean
- [ ] CI: all 3 jobs (Clippy, Rust Tests, Release Smoke) use the composite action and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)