### PR TITLE
fix(accelerator): check codesign exit codes, assert release artifacts

### DIFF
--- a/.github/workflows/release-accelerator.yml
+++ b/.github/workflows/release-accelerator.yml
@@ -173,6 +173,23 @@ jobs:
           echo "Release files:"
           ls -la release-files/
 
+          # Assert all expected files exist — fail fast if any platform is missing
+          EXPECTED=(
+            "Aztec-Accelerator-${VERSION}-macOS-Apple-Silicon.dmg"
+            "Aztec-Accelerator-${VERSION}-macOS-Intel.dmg"
+            "Aztec-Accelerator-${VERSION}-macOS-Apple-Silicon.app.tar.gz"
+            "Aztec-Accelerator-${VERSION}-macOS-Intel.app.tar.gz"
+            "Aztec-Accelerator-${VERSION}-Linux-x86_64.deb"
+            "Aztec-Accelerator-${VERSION}-Linux-x86_64.AppImage"
+          )
+          for f in "${EXPECTED[@]}"; do
+            if [ ! -f "release-files/$f" ]; then
+              echo "::error::Missing expected release artifact: $f"
+              exit 1
+            fi
+          done
+          echo "All ${#EXPECTED[@]} expected artifacts present"
+
       - name: Generate latest.json for auto-updater
         env:
           VERSION: ${{ needs.tag.outputs.version }}

--- a/packages/accelerator/src-tauri/src/versions.rs
+++ b/packages/accelerator/src-tauri/src/versions.rs
@@ -304,14 +304,37 @@ pub async fn download_bb(version: &str) -> Result<PathBuf, Box<dyn Error + Send 
     //   caused by chmod modifying the binary after the original signature was applied)
     #[cfg(target_os = "macos")]
     {
-        let _ = std::process::Command::new("xattr")
+        let xattr_out = std::process::Command::new("xattr")
             .args(["-cr"])
             .arg(&final_path)
             .output();
-        let _ = std::process::Command::new("codesign")
+        if let Err(e) = &xattr_out {
+            tracing::warn!(version, error = %e, "Failed to clear quarantine xattrs");
+        } else if let Ok(out) = &xattr_out {
+            if !out.status.success() {
+                tracing::warn!(version, "xattr -cr failed with status {}", out.status);
+            }
+        }
+
+        let codesign_out = std::process::Command::new("codesign")
             .args(["--force", "--sign", "-"])
             .arg(&final_path)
             .output();
+        match &codesign_out {
+            Err(e) => {
+                tracing::error!(version, error = %e, "Failed to ad-hoc sign bb binary");
+                // Clean up — don't cache a binary that can't be signed
+                let _ = std::fs::remove_dir_all(&version_dir);
+                return Err(format!("Failed to sign bb v{version}: {e}").into());
+            }
+            Ok(out) if !out.status.success() => {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                tracing::error!(version, stderr = %stderr, "codesign failed");
+                let _ = std::fs::remove_dir_all(&version_dir);
+                return Err(format!("codesign failed for bb v{version}: {}", out.status).into());
+            }
+            Ok(_) => {}
+        }
     }
 
     tracing::info!(version, "bb cached successfully");


### PR DESCRIPTION
## Summary

Batch 2, Items 7+8 of the quality audit.

### Item 7: codesign exit codes (versions.rs)
- `xattr -cr` failure now logged (was silently ignored via `let _ =`)
- `codesign` failure deletes the cached binary and returns an error — previously it silently cached a potentially broken binary that would fail later during proving

### Item 8: Release artifact assertions (release-accelerator.yml)
- After flattening artifacts, asserts all 6 expected files exist (2 DMGs, 2 `.app.tar.gz`, 1 `.deb`, 1 `.AppImage`)
- Fails the release job immediately if any platform artifact is missing — prevents publishing a broken release

### Item 6 (digest verification): Deferred
Making verification fail-closed when GitHub API is down would prevent bb downloads during GitHub outages — too aggressive. Current warn-and-continue is the right behavior.

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --lib` — 64 tests pass
- [x] actionlint — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)