### PR TITLE
ci: audit batch 2 — timeouts, action upgrades, concurrency, deploy guards

### DIFF
--- a/.github/actions/setup-aztec/action.yml
+++ b/.github/actions/setup-aztec/action.yml
@@ -14,7 +14,7 @@ runs:
       with:
         bun-version: latest
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       with:
         path: ~/.bun/install/cache
         key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
@@ -45,7 +45,7 @@ runs:
     - name: Cache Aztec CLI
       if: inputs.skip_cli != 'true'
       id: cache-aztec
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.aztec/versions/${{ steps.detect.outputs.version }}
         key: ${{ runner.os }}-aztec-${{ steps.detect.outputs.version }}

--- a/.github/workflows/backport-nightlies.yml
+++ b/.github/workflows/backport-nightlies.yml
@@ -17,13 +17,14 @@ jobs:
   backport:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.PAT_TOKEN }}
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -14,8 +14,9 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: oven-sh/setup-bun@v2
 
@@ -23,7 +24,7 @@ jobs:
 
       - run: bun run --cwd packages/landing build
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/publish-nightlies.yml
+++ b/.github/workflows/publish-nightlies.yml
@@ -8,6 +8,10 @@ on:
       - "packages/playground/**"
   workflow_dispatch:
 
+concurrency:
+  group: publish-nightlies
+  cancel-in-progress: true
+
 permissions:
   id-token: write
   contents: write
@@ -16,12 +20,13 @@ jobs:
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     outputs:
       sdk: ${{ steps.filter.outputs.sdk }}
       playground: ${{ steps.filter.outputs.playground }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -45,13 +50,13 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   deploy-app:
-    # Deploy playground regardless of E2E outcome — it's a static site build
-    # that shouldn't be blocked by SDK test failures.
-    if: ${{ !cancelled() }}
+    # Deploy playground unless E2E explicitly failed — skip on cancel, proceed on skip/success.
+    if: ${{ !cancelled() && needs.e2e.result != 'failure' }}
     needs: e2e
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: oven-sh/setup-bun@v2
 
@@ -63,7 +68,7 @@ jobs:
           SPONSORED_FPC_SALT: ${{ secrets.SPONSORED_FPC_SALT }}
         run: bun run --cwd packages/playground build
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/publish-testnet.yml
+++ b/.github/workflows/publish-testnet.yml
@@ -8,6 +8,10 @@ on:
       - "packages/playground/**"
   workflow_dispatch:
 
+concurrency:
+  group: publish-testnet
+  cancel-in-progress: true
+
 permissions:
   id-token: write
   contents: write
@@ -16,12 +20,13 @@ jobs:
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     outputs:
       sdk: ${{ steps.filter.outputs.sdk }}
       playground: ${{ steps.filter.outputs.playground }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -46,13 +51,13 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   deploy-app:
-    # Deploy playground regardless of E2E outcome — it's a static site build
-    # that shouldn't be blocked by SDK test failures.
-    if: ${{ !cancelled() }}
+    # Deploy playground unless E2E explicitly failed — skip on cancel, proceed on skip/success.
+    if: ${{ !cancelled() && needs.e2e.result != 'failure' }}
     needs: e2e
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: oven-sh/setup-bun@v2
 
@@ -64,7 +69,7 @@ jobs:
           SPONSORED_FPC_SALT: ${{ secrets.SPONSORED_FPC_SALT }}
         run: bun run --cwd packages/playground build
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/release-accelerator.yml
+++ b/.github/workflows/release-accelerator.yml
@@ -28,6 +28,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Validate version format
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if ! echo "$INPUT_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+            echo "::error::Invalid version format: '$INPUT_VERSION'. Expected semver (e.g. 1.0.0 or 1.0.0-rc.1)"
+            exit 1
+          fi
+
       - name: Create and push tag
         id: tag
         env:
@@ -118,7 +127,7 @@ jobs:
         working-directory: packages/accelerator
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
@@ -283,7 +292,7 @@ jobs:
             --notes-file /tmp/release-notes.md \
             "${FILES[@]}"
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}


### PR DESCRIPTION
## Summary
CI hardening from the combined audit (batch 2):

- **Timeouts**: Add `timeout-minutes` to all jobs missing them (deploy-landing, backport, publish changes/deploy-app)
- **Action upgrades**: `checkout` v4→v6, `cache` v4→v5, `paths-filter` v3→v4, `aws-credentials` v4→v6 — all standardized to latest
- **Signing password**: Move `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` from hardcoded `""` to `${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}`
- **Concurrency**: Add concurrency groups to `publish-nightlies` and `publish-testnet` to prevent parallel races
- **Deploy guard**: Change `!cancelled()` to `!cancelled() && needs.e2e.result != 'failure'` — don't deploy playground when E2E explicitly fails
- **Semver validation**: Validate release version input against `^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$` before using in sed/cargo

## Test plan
- [x] `bun run lint:actions` — actionlint clean
- [x] No remaining old action versions (`checkout@v4`, `cache@v4`, `paths-filter@v3`, `aws-credentials@v4`)
- [x] No exposed empty password strings in workflow files

🤖 Generated with [Claude Code](https://claude.com/claude-code)