### PR TITLE
refactor(accelerator): extract shared tauri-bridge.js for consistent IPC

### DIFF
--- a/packages/accelerator/src-tauri/frontend/authorize.html
+++ b/packages/accelerator/src-tauri/frontend/authorize.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Authorize Site</title>
   <link rel="stylesheet" href="style.css" />
+  <script src="tauri-bridge.js"></script>
 </head>
 <body>
   <div class="auth-container">
@@ -21,27 +22,24 @@
   </div>
 
   <script>
-    const { invoke } = window.__TAURI__.core;
-
-    // Origin is passed as a query parameter
     const params = new URLSearchParams(window.location.search);
     const origin = params.get("origin") || "unknown";
     document.getElementById("origin").textContent = origin;
 
-    async function respond(allowed) {
-      // Disable buttons to prevent double-click
-      document.getElementById("allow").disabled = true;
-      document.getElementById("deny").disabled = true;
+    function respond(allowed) {
       const remember = document.getElementById("remember").checked;
-      try {
-        await invoke("respond_auth", { origin, allowed, remember });
-      } catch (err) {
-        console.error("respond_auth failed:", err);
-      }
+      return invoke("respond_auth", { origin, allowed, remember });
     }
 
-    document.getElementById("allow").addEventListener("click", () => respond(true));
-    document.getElementById("deny").addEventListener("click", () => respond(false));
+    wireButton("allow", {
+      disableAlso: "deny",
+      onClick: () => respond(true),
+    });
+
+    wireButton("deny", {
+      disableAlso: "allow",
+      onClick: () => respond(false),
+    });
   </script>
 </body>
 </html>

--- a/packages/accelerator/src-tauri/frontend/settings.html
+++ b/packages/accelerator/src-tauri/frontend/settings.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Aztec Accelerator Settings</title>
   <link rel="stylesheet" href="style.css" />
+  <script src="tauri-bridge.js"></script>
 </head>
 <body>
   <div class="section">
@@ -56,7 +57,7 @@
   </div>
 
   <script>
-    const { invoke } = window.__TAURI__.core;
+    // invoke and wireToggle are provided by tauri-bridge.js (loaded in <head>)
 
     // CPU count comes from the Rust backend (std::thread::available_parallelism),
     // NOT navigator.hardwareConcurrency which WebKit caps for fingerprinting protection.
@@ -150,42 +151,12 @@
       }
     }
 
-    // Autostart toggle
-    document.getElementById("autostart").addEventListener("change", (e) => {
-      const el = e.target;
-      el.disabled = true;
-      invoke("set_autostart", { enabled: el.checked })
-        .catch((err) => {
-          el.checked = !el.checked;
-          console.error("Failed to set autostart:", err);
-        })
-        .finally(() => { el.disabled = false; });
-    });
-
-    // Auto-update toggle
-    document.getElementById("auto-update").addEventListener("change", (e) => {
-      const el = e.target;
-      el.disabled = true;
-      invoke("set_auto_update", { enabled: el.checked })
-        .catch((err) => {
-          el.checked = !el.checked;
-          console.error("Failed to set auto_update:", err);
-        })
-        .finally(() => { el.disabled = false; });
-    });
-
-    // Safari toggle
-    document.getElementById("safari").addEventListener("change", (e) => {
-      const el = e.target;
-      el.disabled = true;
-      const cmd = el.checked ? "enable_safari_support" : "disable_safari_support";
-      invoke(cmd)
-        .catch((err) => {
-          el.checked = !el.checked;
-          console.error("Failed to toggle Safari support:", err);
-        })
-        .finally(() => { el.disabled = false; });
-    });
+    // Toggles — all use wireToggle from tauri-bridge.js
+    wireToggle("autostart", (checked) => ({ cmd: "set_autostart", args: { enabled: checked } }));
+    wireToggle("auto-update", (checked) => ({ cmd: "set_auto_update", args: { enabled: checked } }));
+    wireToggle("safari", (checked) => ({
+      cmd: checked ? "enable_safari_support" : "disable_safari_support",
+    }));
 
     // Speed slider
     const speedSlider = document.getElementById("speed");

--- a/packages/accelerator/src-tauri/frontend/tauri-bridge.js
+++ b/packages/accelerator/src-tauri/frontend/tauri-bridge.js
@@ -1,0 +1,66 @@
+/**
+ * Shared utilities for Tauri IPC in accelerator frontend pages.
+ * Provides consistent error handling and loading states.
+ *
+ * Loaded via <script src="tauri-bridge.js"> in each HTML page.
+ * Functions are used globally — biome can't see cross-file usage.
+ */
+
+const { invoke } = window.__TAURI__.core;
+
+/**
+ * Wire a checkbox toggle to a Tauri command.
+ * Disables during operation, reverts on error.
+ *
+ * @param {string} id — element ID of the checkbox input
+ * @param {(checked: boolean) => {cmd: string, args?: object}} handler
+ *   Function that returns the command name and args based on checked state.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: used by HTML pages
+function wireToggle(id, handler) {
+  document.getElementById(id).addEventListener("change", (e) => {
+    const el = e.target;
+    el.disabled = true;
+    const { cmd, args } = handler(el.checked);
+    invoke(cmd, args)
+      .catch((err) => {
+        el.checked = !el.checked;
+        console.error(`Failed to invoke ${cmd}:`, err);
+      })
+      .finally(() => {
+        el.disabled = false;
+      });
+  });
+}
+
+/**
+ * Wire a button to a Tauri command.
+ * Disables the button (and an optional second button) during operation.
+ *
+ * @param {string} id — element ID of the button
+ * @param {object} opts
+ * @param {string} [opts.disableAlso] — ID of another button to disable during operation
+ * @param {string} [opts.loadingText] — text to show while loading (restores original on error)
+ * @param {() => Promise<void>} opts.onClick — async handler
+ */
+// biome-ignore lint/correctness/noUnusedVariables: used by HTML pages
+function wireButton(id, opts) {
+  const btn = document.getElementById(id);
+  btn.addEventListener("click", async () => {
+    btn.disabled = true;
+    const originalText = btn.textContent;
+    if (opts.loadingText) btn.textContent = opts.loadingText;
+
+    const otherBtn = opts.disableAlso ? document.getElementById(opts.disableAlso) : null;
+    if (otherBtn) otherBtn.disabled = true;
+
+    try {
+      await opts.onClick();
+    } catch (err) {
+      console.error(`Button ${id} action failed:`, err);
+      btn.textContent = originalText;
+      btn.disabled = false;
+      if (otherBtn) otherBtn.disabled = false;
+    }
+  });
+}

--- a/packages/accelerator/src-tauri/frontend/update-prompt.html
+++ b/packages/accelerator/src-tauri/frontend/update-prompt.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Aztec Accelerator Update</title>
   <link rel="stylesheet" href="style.css" />
+  <script src="tauri-bridge.js"></script>
 </head>
 <body>
   <div class="auth-container">
@@ -21,37 +22,24 @@
   </div>
 
   <script>
-    const { invoke } = window.__TAURI__.core;
-
     const params = new URLSearchParams(window.location.search);
     const currentVersion = params.get("current") || "unknown";
     const newVersion = params.get("version") || "unknown";
     document.getElementById("version").textContent =
       "v" + currentVersion + "  \u2192  v" + newVersion;
 
-    document.getElementById("update").addEventListener("click", async () => {
-      document.getElementById("update").disabled = true;
-      document.getElementById("later").disabled = true;
-      document.getElementById("update").textContent = "Updating\u2026";
-      const autoUpdate = document.getElementById("auto-update").checked;
-      try {
-        await invoke("respond_update_prompt", { action: "update", autoUpdate });
-      } catch (err) {
-        console.error("Update failed:", err);
-        document.getElementById("update").textContent = "Update Now";
-        document.getElementById("update").disabled = false;
-        document.getElementById("later").disabled = false;
-      }
+    wireButton("update", {
+      disableAlso: "later",
+      loadingText: "Updating\u2026",
+      onClick: () => {
+        const autoUpdate = document.getElementById("auto-update").checked;
+        return invoke("respond_update_prompt", { action: "update", autoUpdate });
+      },
     });
 
-    document.getElementById("later").addEventListener("click", async () => {
-      document.getElementById("update").disabled = true;
-      document.getElementById("later").disabled = true;
-      try {
-        await invoke("respond_update_prompt", { action: "later", autoUpdate: false });
-      } catch (err) {
-        console.error("Failed:", err);
-      }
+    wireButton("later", {
+      disableAlso: "update",
+      onClick: () => invoke("respond_update_prompt", { action: "later", autoUpdate: false }),
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary

Batch 3b, Item 10. Shared frontend utilities for consistent Tauri IPC handling.

### New: `tauri-bridge.js`
- **`wireToggle(id, handler)`** — disables during operation, reverts checkbox on error
- **`wireButton(id, opts)`** — disables during operation, supports loading text and paired button disabling

### Changes per page
- **settings.html**: 3 identical toggle handlers → 3 `wireToggle()` one-liners
- **authorize.html**: manual button disabling → 2 `wireButton()` calls
- **update-prompt.html**: manual button + loading text management → 2 `wireButton()` calls

## Test plan
- [x] `bun run test` — full workspace green
- [ ] **Manual (you)**: open Settings, toggle autostart/auto-update/speed. Open authorize popup (visit playground). Verify buttons work and revert on error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)