### PR TITLE
backport: chore: TypeScript 6.0, polyfills 0.26, target ES2025 (#131)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "sort-package-json": "^3.6.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6",
       },
     },
     "packages/accelerator": {
@@ -49,7 +49,7 @@
         "autoprefixer": "^10.4.27",
         "postcss": "^8.5.8",
         "tailwindcss": "^4.2.2",
-        "typescript": "^5.9.3",
+        "typescript": "^6",
         "viem": "npm:@aztec/viem@2.38.2",
         "vite": "^7.3.1",
         "vite-plugin-node-polyfills": "^0.25.0",
@@ -1646,7 +1646,7 @@
 
     "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
     "typical": ["typical@4.0.0", "", {}, "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="],
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "sort-package-json": "^3.6.1",
-    "typescript": "^5.9.3"
+    "typescript": "^6"
   }
 }

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -38,7 +38,7 @@
     "autoprefixer": "^10.4.27",
     "postcss": "^8.5.8",
     "tailwindcss": "^4.2.2",
-    "typescript": "^5.9.3",
+    "typescript": "^6",
     "viem": "npm:@aztec/viem@2.38.2",
     "vite": "^7.3.1",
     "vite-plugin-node-polyfills": "^0.25.0"

--- a/packages/playground/tsconfig.json
+++ b/packages/playground/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2025",
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["ES2025", "DOM"],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2025",
     "moduleResolution": "NodeNext",
     "module": "NodeNext",
 


### PR DESCRIPTION
Automated backport of #131 from main to nightlies.