### PR TITLE
backport: fix(sdk): set rootDir to prevent dist/src nesting (#157)

### DIFF
--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "outDir": "./dist",
     "types": ["bun-types"]
   },


### PR DESCRIPTION
Automated backport of #157 from main to nightlies.