### PR TITLE
backport: refactor(playground): use data attributes instead of CSS classes in tests (#74)

### DIFF
--- a/packages/playground/e2e/demo.mocked.spec.ts
+++ b/packages/playground/e2e/demo.mocked.spec.ts
@@ -15,6 +15,8 @@ async function mockServicesOnline(page: import("@playwright/test").Page) {
 }
 
 // ── Tests ──
+// Assertions use data-* attributes (data-active, data-status) instead of CSS
+// classes, so design refactors don't break tests.
 
 test("page loads with correct initial state", async ({ page }) => {
   await mockServicesOffline(page);
@@ -24,34 +26,28 @@ test("page loads with correct initial state", async ({ page }) => {
   await expect(page.locator("#embedded-ui")).toBeVisible({ timeout: 10000 });
 
   // Accelerated mode button is active by default
-  const accelBtn = page.locator("#mode-accelerated");
-  await expect(accelBtn).toHaveClass(/mode-active/);
-
-  // Local mode button is not active
-  const localBtn = page.locator("#mode-local");
-  await expect(localBtn).not.toHaveClass(/mode-active/);
+  await expect(page.locator("#mode-accelerated")).toHaveAttribute("data-active", "true");
+  await expect(page.locator("#mode-local")).toHaveAttribute("data-active", "false");
 
   // Action buttons are disabled
   await expect(page.locator("#deploy-btn")).toBeDisabled();
   await expect(page.locator("#token-flow-btn")).toBeDisabled();
 });
 
-test("mode buttons toggle active class", async ({ page }) => {
+test("mode buttons toggle active state", async ({ page }) => {
   await mockServicesOffline(page);
   await page.goto("/");
-
-  // Wait for init to settle
   await expect(page.locator("#log")).toContainText("Checking Aztec node");
 
   // Click Local
   await page.click("#mode-local");
-  await expect(page.locator("#mode-local")).toHaveClass(/mode-active/);
-  await expect(page.locator("#mode-accelerated")).not.toHaveClass(/mode-active/);
+  await expect(page.locator("#mode-local")).toHaveAttribute("data-active", "true");
+  await expect(page.locator("#mode-accelerated")).toHaveAttribute("data-active", "false");
 
   // Click Accelerated
   await page.click("#mode-accelerated");
-  await expect(page.locator("#mode-accelerated")).toHaveClass(/mode-active/);
-  await expect(page.locator("#mode-local")).not.toHaveClass(/mode-active/);
+  await expect(page.locator("#mode-accelerated")).toHaveAttribute("data-active", "true");
+  await expect(page.locator("#mode-local")).toHaveAttribute("data-active", "false");
 });
 
 test("service dots show online when Aztec node responds OK", async ({ page }) => {
@@ -67,16 +63,16 @@ test("service dots show online when Aztec node responds OK", async ({ page }) =>
 
   await page.goto("/");
 
-  // Aztec dot should turn green
-  await expect(page.locator("#aztec-status")).toHaveClass(/status-online/);
+  // Aztec dot should be online
+  await expect(page.locator("#aztec-status")).toHaveAttribute("data-status", "online");
 });
 
 test("service dots show offline when Aztec node fails", async ({ page }) => {
   await mockServicesOffline(page);
   await page.goto("/");
 
-  // Aztec dot should be red
-  await expect(page.locator("#aztec-status")).toHaveClass(/status-offline/);
+  // Aztec dot should be offline
+  await expect(page.locator("#aztec-status")).toHaveAttribute("data-status", "offline");
 });
 
 test("log panel shows checking Aztec node message on load", async ({ page }) => {

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -54,7 +54,9 @@ function updateModeUI(mode: UiMode): void {
   };
 
   for (const [key, btn] of Object.entries(buttons)) {
-    btn.className = key === mode ? ACTIVE_BTN : INACTIVE_BTN;
+    const active = key === mode;
+    btn.className = active ? ACTIVE_BTN : INACTIVE_BTN;
+    btn.dataset.active = String(active);
   }
 }
 

--- a/packages/playground/src/ui.test.ts
+++ b/packages/playground/src/ui.test.ts
@@ -53,24 +53,23 @@ describe("setStatus", () => {
 
   test("sets status-online when connected=true", () => {
     setStatus("aztec-status", true);
-    const el = $("aztec-status");
+    const el = $("aztec-status") as HTMLElement;
     expect(el.className).toContain("status-online");
-    expect(el.className).not.toContain("status-offline");
-    expect(el.className).not.toContain("status-unknown");
+    expect(el.dataset.status).toBe("online");
   });
 
   test("sets status-offline when connected=false", () => {
     setStatus("aztec-status", false);
-    const el = $("aztec-status");
+    const el = $("aztec-status") as HTMLElement;
     expect(el.className).toContain("status-offline");
-    expect(el.className).not.toContain("status-online");
+    expect(el.dataset.status).toBe("offline");
   });
 
   test("sets status-unknown when connected=null", () => {
     setStatus("aztec-status", null);
-    const el = $("aztec-status");
+    const el = $("aztec-status") as HTMLElement;
     expect(el.className).toContain("status-unknown");
-    expect(el.className).not.toContain("status-online");
+    expect(el.dataset.status).toBe("unknown");
   });
 });
 

--- a/packages/playground/src/ui.ts
+++ b/packages/playground/src/ui.ts
@@ -12,9 +12,9 @@ export function $btn(id: string): HTMLButtonElement {
 
 export function setStatus(elementId: string, connected: boolean | null): void {
   const el = $(elementId);
-  el.className = `status-dot ${
-    connected === null ? "status-unknown" : connected ? "status-online" : "status-offline"
-  }`;
+  const status = connected === null ? "unknown" : connected ? "online" : "offline";
+  el.className = `status-dot status-${status}`;
+  el.dataset.status = status;
 }
 
 let logCount = 0;


### PR DESCRIPTION
Automated backport of #74 from main to nightlies.