### PR TITLE
fix: show update prompt in manual mode, fix clearIndexedDB await

### DIFF
--- a/packages/accelerator/src-tauri/src/main.rs
+++ b/packages/accelerator/src-tauri/src/main.rs
@@ -535,12 +535,14 @@ async fn run_update_check(app: &AppHandle, config_state: &ConfigState) {
             *pending.lock() = Some(update);
         }
 
-        if auto_update_pref.is_none() {
-            tracing::info!("Showing update prompt (first time)");
-            show_update_prompt_window(app, &current_version, &new_version);
-        } else {
-            tracing::info!(version = %new_version, "Update available (manual mode)");
-        }
+        // Show prompt for both None (first time) and Some(false) (manual mode).
+        // Some(true) users never reach here — check_for_update auto-installs for them.
+        tracing::info!(
+            ?auto_update_pref,
+            version = %new_version,
+            "Showing update prompt"
+        );
+        show_update_prompt_window(app, &current_version, &new_version);
     }
 }
 

--- a/packages/playground/src/aztec.ts
+++ b/packages/playground/src/aztec.ts
@@ -133,7 +133,15 @@ async function clearIndexedDB(): Promise<void> {
   await Promise.all(
     dbs
       .filter((db) => db.name && aztecPrefixes.some((prefix) => db.name!.startsWith(prefix)))
-      .map((db) => indexedDB.deleteDatabase(db.name!)),
+      .map(
+        (db) =>
+          new Promise<void>((resolve, reject) => {
+            const req = indexedDB.deleteDatabase(db.name!);
+            req.onsuccess = () => resolve();
+            req.onerror = () => reject(req.error);
+            req.onblocked = () => resolve(); // best-effort: proceed even if blocked
+          }),
+      ),
   );
 }
 


### PR DESCRIPTION
## Summary
Audit pass 4, PR 2 — UX fixes:

- **Manual update prompt**: Users who chose "manual mode" (`auto_update=Some(false)`) were never shown update prompts — the popup only appeared for first-time users (`auto_update=None`). Now the prompt is shown for both `None` and `Some(false)`, while `Some(true)` users still get auto-updates silently.
- **clearIndexedDB**: `indexedDB.deleteDatabase()` returns an `IDBOpenDBRequest`, not a `Promise`. Wrapping it in `Promise.all` resolved immediately without waiting for deletion. Now properly wraps each call in a Promise with `onsuccess`/`onerror`/`onblocked` handlers.

## Test plan
- [x] `bun run test` — lint, typecheck, 93 unit tests pass
- [ ] Manual: set auto_update to false in config, restart app — update prompt should appear when update is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)