### PR TITLE
fix(accelerator): match plist filename to productName

### DIFF
--- a/packages/accelerator/src-tauri/src/crash_recovery.rs
+++ b/packages/accelerator/src-tauri/src/crash_recovery.rs
@@ -4,7 +4,9 @@
 //!   so launchd restarts the app if it crashes.
 //! - **Linux**: Manages a systemd user service with `Restart=on-failure`.
 
-const APP_NAME: &str = "aztec-accelerator";
+/// Must match `productName` in tauri.conf.json — the auto-launch crate uses this
+/// (not the identifier) as the LaunchAgent plist filename and systemd service name.
+const APP_NAME: &str = "Aztec Accelerator";
 
 /// Patch the LaunchAgent plist created by tauri-plugin-autostart to add crash recovery keys.
 /// Call this after `manager.enable()`.
@@ -69,7 +71,7 @@ fn patch_plist_with_keepalive(content: &str) -> Option<String> {
 pub fn disable_crash_recovery() {
     // The plugin recreates the plist from scratch on enable(), so disabling
     // just means the standard disable() removes the plist entirely. Nothing extra needed.
-    tracing::debug!("macOS crash recovery disabled (plist removed by plugin)");
+    tracing::info!("macOS crash recovery disabled (plist removed by plugin)");
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary
- **Bug**: `crash_recovery.rs` hardcoded `APP_NAME = "aztec-accelerator"` but `auto-launch` crate uses `productName` from tauri.conf.json (`"Aztec Accelerator"` with space + caps) for the LaunchAgent plist filename
- **Effect**: `KeepAlive` + `ThrottleInterval` patching silently failed — crash recovery was never actually enabled
- **Fix**: Match the constant to `"Aztec Accelerator"`, bump disable log to `info` for symmetry

## Test plan
- [x] `cargo test --lib crash_recovery` — 3 tests pass
- [ ] Toggle "Start on Login" ON → `cat ~/Library/LaunchAgents/Aztec\ Accelerator.plist` contains `KeepAlive` and `ThrottleInterval`
- [ ] Toggle OFF → plist removed, `info` log emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)