### PR TITLE
fix(accelerator): use HARDWARE_CONCURRENCY env var for bb thread control

### DIFF
--- a/packages/accelerator/src-tauri/src/bb.rs
+++ b/packages/accelerator/src-tauri/src/bb.rs
@@ -96,7 +96,9 @@ pub async fn prove(
         output_dir.to_str().unwrap(),
     ]);
     if let Some(t) = threads {
-        cmd.args(["-t", &t.to_string()]);
+        // bb uses HARDWARE_CONCURRENCY env var to control thread count.
+        // The -t flag was repurposed to --verifier_target in recent versions.
+        cmd.env("HARDWARE_CONCURRENCY", t.to_string());
     }
     let output = cmd.output().await?;
 


### PR DESCRIPTION
## Summary

**Critical bug fix**: Speed control was completely broken for any setting other than "Full".

The `-t` flag was repurposed to `--verifier_target` in recent bb versions. Passing `-t 7` (for Balanced speed) caused:
```
--verifier_target: 7 not in {evm,evm-no-zk,...}
```

bb uses the `HARDWARE_CONCURRENCY` environment variable for thread control. Switch from `cmd.args(["-t", N])` to `cmd.env("HARDWARE_CONCURRENCY", N)`.

## Test plan
- [x] `cargo test` — 66 tests pass
- [ ] Manual: set speed to Balanced, run a prove — should succeed with reduced threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)