### PR TITLE
fix(accelerator): batch 3a quick wins — logging, hex allocation

### DIFF
--- a/packages/accelerator/src-tauri/src/commands.rs
+++ b/packages/accelerator/src-tauri/src/commands.rs
@@ -107,8 +107,13 @@ pub fn respond_auth(
 /// (e.g. `example.com` vs `example_com` would collide with naive character replacement).
 pub fn sanitize_window_label(origin: &str) -> String {
     use sha2::{Digest, Sha256};
+    use std::fmt::Write;
     let hash = Sha256::digest(origin.as_bytes());
-    hash.iter().take(6).map(|b| format!("{b:02x}")).collect()
+    let mut hex = String::with_capacity(12);
+    for b in hash.iter().take(6) {
+        let _ = write!(hex, "{b:02x}");
+    }
+    hex
 }
 
 /// Enable Safari Support: generate certs, install trust, save config, start HTTPS.

--- a/packages/accelerator/src-tauri/src/config.rs
+++ b/packages/accelerator/src-tauri/src/config.rs
@@ -60,7 +60,10 @@ pub fn config_path() -> PathBuf {
 pub fn load() -> AcceleratorConfig {
     let path = config_path();
     match std::fs::read_to_string(&path) {
-        Ok(contents) => serde_json::from_str(&contents).unwrap_or_default(),
+        Ok(contents) => serde_json::from_str(&contents).unwrap_or_else(|e| {
+            tracing::warn!(path = %path.display(), error = %e, "Malformed config, using defaults");
+            AcceleratorConfig::default()
+        }),
         Err(_) => AcceleratorConfig::default(),
     }
 }

--- a/packages/accelerator/src-tauri/src/main.rs
+++ b/packages/accelerator/src-tauri/src/main.rs
@@ -56,23 +56,16 @@ fn is_dev_mode() -> bool {
 
 /// Open a path or URL in the platform's default handler.
 fn open_in_browser(target: &impl AsRef<Path>) {
+    let path = target.as_ref();
     #[cfg(target_os = "macos")]
-    {
-        let _ = std::process::Command::new("open")
-            .arg(target.as_ref())
-            .spawn();
-    }
+    let result = std::process::Command::new("open").arg(path).spawn();
     #[cfg(target_os = "linux")]
-    {
-        let _ = std::process::Command::new("xdg-open")
-            .arg(target.as_ref())
-            .spawn();
-    }
+    let result = std::process::Command::new("xdg-open").arg(path).spawn();
     #[cfg(target_os = "windows")]
-    {
-        let _ = std::process::Command::new("explorer")
-            .arg(target.as_ref())
-            .spawn();
+    let result = std::process::Command::new("explorer").arg(path).spawn();
+
+    if let Err(e) = result {
+        tracing::warn!(path = %path.display(), error = %e, "Failed to open in browser");
     }
 }
 

--- a/packages/accelerator/src-tauri/src/versions.rs
+++ b/packages/accelerator/src-tauri/src/versions.rs
@@ -162,8 +162,13 @@ pub fn list_cached_versions() -> Vec<String> {
 /// Compute SHA-256 hex digest of the given bytes.
 fn sha256_hex(data: &[u8]) -> String {
     use sha2::{Digest, Sha256};
+    use std::fmt::Write;
     let hash = Sha256::digest(data);
-    hash.iter().map(|b| format!("{b:02x}")).collect()
+    let mut hex = String::with_capacity(64);
+    for b in hash {
+        let _ = write!(hex, "{b:02x}");
+    }
+    hex
 }
 
 /// Fetch the expected SHA-256 digest for a release asset from the GitHub API.


### PR DESCRIPTION
## Summary

Batch 3a quick wins from the quality audit.

| Item | Fix |
|------|-----|
| **#18** | `open_in_browser` logs errors with `tracing::warn!` (was `let _ =`) |
| **#14** | `config::load` logs malformed JSON with `tracing::warn!` (was silent default) |
| **#19** | `sha256_hex` pre-allocates `String::with_capacity(64)` (was 32 `format!` allocations). Same fix in `sanitize_window_label`. |
| **#12** | Already fixed — `on_versions_changed` fires once after the prove extraction refactor |

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --lib` — 64 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)