### PR TITLE
fix(accelerator): P0 — fail-closed download verification, 5-minute prove timeout

### DIFF
--- a/packages/accelerator/src-tauri/src/bb.rs
+++ b/packages/accelerator/src-tauri/src/bb.rs
@@ -1,6 +1,10 @@
 use std::path::PathBuf;
+use std::time::Duration;
 
 use crate::versions;
+
+/// Maximum time to wait for bb prove to complete before killing the process.
+const PROVE_TIMEOUT: Duration = Duration::from_secs(300); // 5 minutes
 
 /// Find the `bb` binary. When `version` is provided, the version cache is checked
 /// before the standard search chain.
@@ -100,7 +104,18 @@ pub async fn prove(
         // The -t flag was repurposed to --verifier_target in recent versions.
         cmd.env("HARDWARE_CONCURRENCY", t.to_string());
     }
-    let output = cmd.output().await?;
+    // kill_on_drop ensures the bb process is killed if the future is cancelled
+    // (e.g., client disconnect, timeout). Without it, an orphaned bb would run to
+    // completion wasting CPU while holding the prove semaphore.
+    cmd.kill_on_drop(true);
+    let child = cmd.spawn()?;
+    let output = match tokio::time::timeout(PROVE_TIMEOUT, child.wait_with_output()).await {
+        Ok(result) => result?,
+        Err(_) => {
+            tracing::error!("bb prove timed out after {:?}", PROVE_TIMEOUT);
+            return Err("bb prove timed out after 5 minutes".into());
+        }
+    };
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     if !stderr.is_empty() {

--- a/packages/accelerator/src-tauri/src/versions.rs
+++ b/packages/accelerator/src-tauri/src/versions.rs
@@ -271,6 +271,8 @@ pub async fn download_bb(version: &str) -> Result<PathBuf, Box<dyn Error + Send 
     );
 
     // Verify download integrity against GitHub API digest.
+    // Fail closed: if we can't verify, we don't execute. The bundled bb sidecar
+    // always works without verification; this only affects on-demand downloads.
     let asset_name = format!("barretenberg-{}.tar.gz", current_platform());
     match fetch_github_asset_digest(version, &asset_name).await {
         Ok(Some(expected)) => {
@@ -284,17 +286,13 @@ pub async fn download_bb(version: &str) -> Result<PathBuf, Box<dyn Error + Send 
             tracing::info!(version, digest = %actual, "Download integrity verified");
         }
         Ok(None) => {
-            tracing::warn!(
-                version,
-                "No digest available from GitHub API — skipping integrity check"
-            );
+            return Err(format!(
+                "Cannot verify bb v{version}: no digest available from GitHub API"
+            )
+            .into());
         }
         Err(e) => {
-            tracing::warn!(
-                version,
-                error = %e,
-                "Failed to fetch digest from GitHub API — skipping integrity check"
-            );
+            return Err(format!("Cannot verify bb v{version}: digest fetch failed: {e}").into());
         }
     }
 


### PR DESCRIPTION
## Summary
P0 security + reliability hardening:

- **Fail-closed bb verification**: If GitHub API digest is unavailable or fetch fails, reject the download instead of executing an unverified binary. The bundled bb sidecar is unaffected (no download needed for the default version). This closes the supply-chain gap identified across all 5 audit passes.
- **5-minute prove timeout**: `bb prove` subprocess now has a `tokio::time::timeout(300s)` with `kill_on_drop(true)`. A hung bb no longer holds the prove semaphore forever, and orphaned processes are killed on timeout or client disconnect.

## Test plan
- [x] `cargo test --lib` — 72 tests pass
- [x] `cargo clippy` — clean
- [ ] Manual: trigger a prove from playground, verify it completes normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)