### PR TITLE
refactor(accelerator): extract updater module, eliminate redundant network check

### DIFF
--- a/packages/accelerator/src-tauri/src/commands.rs
+++ b/packages/accelerator/src-tauri/src/commands.rs
@@ -10,6 +10,10 @@ pub type AuthState = Arc<AuthorizationManager>;
 /// state including auth_manager, config, and show_auth_popup — not a bare Default.
 pub type SharedAppState = Arc<crate::server::AppState>;
 
+/// Holds a pending update so `respond_update_prompt` can use it directly
+/// instead of re-checking the network. Managed as Tauri state.
+pub type PendingUpdate = Arc<parking_lot::Mutex<Option<tauri_plugin_updater::Update>>>;
+
 #[tauri::command]
 pub fn get_config(config: tauri::State<'_, ConfigState>) -> AcceleratorConfig {
     config.read().clone()
@@ -180,12 +184,13 @@ pub fn set_auto_update(config: tauri::State<'_, ConfigState>, enabled: bool) -> 
 }
 
 /// Called from the update prompt.
-/// - action="update": save auto_update preference from checkbox, then download + install
+/// - action="update": save auto_update preference, then download + install using stored Update
 /// - action="later": dismiss, auto_update stays None (prompt returns next launch)
 #[tauri::command]
 pub fn respond_update_prompt(
     app: tauri::AppHandle,
     config: tauri::State<'_, ConfigState>,
+    pending: tauri::State<'_, PendingUpdate>,
     action: String,
     auto_update: bool,
 ) -> Result<(), String> {
@@ -199,54 +204,28 @@ pub fn respond_update_prompt(
                     tracing::warn!("Failed to save auto-update preference: {e}");
                 }
             }
-            tracing::info!(auto_update, "User clicked Update Now");
-            // Download + install in background. The prompt window stays open showing
-            // "Updating..." until the app restarts or the download fails.
-            let handle = app.clone();
-            tauri::async_runtime::spawn(async move {
-                use tauri_plugin_updater::UpdaterExt;
-                tracing::info!("Re-checking for update to trigger download...");
-                let updater = match handle.updater() {
-                    Ok(u) => u,
-                    Err(e) => {
-                        tracing::error!("Failed to build updater: {e}");
+
+            // Take the stored Update object — no redundant network re-check
+            let update = pending.lock().take();
+            match update {
+                Some(update) => {
+                    tracing::info!(
+                        version = %update.version,
+                        auto_update,
+                        "User clicked Update Now, downloading stored update"
+                    );
+                    let handle = app.clone();
+                    tauri::async_runtime::spawn(async move {
+                        crate::updater::perform_update(&handle, update).await;
+                        // If perform_update returns (error), close the prompt
                         close_update_prompt(&handle);
-                        return;
-                    }
-                };
-                let update = match updater.check().await {
-                    Ok(Some(u)) => u,
-                    Ok(None) => {
-                        tracing::warn!("No update found (race condition?)");
-                        close_update_prompt(&handle);
-                        return;
-                    }
-                    Err(e) => {
-                        tracing::error!("Update check failed: {e}");
-                        close_update_prompt(&handle);
-                        return;
-                    }
-                };
-                tracing::info!(version = %update.version, "Downloading and installing update");
-                match update
-                    .download_and_install(
-                        |chunk, total| {
-                            tracing::info!(chunk, total = total.unwrap_or(0), "Download progress");
-                        },
-                        || tracing::info!("Download complete, installing"),
-                    )
-                    .await
-                {
-                    Ok(()) => {
-                        tracing::info!("Update installed, restarting");
-                        handle.restart();
-                    }
-                    Err(e) => {
-                        tracing::error!("Update failed: {e}");
-                        close_update_prompt(&handle);
-                    }
+                    });
                 }
-            });
+                None => {
+                    tracing::warn!("No pending update found — may have expired. Closing prompt.");
+                    close_update_prompt(&app);
+                }
+            }
         }
         "later" => {
             close_update_prompt(&app);

--- a/packages/accelerator/src-tauri/src/lib.rs
+++ b/packages/accelerator/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ pub mod commands;
 pub mod config;
 pub mod crash_recovery;
 pub mod server;
+pub mod updater;
 pub mod versions;
 
 use std::path::PathBuf;

--- a/packages/accelerator/src-tauri/src/main.rs
+++ b/packages/accelerator/src-tauri/src/main.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use aztec_accelerator::authorization::{AuthDecision, AuthorizationManager};
-use aztec_accelerator::commands::{AuthState, ConfigState, SharedAppState};
+use aztec_accelerator::commands::{AuthState, ConfigState, PendingUpdate, SharedAppState};
 use aztec_accelerator::server::{AppState, HTTPS_PORT};
 use aztec_accelerator::versions;
 use aztec_accelerator::{certs, commands, config, log_dir};
@@ -250,6 +250,7 @@ fn main() {
         .plugin(tauri_plugin_process::init())
         .manage(config_state.clone())
         .manage(auth_manager.clone())
+        .manage::<PendingUpdate>(Arc::new(parking_lot::Mutex::new(None)))
         .invoke_handler(tauri::generate_handler![
             commands::get_config,
             commands::get_autostart_enabled,
@@ -427,7 +428,7 @@ fn main() {
             tauri::async_runtime::spawn(async move {
                 tokio::time::sleep(Duration::from_secs(5)).await;
                 loop {
-                    check_for_update(&update_handle, &update_config).await;
+                    run_update_check(&update_handle, &update_config).await;
                     tokio::time::sleep(Duration::from_secs(12 * 3600)).await;
                 }
             });
@@ -535,79 +536,25 @@ fn should_prevent_exit(code: Option<i32>) -> bool {
 
 // ── Auto-update ──────────────────────────────────────────────────────────
 
-use tauri_plugin_updater::UpdaterExt;
+/// Background update check wrapper. Calls the shared updater module and
+/// shows the prompt window if an update is available and the user hasn't chosen yet.
+async fn run_update_check(app: &AppHandle, config_state: &ConfigState) {
+    use tauri::Manager;
+    if let Some(update) = aztec_accelerator::updater::check_for_update(app, config_state).await {
+        let auto_update_pref = { config_state.read().auto_update };
+        let current_version = env!("CARGO_PKG_VERSION").to_string();
+        let new_version = update.version.clone();
 
-/// Background update check. Runs 5s after launch, then every 12 hours.
-/// Also called by `respond_update_prompt` when the user clicks "Update Now".
-pub async fn check_for_update(app: &AppHandle, config_state: &ConfigState) {
-    tracing::info!("Checking for updates...");
-    let updater = match app.updater() {
-        Ok(u) => u,
-        Err(e) => {
-            tracing::warn!("Failed to build updater: {e}");
-            return;
+        // Store the update so respond_update_prompt can use it directly
+        if let Some(pending) = app.try_state::<PendingUpdate>() {
+            *pending.lock() = Some(update);
         }
-    };
 
-    let update = match updater.check().await {
-        Ok(Some(update)) => update,
-        Ok(None) => {
-            tracing::info!("No update available");
-            return;
-        }
-        Err(e) => {
-            tracing::warn!("Update check failed: {e}");
-            return;
-        }
-    };
-
-    let new_version = update.version.clone();
-    let current_version = env!("CARGO_PKG_VERSION").to_string();
-    tracing::info!(current = %current_version, new = %new_version, "Update available");
-
-    let auto_update_pref = { config_state.read().auto_update };
-    tracing::info!(?auto_update_pref, "Auto-update preference");
-
-    match auto_update_pref {
-        None => {
+        if auto_update_pref.is_none() {
             tracing::info!("Showing update prompt (first time)");
             show_update_prompt_window(app, &current_version, &new_version);
-        }
-        Some(true) => {
-            tracing::info!("Auto-update enabled, performing update");
-            perform_update(app, update).await;
-        }
-        Some(false) => {
+        } else {
             tracing::info!(version = %new_version, "Update available (manual mode)");
-        }
-    }
-}
-
-/// Download, verify signature, install, and restart.
-pub async fn perform_update(app: &AppHandle, update: tauri_plugin_updater::Update) {
-    tracing::info!(version = %update.version, "Downloading update");
-
-    match update
-        .download_and_install(
-            |chunk_length, content_length| {
-                tracing::info!(
-                    chunk_length,
-                    content_length = content_length.unwrap_or(0),
-                    "Download progress"
-                );
-            },
-            || {
-                tracing::info!("Download complete, installing");
-            },
-        )
-        .await
-    {
-        Ok(()) => {
-            tracing::info!("Update installed, restarting");
-            app.restart();
-        }
-        Err(e) => {
-            tracing::error!("Update failed: {e}");
         }
     }
 }

--- a/packages/accelerator/src-tauri/src/updater.rs
+++ b/packages/accelerator/src-tauri/src/updater.rs
@@ -1,0 +1,87 @@
+//! Auto-update logic shared between the Tauri app (main.rs) and commands.
+//!
+//! The background loop in main.rs calls `check_for_update()` periodically.
+//! When the user clicks "Update Now" in the prompt, `respond_update_prompt`
+//! calls `perform_update()` directly — no redundant network re-check.
+
+use crate::commands::ConfigState;
+use tauri::AppHandle;
+use tauri_plugin_updater::UpdaterExt;
+
+/// Check for updates and act based on the user's auto_update preference.
+/// Returns the `Update` if one is available and the user hasn't opted into auto-update
+/// (so the caller can show a prompt or store it for later use).
+pub async fn check_for_update(
+    app: &AppHandle,
+    config_state: &ConfigState,
+) -> Option<tauri_plugin_updater::Update> {
+    tracing::info!("Checking for updates...");
+    let updater = match app.updater() {
+        Ok(u) => u,
+        Err(e) => {
+            tracing::warn!("Failed to build updater: {e}");
+            return None;
+        }
+    };
+
+    let update = match updater.check().await {
+        Ok(Some(update)) => update,
+        Ok(None) => {
+            tracing::info!("No update available");
+            return None;
+        }
+        Err(e) => {
+            tracing::warn!("Update check failed: {e}");
+            return None;
+        }
+    };
+
+    let new_version = update.version.clone();
+    let current_version = env!("CARGO_PKG_VERSION").to_string();
+    tracing::info!(current = %current_version, new = %new_version, "Update available");
+
+    let auto_update_pref = { config_state.read().auto_update };
+    tracing::info!(?auto_update_pref, "Auto-update preference");
+
+    match auto_update_pref {
+        Some(true) => {
+            tracing::info!("Auto-update enabled, performing update");
+            perform_update(app, update).await;
+            None
+        }
+        _ => {
+            // None (never asked) or Some(false) (manual) — return the update
+            // so the caller can show a prompt or add a tray menu item
+            Some(update)
+        }
+    }
+}
+
+/// Download, verify Ed25519 signature, install, and restart the app.
+pub async fn perform_update(app: &AppHandle, update: tauri_plugin_updater::Update) {
+    tracing::info!(version = %update.version, "Downloading update");
+
+    match update
+        .download_and_install(
+            |chunk_length, content_length| {
+                tracing::info!(
+                    chunk_length,
+                    content_length = content_length.unwrap_or(0),
+                    "Download progress"
+                );
+            },
+            || {
+                tracing::info!("Download complete, installing");
+            },
+        )
+        .await
+    {
+        Ok(()) => {
+            tracing::info!("Update installed, restarting");
+            app.restart();
+        }
+        Err(e) => {
+            tracing::error!("Update failed: {e}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Batch 2, Item 5 of the quality audit — the proper fix.

### Problem
When a user clicked "Update Now" in the prompt, `respond_update_prompt` re-checked the network from scratch (~40 lines of duplicated updater logic). The update shown in the prompt could theoretically differ from the one downloaded.

### Fix
- New `src/updater.rs` module in the lib with `check_for_update()` and `perform_update()`
- `check_for_update()` returns the `Update` object instead of consuming it
- `main.rs` stores it in `PendingUpdate` managed state when showing the prompt
- `respond_update_prompt` takes the stored update directly — zero redundant network requests

### What changed
- **New**: `src/updater.rs` — shared update logic
- **Simplified**: `commands.rs` — `respond_update_prompt` is now 30 lines (was 70)
- **Simplified**: `main.rs` — `run_update_check` calls the shared module
- **New type**: `PendingUpdate = Arc<Mutex<Option<Update>>>` in commands.rs

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 67 tests pass
- [ ] Manual: prompt shows, "Update Now" downloads without re-checking

🤖 Generated with [Claude Code](https://claude.com/claude-code)