### PR TITLE
fix: replace sleep-based waits with health endpoint polling

### DIFF
--- a/.github/workflows/accelerator.yml
+++ b/.github/workflows/accelerator.yml
@@ -98,12 +98,23 @@ jobs:
         run: |
           ./target/debug/accelerator-server &
           SERVER_PID=$!
-          sleep 3
 
-          if ! kill -0 $SERVER_PID 2>/dev/null; then
-            echo "::error::Server crashed on startup"
-            exit 1
-          fi
+          # Poll until server is ready (max 15s)
+          for i in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:59833/health > /dev/null 2>&1; then
+              break
+            fi
+            if ! kill -0 $SERVER_PID 2>/dev/null; then
+              echo "::error::Server crashed on startup"
+              exit 1
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "::error::Server not ready after 15s"
+              kill $SERVER_PID 2>/dev/null || true
+              exit 1
+            fi
+            sleep 0.5
+          done
 
           HEALTH=$(curl -sf http://127.0.0.1:59833/health || true)
           echo "Health response: $HEALTH"

--- a/packages/playground/scripts/test-production-smoke.sh
+++ b/packages/playground/scripts/test-production-smoke.sh
@@ -10,8 +10,20 @@ echo "Starting vite preview on port 4173..."
 npx vite preview --port 4173 &
 PREVIEW_PID=$!
 
-# Wait for the server to be ready
-sleep 3
+# Poll until the server is ready (max 15s)
+echo "Waiting for preview server..."
+for i in $(seq 1 30); do
+  if curl -sf http://localhost:4173/ > /dev/null 2>&1; then
+    echo "Preview server ready after ${i}x500ms"
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    echo "::error::Preview server not ready after 15s"
+    kill "$PREVIEW_PID" 2>/dev/null || true
+    exit 1
+  fi
+  sleep 0.5
+done
 
 echo "Running production smoke tests..."
 RESULT=0


### PR DESCRIPTION
## Summary

Batch 3a, Item 11. Replace `sleep 3` with health endpoint polling.

### Changes
- **test-production-smoke.sh**: Polls `http://localhost:4173/` every 500ms (max 15s) instead of `sleep 3`
- **accelerator.yml smoke job**: Polls `/health` every 500ms (max 15s) instead of `sleep 3`. Also detects server crash during polling.

### Why
Blind sleeps are CI flakiness: slow runners may need more time, fast runners waste time. Polling adapts to runner speed and fails fast on crashes.

## Test plan
- [x] Local: production smoke passes, server ready in ~1.5s
- [x] actionlint + shellcheck — clean
- [ ] CI: both smoke jobs pass with the polling approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)