### PR TITLE
fix(accelerator): use X.509 notAfter for cert renewal, not file mtime

### DIFF
--- a/packages/accelerator/src-tauri/Cargo.lock
+++ b/packages/accelerator/src-tauri/Cargo.lock
@@ -250,6 +250,7 @@ dependencies = [
  "tracing-subscriber",
  "urlencoding",
  "which",
+ "x509-parser",
 ]
 
 [[package]]

--- a/packages/accelerator/src-tauri/Cargo.toml
+++ b/packages/accelerator/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ reqwest = { version = "0.12", features = ["stream", "json"] }
 flate2 = "1"
 tar = "0.4"
 rcgen = { version = "0.13", features = ["pem", "x509-parser"] }
+x509-parser = "0.16"
 rustls-pemfile = "2"
 tokio-rustls = "0.26"
 time = "0.3"

--- a/packages/accelerator/src-tauri/src/certs.rs
+++ b/packages/accelerator/src-tauri/src/certs.rs
@@ -6,7 +6,6 @@ use std::io::BufReader;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
 use time::OffsetDateTime;
 use tokio_rustls::rustls;
 
@@ -152,15 +151,19 @@ pub fn load_rustls_config(
 
 /// Approximate days remaining on the leaf certificate.
 /// Uses file modification time as a proxy for creation date.
+/// Parse the leaf certificate's notAfter field and return days until expiry.
+/// Uses the actual X.509 certificate, not file mtime (which can be wrong if
+/// the file is copied, restored from backup, or touched).
 pub fn leaf_cert_days_remaining() -> Result<i64, Box<dyn std::error::Error + Send + Sync>> {
-    let metadata = std::fs::metadata(leaf_cert_path())?;
-    let modified = metadata.modified()?;
-    let age = std::time::SystemTime::now()
-        .duration_since(modified)
-        .unwrap_or(Duration::ZERO);
-    let cert_validity_days: i64 = 825;
-    let days_since_creation = age.as_secs() as i64 / 86400;
-    Ok(cert_validity_days - days_since_creation)
+    let pem_bytes = std::fs::read(leaf_cert_path())?;
+    let (_, pem) = x509_parser::pem::parse_x509_pem(&pem_bytes)?;
+    let (_, cert) = x509_parser::parse_x509_certificate(&pem.contents)?;
+    let not_after = cert.validity().not_after.timestamp();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64;
+    Ok((not_after - now) / 86400)
 }
 
 /// Regenerate the leaf certificate if it's expiring within 30 days.


### PR DESCRIPTION
## Summary

Batch 3b, Item 13. Cert renewal now uses the actual certificate expiry, not the file modification time.

**Before**: `leaf_cert_days_remaining()` checked file mtime — `touch`ing or copying the file silently broke renewal.
**After**: Parses the X.509 `notAfter` field from the PEM certificate. Accurate regardless of file operations.

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --lib certs` — 4 cert tests pass
- [x] `cargo test --lib` — 66 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)