### PR TITLE
fix(accelerator): show startup errors in tray tooltip for production builds

### DIFF
--- a/packages/accelerator/src-tauri/src/main.rs
+++ b/packages/accelerator/src-tauri/src/main.rs
@@ -300,9 +300,14 @@ fn main() {
             app.manage::<SharedAppState>(Arc::new(state_with_https));
 
             // ── Startup diagnostics ──
+            // Update both the status menu item text AND tray tooltip so the
+            // message is visible in production builds (where the status item
+            // is not in the tray menu but the tooltip is always visible).
+            let tray_for_diagnostics = tray.clone();
             if aztec_accelerator::bb::find_bb(None).is_err() {
                 tracing::warn!("bb binary not found at startup");
                 let _ = status_for_diagnostics.set_text("Warning: bb not found");
+                let _ = tray_for_diagnostics.set_tooltip(Some("Warning: bb not found"));
             }
 
             // ── HTTP server ──
@@ -320,6 +325,7 @@ fn main() {
                         "Error: server failed"
                     };
                     let _ = status_for_server.set_text(msg);
+                    let _ = tray_for_diagnostics.set_tooltip(Some(msg));
                 }
             });
 


### PR DESCRIPTION
## Summary
The status menu item is only visible in dev mode, but the tray tooltip is always visible (hover over tray icon). Startup diagnostics now update both:

- `status.set_text(msg)` — visible in dev mode menu
- `tray.set_tooltip(msg)` — visible in all builds on hover

Fixes: production users with port conflicts or missing bb would see a normal tray icon with no indication of the problem.

## Test plan
- [x] `cargo clippy` — clean
- [x] `cargo test --bin aztec-accelerator` — 3 tests pass
- [ ] Manual: start two instances in dev mode, hover second instance's tray → shows "Error: port 59833 in use"

🤖 Generated with [Claude Code](https://claude.com/claude-code)