### PR TITLE
test(accelerator): strengthen server API contract tests

### DIFF
--- a/packages/accelerator/src-tauri/Cargo.toml
+++ b/packages/accelerator/src-tauri/Cargo.toml
@@ -40,6 +40,7 @@ sha2 = "0.10"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }
+tokio = { version = "1", features = ["test-util"] }
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/packages/accelerator/src-tauri/src/server.rs
+++ b/packages/accelerator/src-tauri/src/server.rs
@@ -1025,10 +1025,36 @@ mod tests {
         assert!(json["message"].is_string());
     }
 
-    // NOTE: prove_returns_403_on_authorization_timeout would require tokio test-util
-    // feature for time::pause/advance to avoid a real 60s wait. Deferred — the timeout
-    // logic is simple (tokio::time::timeout on line 267) and the JSON shape is covered
-    // by the same json_error() helper tested in the 429 test above.
+    #[tokio::test(start_paused = true)]
+    async fn prove_returns_403_on_authorization_timeout() {
+        let (popup_tx, _popup_rx) = std::sync::mpsc::channel();
+        let (state, _auth) = auth_state_with_popup(popup_tx);
+        let app = router(state);
+
+        // Send request from unknown origin — popup fires but nobody resolves it.
+        // start_paused = true means tokio time is auto-advanced when all tasks
+        // are waiting on timers, so the 60s timeout resolves instantly.
+        let response: axum::http::Response<_> = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/prove")
+                    .header("content-type", "application/octet-stream")
+                    .header("origin", "https://slow-user.com")
+                    .body(Body::from(vec![0u8; 10]))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"], "authorization_timeout");
+        assert!(json["message"].is_string());
+    }
 
     // ── Helper unit tests ──
 


### PR DESCRIPTION
## Summary
Server API contract tests — validates response shapes, not just status codes:

**Extended existing tests:**
- `/health`: assert complete shape (api_version=1, version/aztec_version as strings, available_versions as array, bb_available as boolean, https_port absent by default)
- `/prove` invalid version: assert JSON body has `error` + `message` fields
- `/prove` denied: assert `message` is a string
- CORS: assert `cross-origin-resource-policy: cross-origin` header

**New tests:**
- `health_includes_https_port_when_safari_enabled`: Safari config → `https_port` in response
- `prove_returns_429_when_too_many_pending_origins`: fill auth manager to capacity (10 origins), 11th gets 429 with JSON error

**Fixed:**
- Race condition in `prove_triggers_popup_for_unknown_origin`: replaced 50ms `sleep` with `popup_rx.recv()` signal — deterministic, not timing-dependent

Total: **83 Rust tests** (up from 81).

## Test plan
- [x] `cargo test --lib` — 83 tests pass
- [x] `cargo clippy` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)