### PR TITLE
feat(release): ship headless accelerator-server tarballs for CI test acceleration

### DIFF
--- a/.github/workflows/accelerator.yml
+++ b/.github/workflows/accelerator.yml
@@ -83,7 +83,7 @@ jobs:
       - run: bun run lint
 
   smoke:
-    name: Release Smoke
+    name: Smoke
     needs: changes
     if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
@@ -130,6 +130,29 @@ jobs:
           echo "$HEALTH" | jq -e '.status == "ok"' > /dev/null
           echo "Smoke test passed"
           kill $SERVER_PID 2>/dev/null || true
+
+  release-smoke:
+    name: Release Smoke
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: packages/accelerator/src-tauri
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-accelerator
+      - name: Build release headless server (linux-x86_64)
+        run: cargo build --release --bin accelerator-server
+      - name: Package and checksum
+        run: |
+          cd target/release
+          tar -czf accelerator-server-pr-smoke-linux-x86_64.tar.gz accelerator-server
+          shasum -a 256 accelerator-server-pr-smoke-linux-x86_64.tar.gz > accelerator-server-pr-smoke-linux-x86_64.tar.gz.sha256
+          shasum -a 256 -c accelerator-server-pr-smoke-linux-x86_64.tar.gz.sha256
 
   desktop-ui:
     name: Desktop UI Tests
@@ -187,13 +210,13 @@ jobs:
   accelerator-status:
     name: Accelerator Status
     if: always()
-    needs: [changes, clippy, test, lint, smoke, desktop-ui, e2e, e2e-webdriver]
+    needs: [changes, clippy, test, lint, smoke, release-smoke, desktop-ui, e2e, e2e-webdriver]
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
       - name: Check results
         run: |
-          results="${{ needs.changes.result }} ${{ needs.clippy.result }} ${{ needs.test.result }} ${{ needs.lint.result }} ${{ needs.smoke.result }} ${{ needs.desktop-ui.result }} ${{ needs.e2e.result }} ${{ needs.e2e-webdriver.result }}"
+          results="${{ needs.changes.result }} ${{ needs.clippy.result }} ${{ needs.test.result }} ${{ needs.lint.result }} ${{ needs.smoke.result }} ${{ needs.release-smoke.result }} ${{ needs.desktop-ui.result }} ${{ needs.e2e.result }} ${{ needs.e2e-webdriver.result }}"
           for r in $results; do
             if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
               echo "Job failed or was cancelled: $r"

--- a/.github/workflows/release-accelerator.yml
+++ b/.github/workflows/release-accelerator.yml
@@ -160,6 +160,78 @@ jobs:
             packages/accelerator/src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.sig
             packages/accelerator/src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.sig
 
+  build-headless:
+    name: Build Headless (${{ matrix.platform }})
+    needs: [validate, tag]
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+            platform: macos-arm64
+          - target: x86_64-apple-darwin
+            runner: macos-15-intel
+            platform: macos-x86_64
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            platform: linux-x86_64
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+            platform: linux-arm64
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: packages/accelerator/src-tauri -> target
+          key: headless-${{ matrix.target }}
+
+      - name: Install libssl-dev (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev
+
+      - name: Patch version in Cargo.toml
+        env:
+          RELEASE_VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          cd packages/accelerator/src-tauri
+          sed -i.bak "s/^version = \".*\"/version = \"$RELEASE_VERSION\"/" Cargo.toml
+          rm -f Cargo.toml.bak
+
+      - name: Build accelerator-server
+        working-directory: packages/accelerator/src-tauri
+        run: cargo build --release --bin accelerator-server --target ${{ matrix.target }}
+
+      - name: Package and checksum
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          cd packages/accelerator/src-tauri/target/${{ matrix.target }}/release
+          TARBALL="accelerator-server-${VERSION}-${PLATFORM}.tar.gz"
+          tar -czf "$TARBALL" accelerator-server
+          shasum -a 256 "$TARBALL" > "$TARBALL.sha256"
+          shasum -a 256 -c "$TARBALL.sha256"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: accelerator-server-${{ matrix.platform }}
+          path: |
+            packages/accelerator/src-tauri/target/${{ matrix.target }}/release/accelerator-server-*.tar.gz
+            packages/accelerator/src-tauri/target/${{ matrix.target }}/release/accelerator-server-*.tar.gz.sha256
+
   smoke:
     name: Post-build Smoke
     needs: [validate, build]
@@ -234,7 +306,7 @@ jobs:
 
   release:
     name: Create GitHub Release
-    needs: [validate, build, smoke]
+    needs: [validate, build, build-headless, smoke]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -266,6 +338,10 @@ jobs:
           find artifacts -name '*_amd64.deb'      -exec mv {} "release-files/Aztec-Accelerator-${VERSION}-Linux-x86_64.deb" \;
           find artifacts -name '*_amd64.AppImage'  -exec mv {} "release-files/Aztec-Accelerator-${VERSION}-Linux-x86_64.AppImage" \;
 
+          # Headless server tarballs + checksums (named accelerator-server-${VERSION}-<platform>.tar.gz)
+          find artifacts -name 'accelerator-server-*.tar.gz' -exec mv {} release-files/ \;
+          find artifacts -name 'accelerator-server-*.tar.gz.sha256' -exec mv {} release-files/ \;
+
           echo "Release files:"
           ls -la release-files/
 
@@ -277,6 +353,14 @@ jobs:
             "Aztec-Accelerator-${VERSION}-macOS-Intel.app.tar.gz"
             "Aztec-Accelerator-${VERSION}-Linux-x86_64.deb"
             "Aztec-Accelerator-${VERSION}-Linux-x86_64.AppImage"
+            "accelerator-server-${VERSION}-macos-arm64.tar.gz"
+            "accelerator-server-${VERSION}-macos-arm64.tar.gz.sha256"
+            "accelerator-server-${VERSION}-macos-x86_64.tar.gz"
+            "accelerator-server-${VERSION}-macos-x86_64.tar.gz.sha256"
+            "accelerator-server-${VERSION}-linux-x86_64.tar.gz"
+            "accelerator-server-${VERSION}-linux-x86_64.tar.gz.sha256"
+            "accelerator-server-${VERSION}-linux-arm64.tar.gz"
+            "accelerator-server-${VERSION}-linux-arm64.tar.gz.sha256"
           )
           for f in "${EXPECTED[@]}"; do
             if [ ! -f "release-files/$f" ]; then
@@ -338,7 +422,7 @@ jobs:
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
           # Collect all bundle files into a null-delimited list
-          mapfile -d '' FILES < <(find release-files -type f \( -name '*.dmg' -o -name '*.deb' -o -name '*.AppImage' -o -name '*.app.tar.gz' -o -name 'latest.json' \) -print0)
+          mapfile -d '' FILES < <(find release-files -type f \( -name '*.dmg' -o -name '*.deb' -o -name '*.AppImage' -o -name '*.app.tar.gz' -o -name 'accelerator-server-*.tar.gz' -o -name 'accelerator-server-*.tar.gz.sha256' -o -name 'latest.json' \) -print0)
 
           if [ ${#FILES[@]} -eq 0 ]; then
             echo "No artifacts found!"
@@ -378,6 +462,24 @@ jobs:
           ### macOS: First Launch
 
           The app is **code-signed and notarized** by Apple. Double-click the DMG, drag to Applications, and launch.
+
+          ### Headless server for CI test acceleration
+
+          > **For CI test acceleration only. Not for production.** Listens on \`127.0.0.1\` only.
+          > Tested on GitHub-hosted (single-tenant) runners. The built-in \`ALLOWED_ORIGINS\`
+          > access control only gates browser-driven callers; on shared or self-hosted runners,
+          > other processes on the same host can bypass it. Do not deploy this binary as a service.
+
+          | Platform | File |
+          |---|---|
+          | macOS (Apple Silicon) | \`accelerator-server-${VERSION}-macos-arm64.tar.gz\` |
+          | macOS (Intel)         | \`accelerator-server-${VERSION}-macos-x86_64.tar.gz\` |
+          | Linux (x86_64)        | \`accelerator-server-${VERSION}-linux-x86_64.tar.gz\` |
+          | Linux (ARM64)         | \`accelerator-server-${VERSION}-linux-arm64.tar.gz\` |
+
+          Each tarball ships with a \`.sha256\` sidecar. Verify before extracting. See [Headless
+          server section in the accelerator README](https://github.com/alejoamiras/aztec-accelerator/blob/main/packages/accelerator/README.md#headless-server-for-ci-test-acceleration)
+          for the install one-liner and \`ALLOWED_ORIGINS\` configuration.
 
           ### Aztec Version
           Built against Aztec \`${AZTEC_VER}\`.

--- a/packages/accelerator/README.md
+++ b/packages/accelerator/README.md
@@ -18,6 +18,8 @@ Download the latest release from [GitHub Releases](https://github.com/alejoamira
 | macOS (Intel) | `.dmg` |
 | Linux (x86_64) | `.deb`, `.AppImage` |
 
+**Running CI tests?** The release also ships a [headless server tarball](#headless-server-for-ci-test-acceleration) for accelerating end-to-end tests on GitHub-hosted runners.
+
 ### macOS Gatekeeper
 
 The app is code-signed and notarized by Apple. It should open without any Gatekeeper warnings. If macOS still blocks it (e.g., a local build), allow it via:
@@ -59,7 +61,7 @@ Every `/prove` response includes an `x-prove-duration-ms` header with the actual
 
 ### Port
 
-The default port is `59833`. Override it with the `AZTEC_ACCELERATOR_PORT` environment variable (must match on both SDK and accelerator sides).
+The default port is `59833`. The SDK reads `AZTEC_ACCELERATOR_PORT` to override the client-side target. The server itself currently does **not** honor this env var — it always binds `127.0.0.1:59833`. If you need to change the port on both sides, that requires a code change to `server.rs`.
 
 ### Automatic Version Management
 
@@ -96,7 +98,75 @@ The accelerator uses a MetaMask-style approval flow. When a new website calls `/
 
 Approved sites can be reviewed and removed from the Settings window.
 
-For the headless server binary (CI/testing), set `ALLOWED_ORIGINS=origin1,origin2` to restrict access. Without it, all origins are auto-approved.
+For the headless server binary (CI/testing), set `ALLOWED_ORIGINS=origin1,origin2` to restrict browser-driven access. See the [Headless Server section](#headless-server-for-ci-test-acceleration) below for the full security model.
+
+## Headless Server for CI Test Acceleration
+
+> **For CI test acceleration only. Not for production. Not for shared or self-hosted CI runners.**
+>
+> The headless server is a stripped-down build of the accelerator with no tray, no window, and no GUI dependencies. It exists so external Aztec dApp teams can install the accelerator on their CI runners and speed up E2E test proving (native `bb` instead of WASM).
+>
+> **Security caveats — read before deploying:**
+>
+> - The server listens on `127.0.0.1` only. On a single-tenant CI runner (GitHub-hosted) this is the auth boundary.
+> - `ALLOWED_ORIGINS` only gates **browser-driven** callers via the `Origin` header. Non-browser callers (curl, another process on the same host) can omit the header and bypass the check. This is acceptable for single-tenant CI but **unsafe for shared/self-hosted runners or any production environment**.
+> - The tarball is shipped with a SHA-256 sidecar only, not a cryptographic signature. Verify the checksum before extracting.
+> - Do not run this as a service. Do not expose it on a public interface. Do not use on a multi-tenant host.
+
+### Download
+
+Each [GitHub release](https://github.com/alejoamiras/aztec-accelerator/releases) ships four tarballs:
+
+| Platform | Tarball |
+|---|---|
+| macOS (Apple Silicon) | `accelerator-server-${VERSION}-macos-arm64.tar.gz` |
+| macOS (Intel)         | `accelerator-server-${VERSION}-macos-x86_64.tar.gz` |
+| Linux (x86_64)        | `accelerator-server-${VERSION}-linux-x86_64.tar.gz` |
+| Linux (ARM64)         | `accelerator-server-${VERSION}-linux-arm64.tar.gz` |
+
+Each has a matching `.sha256` sidecar file.
+
+### Install in GitHub Actions (Linux x86_64 example)
+
+```yaml
+- name: Install aztec-accelerator headless server
+  env:
+    ACCELERATOR_VERSION: "1.0.1"
+  run: |
+    BASE_URL="https://github.com/alejoamiras/aztec-accelerator/releases/download/accelerator-v${ACCELERATOR_VERSION}"
+    TARBALL="accelerator-server-${ACCELERATOR_VERSION}-linux-x86_64.tar.gz"
+    curl -sSfL "${BASE_URL}/${TARBALL}" -o "${TARBALL}"
+    curl -sSfL "${BASE_URL}/${TARBALL}.sha256" -o "${TARBALL}.sha256"
+    shasum -a 256 -c "${TARBALL}.sha256"
+    tar -xzf "${TARBALL}"
+    sudo mv accelerator-server /usr/local/bin/
+
+- name: Start headless accelerator
+  env:
+    ALLOWED_ORIGINS: http://localhost:5173
+  run: accelerator-server > accelerator.log 2>&1 &
+```
+
+The accelerator will download the matching `bb` binary on the first prove request (from Aztec's GitHub releases) and cache it in `~/.aztec-accelerator/versions/`. Subsequent runs reuse the cache.
+
+### Configuration
+
+| Env var | Effect |
+|---|---|
+| `ALLOWED_ORIGINS` | Comma-separated list of origins pre-approved for browser-driven `/prove` calls. If unset, all browser origins are auto-approved on the headless server. |
+| `BB_BINARY_PATH` | Path to a pre-installed `bb` binary, bypassing the auto-download. |
+| `RUST_LOG` | Standard `tracing-subscriber` filter (e.g. `info`, `debug`). |
+
+### Verifying it's running
+
+```sh
+curl http://127.0.0.1:59833/health
+# {"status":"ok","api_version":1,"version":"...","aztec_version":"...","available_versions":[...],"bb_available":true}
+```
+
+### Source
+
+The headless server is `cargo build --bin accelerator-server` against the same `packages/accelerator/src-tauri` crate as the desktop app — it just uses a different `main()` that skips the Tauri runtime. See `src/bin/accelerator-server.rs`.
 
 ## Tray Menu
 
@@ -267,10 +337,11 @@ ACCELERATOR_DOWNLOAD_TEST=1 cargo test download_and_verify -- --nocapture
 Releases are triggered via `gh workflow run release-accelerator.yml -f version=X.Y.Z`.
 
 ```
-validate → e2e-webdriver gate → tag → build (3 platforms) → post-build smoke → release → bump
+validate → e2e-webdriver gate → tag → build (3 Tauri + 4 headless platforms) → post-build smoke → release → bump
 ```
 
 - **E2E gate**: builds with `--features webdriver`, runs 9 WebDriver tests (macOS, release mode)
+- **Build**: Tauri bundles for 3 platforms (macOS arm64/x86_64, Linux x86_64) + headless `accelerator-server` for 4 platforms (macOS arm64/x86_64, Linux x86_64/arm64)
 - **Post-build smoke**: mounts the signed DMG, launches the app, polls `/health`
-- **Release**: creates GitHub Release with DMGs/debs/AppImages + `latest.json` for auto-updater
+- **Release**: creates GitHub Release with DMGs/debs/AppImages + headless tarballs (with SHA-256 sidecars) + `latest.json` for auto-updater
 - **Bump**: auto-creates PR to bump source version

--- a/packages/accelerator/src-tauri/Cargo.lock
+++ b/packages/accelerator/src-tauri/Cargo.lock
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "aztec-accelerator"
-version = "1.0.0-rc.22"
+version = "1.0.1-rc.1"
 dependencies = [
  "axum",
  "base64 0.22.1",


### PR DESCRIPTION
## Summary

Ships the already-existing `accelerator-server` binary (no-Tauri / no-GUI build) as cross-compiled tarballs on every release, so external Aztec dApp teams can install it on GitHub-hosted CI runners and speed up their E2E proving tests.

**Strictly scoped to CI test acceleration.** Docs lead with an explicit warning box: single-tenant runners only, `ALLOWED_ORIGINS` is browser-only and bypassable by non-browser callers, SHA-256 sidecar is integrity-only, do not run as a service. Per the maintenance plan (`implementations-plan/maintenance-2026-05-27/plan.md`), no server-side code changes are in this PR — we ship what the existing code actually does, with honest docs.

## What's in this PR

### `release-accelerator.yml` — new `build-headless` matrix job

| Target triple | Runner | Tarball |
|---|---|---|
| `aarch64-apple-darwin` | `macos-latest` | `accelerator-server-${VERSION}-macos-arm64.tar.gz` |
| `x86_64-apple-darwin` | `macos-15-intel` | `accelerator-server-${VERSION}-macos-x86_64.tar.gz` |
| `x86_64-unknown-linux-gnu` | `ubuntu-latest` | `accelerator-server-${VERSION}-linux-x86_64.tar.gz` |
| `aarch64-unknown-linux-gnu` | `ubuntu-24.04-arm` | `accelerator-server-${VERSION}-linux-arm64.tar.gz` |

Each tarball ships with a `.sha256` sidecar. Job has `permissions: contents: read`. Linux runners install `libssl-dev` (reqwest's default features pull native-tls per `Cargo.lock`).

The `release` job's `EXPECTED` array fails fast if any of the 8 new files (4 tarballs + 4 sidecars) is missing. The `gh release create` file glob is extended to include them.

### `accelerator.yml` — new `release-smoke` PR-gate job

Mirrors the release workflow's `cargo build --release --bin accelerator-server` + `tar` + `shasum -a 256 -c` chain on linux-x86_64. `release-accelerator.yml` is `workflow_dispatch`-only and tags before building, so this PR-gate smoke catches regressions to the release build path before any merge ever lands.

### `packages/accelerator/README.md`

- New top-level **Headless Server for CI Test Acceleration** section with warning box, download table, copy-pasteable GitHub Actions install snippet, configuration table, source pointer.
- Fixes a pre-existing inaccuracy in the **Port** section — the previous text claimed `AZTEC_ACCELERATOR_PORT` works "on both SDK and accelerator sides", but only the SDK reads it; the server hardcodes 59833. Documents the real behavior.
- Release Pipeline section updated for the new build matrix (3 Tauri + 4 headless platforms).

## What's NOT in this PR

Per the plan's explicit scope:

- No bearer-token auth on `/prove`.
- No `AZTEC_ACCELERATOR_PORT` plumbing into the server.
- No `reqwest` → rustls-only switch.
- No GitHub artifact attestation / Sigstore / minisign.
- No Windows target.
- No npm wrapper package.
- No code signing for the headless binary.

Track these as follow-up issues if there's demand.

## Local validation

- [x] `cargo build --release --bin accelerator-server` on macOS arm64 — clean (47s, 1.5MB binary)
- [x] `tar -czf` + `shasum -a 256` + `shasum -a 256 -c` round-trip — clean
- [x] `bun run lint:actions` — clean
- [x] Lint hooks via lint-staged on commits — clean (actionlint runs on the workflow edits)

## Test plan

- [ ] CI PR-gate workflows green: `accelerator.yml` (including the new `release-smoke` job), `actionlint.yml`
- [ ] After merge: manually trigger `release-accelerator.yml` against a throwaway `-rc.X` version to validate the full headless build matrix end-to-end (4 platforms) before any stable release. `ubuntu-24.04-arm` is the only runner not previously used by our pipelines.
- [ ] First real release: confirm 8 new files (4 tarballs + 4 sidecars) appear on the GitHub release, sidecars verify cleanly, and the release notes render the headless section correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)