### PR TITLE
fix: audit batch 3 — atomic permissions, error feedback, backport conflicts

### DIFF
--- a/.github/workflows/backport-nightlies.yml
+++ b/.github/workflows/backport-nightlies.yml
@@ -12,6 +12,7 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   backport:
@@ -54,16 +55,12 @@ jobs:
               --head "$BRANCH" \
               --title "backport: ${PR_TITLE} (#${PR_NUMBER})" \
               --body "Automated backport of #${PR_NUMBER} from main to nightlies.")
+            gh pr edit "$PR_URL" --add-label backport || true
           else
             git cherry-pick --abort || true
-            git checkout -- . || true
-            git push origin "$BRANCH"
-            PR_URL=$(gh pr create \
-              --base nightlies \
-              --head "$BRANCH" \
-              --title "backport (conflicts): ${PR_TITLE} (#${PR_NUMBER})" \
-              --body "Automated backport of #${PR_NUMBER} — has merge conflicts that need manual resolution.")
+            echo "Cherry-pick has conflicts — creating issue instead of empty PR"
+            gh issue create \
+              --title "Backport conflict: ${PR_TITLE} (#${PR_NUMBER})" \
+              --body "Automated cherry-pick of #${PR_NUMBER} to \`nightlies\` has conflicts. Manual backport needed." \
+              --label backport || echo "Warning: issue creation failed"
           fi
-
-          # Add label separately so a missing label doesn't prevent PR creation
-          gh pr edit "$PR_URL" --add-label backport || echo "Warning: could not add 'backport' label"

--- a/packages/accelerator/src-tauri/frontend/settings.html
+++ b/packages/accelerator/src-tauri/frontend/settings.html
@@ -167,6 +167,7 @@
       const level = SPEED_LEVELS[Number(e.target.value)];
       invoke("set_speed", { speed: level.value }).catch((err) => {
         console.error("Failed to set speed:", err);
+        showErrorHint(speedSlider, "Failed to save");
         loadSettings();
       });
     });

--- a/packages/accelerator/src-tauri/frontend/style.css
+++ b/packages/accelerator/src-tauri/frontend/style.css
@@ -338,3 +338,16 @@ h2 {
 .popup-remember input[type="checkbox"] {
   accent-color: var(--accent);
 }
+
+/* Error hints — brief inline feedback on command failure */
+.error-hint {
+  color: var(--danger);
+  font-size: 11px;
+  margin-left: 8px;
+  animation: fade-in 0.15s ease-out;
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}

--- a/packages/accelerator/src-tauri/frontend/tauri-bridge.js
+++ b/packages/accelerator/src-tauri/frontend/tauri-bridge.js
@@ -9,8 +9,25 @@
 const { invoke } = window.__TAURI__.core;
 
 /**
+ * Show a brief error hint near a control. Disappears after 3 seconds.
+ * @param {HTMLElement} anchor — element to show the error near
+ * @param {string} message
+ */
+function showErrorHint(anchor, message) {
+  // Remove any existing hint on this anchor
+  const existing = anchor.parentElement?.querySelector(".error-hint");
+  if (existing) existing.remove();
+
+  const hint = document.createElement("span");
+  hint.className = "error-hint";
+  hint.textContent = message;
+  anchor.closest(".row, .speed-section, .popup-container")?.appendChild(hint);
+  setTimeout(() => hint.remove(), 3000);
+}
+
+/**
  * Wire a checkbox toggle to a Tauri command.
- * Disables during operation, reverts on error.
+ * Disables during operation, reverts on error with visible feedback.
  *
  * @param {string} id — element ID of the checkbox input
  * @param {(checked: boolean) => {cmd: string, args?: object}} handler
@@ -26,6 +43,7 @@ function wireToggle(id, handler) {
       .catch((err) => {
         el.checked = !el.checked;
         console.error(`Failed to invoke ${cmd}:`, err);
+        showErrorHint(el, "Failed — try again");
       })
       .finally(() => {
         el.disabled = false;
@@ -61,6 +79,7 @@ function wireButton(id, opts) {
       btn.textContent = originalText;
       btn.disabled = false;
       if (otherBtn) otherBtn.disabled = false;
+      showErrorHint(btn, "Failed — try again");
     }
   });
 }

--- a/packages/accelerator/src-tauri/src/certs.rs
+++ b/packages/accelerator/src-tauri/src/certs.rs
@@ -118,15 +118,27 @@ pub fn generate_and_save() -> Result<(), Box<dyn std::error::Error + Send + Sync
 }
 
 /// Write a PEM file with 0o600 permissions (owner read/write only).
+/// On Unix, the file is created with restricted permissions atomically via OpenOptions::mode()
+/// to avoid a TOCTOU window where the file is briefly world-readable.
 fn write_pem_file(
     path: &std::path::Path,
     contents: &str,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    std::fs::write(path, contents)?;
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        file.write_all(contents.as_bytes())?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(path, contents)?;
     }
     Ok(())
 }

--- a/packages/accelerator/src-tauri/src/config.rs
+++ b/packages/accelerator/src-tauri/src/config.rs
@@ -80,11 +80,21 @@ pub fn save(config: &AcceleratorConfig) -> Result<(), Box<dyn std::error::Error 
         }
     }
     let json = serde_json::to_string_pretty(config)?;
-    std::fs::write(&path, &json)?;
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)?;
+        file.write_all(json.as_bytes())?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&path, &json)?;
     }
     Ok(())
 }

--- a/packages/accelerator/src-tauri/src/server.rs
+++ b/packages/accelerator/src-tauri/src/server.rs
@@ -210,7 +210,11 @@ async fn authorize_origin(
         .and_then(|v| v.to_str().ok())
     {
         Some(o) => o.to_string(),
-        None => return Ok(()), // No Origin header → auto-approve (curl, same-origin)
+        // No Origin header → auto-approve. Browsers always send Origin on cross-origin
+        // requests, so this only applies to curl/scripts/same-origin. Non-browser clients
+        // can bypass auth by omitting Origin, but this is inherent to localhost services —
+        // CORS/Origin is a browser-only mechanism, not a general access control boundary.
+        None => return Ok(()),
     };
 
     let approved = state.config.as_ref().is_some_and(|cfg| {


### PR DESCRIPTION
## Summary
Audit batch 3 — polish:

- **TOCTOU fix**: PEM key files and config.json now created with `OpenOptions::mode(0o600)` on Unix — never briefly world-readable between write and chmod
- **Error feedback**: Settings UI shows brief red error hint near the failed control when a Tauri command fails (toggles, speed slider, buttons) — auto-dismisses after 3s
- **Origin trade-off documented**: Expanded comment explaining why missing `Origin` header is auto-approved — inherent to localhost services, not a bypass
- **Backport conflicts**: Cherry-pick conflicts now create a GitHub issue instead of pushing an empty branch that produces an unmergeable no-diff PR

## Test plan
- [x] `cargo test --lib` — 71 tests pass
- [x] `cargo clippy` — clean
- [x] `bun run lint:actions` — clean
- [ ] Manual: trigger a toggle error in Settings (e.g. stop backend), confirm red hint appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)