### PR TITLE
fix(ci): auto-merge backport PRs, close stale nightly updates

### DIFF
--- a/.github/workflows/_aztec-update.yml
+++ b/.github/workflows/_aztec-update.yml
@@ -152,6 +152,23 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Close stale update PRs
+        env:
+          BRANCH_PREFIX: ${{ inputs.branch_prefix }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          NEW_VERSION: ${{ needs.check-update.outputs.new_version }}
+        run: |
+          CURRENT_BRANCH="${BRANCH_PREFIX}-${NEW_VERSION}"
+          gh pr list \
+            --base "$TARGET_BRANCH" \
+            --state open \
+            --json number,headRefName \
+            --jq ".[] | select(.headRefName | startswith(\"${BRANCH_PREFIX}-\")) | select(.headRefName != \"${CURRENT_BRANCH}\") | .number" \
+          | while read -r pr_num; do
+              echo "Closing stale PR #$pr_num"
+              gh pr close "$pr_num" --delete-branch --comment "Superseded by ${NEW_VERSION} update."
+            done
+
       - name: Create or update PR
         env:
           BRANCH_PREFIX: ${{ inputs.branch_prefix }}

--- a/.github/workflows/backport-nightlies.yml
+++ b/.github/workflows/backport-nightlies.yml
@@ -12,7 +12,6 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
-  issues: write
 
 jobs:
   backport:
@@ -48,19 +47,22 @@ jobs:
 
           git checkout -b "$BRANCH" origin/nightlies
 
-          if git cherry-pick --no-commit "$MERGE_SHA" && git commit -m "backport: ${PR_TITLE} (#${PR_NUMBER})"; then
-            git push origin "$BRANCH"
-            PR_URL=$(gh pr create \
-              --base nightlies \
-              --head "$BRANCH" \
-              --title "backport: ${PR_TITLE} (#${PR_NUMBER})" \
-              --body "Automated backport of #${PR_NUMBER} from main to nightlies.")
-            gh pr edit "$PR_URL" --add-label backport || true
+          if git cherry-pick --no-commit -m 1 "$MERGE_SHA"; then
+            if git diff --cached --quiet; then
+              echo "Cherry-pick produced no changes — already applied on nightlies"
+            else
+              git commit -m "backport: ${PR_TITLE} (#${PR_NUMBER})"
+              git push origin "$BRANCH"
+              gh pr create \
+                --base nightlies \
+                --head "$BRANCH" \
+                --title "backport: ${PR_TITLE} (#${PR_NUMBER})" \
+                --body "Automated backport of #${PR_NUMBER} from main to nightlies." \
+                --label backport
+              gh pr merge "$BRANCH" --auto --squash --delete-branch \
+                || echo "::warning::Auto-merge could not be enabled — merge manually"
+            fi
           else
             git cherry-pick --abort || true
-            echo "Cherry-pick has conflicts — creating issue instead of empty PR"
-            gh issue create \
-              --title "Backport conflict: ${PR_TITLE} (#${PR_NUMBER})" \
-              --body "Automated cherry-pick of #${PR_NUMBER} to \`nightlies\` has conflicts. Manual backport needed." \
-              --label backport || echo "Warning: issue creation failed"
+            echo "::warning::Cherry-pick of #${PR_NUMBER} to nightlies has conflicts — skipping"
           fi


### PR DESCRIPTION
## Summary
- **Backport PRs now auto-merge** when CI passes (previously required manual merge, causing pile-up)
- **Cherry-pick conflicts skip silently** with a warning instead of creating noisy GitHub Issues
- **Stale nightly update PRs are closed** before creating a new one (prevents daily stacking when CI is slow)
- Added `-m 1` safety net for merge-commit cherry-picks and empty cherry-pick detection

## Test plan
- [x] `actionlint` passes
- [ ] CI passes (workflow-only change, no code impact)
- Backport auto-merge will be exercised once this PR merges and a subsequent PR triggers the backport flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)