### PR TITLE
fix(release): build-headless needs prebuild + full Tauri Linux deps

### DIFF
--- a/.github/workflows/release-accelerator.yml
+++ b/.github/workflows/release-accelerator.yml
@@ -184,11 +184,21 @@ jobs:
           workspaces: packages/accelerator/src-tauri -> target
           key: headless-${{ matrix.target }}
 
-      - name: Install libssl-dev (Linux)
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: ${{ runner.os }}-bun-
+      - run: bun install --frozen-lockfile
+
+      - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libssl-dev
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libssl-dev libgtk-3-dev
 
       - name: Patch version in Cargo.toml
         env:
@@ -197,6 +207,9 @@ jobs:
           cd packages/accelerator/src-tauri
           sed -i.bak "s/^version = \".*\"/version = \"$RELEASE_VERSION\"/" Cargo.toml
           rm -f Cargo.toml.bak
+
+      - name: Copy bb sidecar
+        run: bun run --cwd packages/accelerator prebuild
 
       - name: Build accelerator-server
         working-directory: packages/accelerator/src-tauri


### PR DESCRIPTION
## Summary

Hotfix discovered during the `1.0.1-rc.2` accelerator dry-run (run [26533457162](https://github.com/alejoamiras/aztec-accelerator/actions/runs/26533457162)) — all 4 `build-headless` jobs failed because the matrix from #225 was under-provisioned for the real release pipeline.

**Good news first**: PR #226's tag-after-build ordering worked correctly. With all 4 headless builds red, the `tag`, `release`, and `bump-source` jobs all SKIPPED — no orphan tag pushed.

## Two specific fixes

1. **Add prebuild step.** `tauri-build`'s build script runs for the whole crate (not just selected `[[bin]]`), and it asserts `binaries/bb-<target>` exists. Without `bun run --cwd packages/accelerator prebuild`, every platform fails with `resource path 'binaries/bb-<target>' doesn't exist`. The Tauri `build` job (which succeeds) has this step at line 136; the `build-headless` job was missing it.

2. **Install full Tauri Linux system deps**, not just `libssl-dev`. The headless binary pulls Tauri's transitive deps (`glib-sys`, `gobject-sys`, `gtk-sys`, `webkit-gtk`) via the crate-level `tauri = { version = "2" }` dep. Linux build was failing on `gobject-2.0.pc` not found. Bring in line with the existing Tauri `build` job's apt install list.

## Why didn't the PR-gate catch it?

`accelerator.yml`'s `release-smoke` job uses the `setup-accelerator` composite action, which DOES install both the full apt deps AND run `prebuild`. So the PR-gate validated the build path correctly — but it didn't exercise the standalone configuration of `release-accelerator.yml`'s `build-headless` job.

I underestimated the difference between "host build" (PR-gate smoke) and "cross-compile with selected `--target`" — the latter still needs the full Linux deps because the crate's build script runs unconditionally.

## Validation

- [x] `bun run lint:actions` — clean
- [ ] After merge: re-trigger `gh workflow run release-accelerator.yml -f version=1.0.1-rc.3` to validate end-to-end. (Using `-rc.3` since `-rc.2` is taken.)

## Test plan

- [ ] PR-gate workflows green
- [ ] After merge: `1.0.1-rc.3` dry-run produces all 4 headless tarballs + sidecars
- [ ] Then trigger `1.0.1` stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)