### PR TITLE
fix(accelerator): stop bundling accelerator-server in desktop .app — 1.0.2 hotfix

### DIFF
--- a/.github/workflows/_e2e.yml
+++ b/.github/workflows/_e2e.yml
@@ -67,13 +67,14 @@ jobs:
       - name: Build headless accelerator server
         if: inputs.build_accelerator
         working-directory: packages/accelerator/src-tauri
-        run: cargo build --bin accelerator-server
+        # `--features server` enables the gated bin (see Cargo.toml).
+        run: cargo build --features server --bin accelerator-server
 
       - name: Start headless accelerator server
         if: inputs.build_accelerator
         run: |
           cd packages/accelerator/src-tauri
-          cargo run --bin accelerator-server > /tmp/accelerator.log 2>&1 &
+          cargo run --features server --bin accelerator-server > /tmp/accelerator.log 2>&1 &
           echo "ACCELERATOR_PID=$!" >> "$GITHUB_ENV"
 
       - name: Wait for accelerator

--- a/.github/workflows/accelerator.yml
+++ b/.github/workflows/accelerator.yml
@@ -96,7 +96,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-accelerator
       - name: Build headless server
-        run: cargo build --bin accelerator-server
+        # `--features server` enables the gated bin (see Cargo.toml).
+        run: cargo build --features server --bin accelerator-server
       - name: Launch and health check
         run: |
           ./target/debug/accelerator-server &
@@ -147,7 +148,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-accelerator
       - name: Build release headless server (linux-x86_64)
-        run: cargo build --release --bin accelerator-server
+        # `--features server` enables the gated bin (see Cargo.toml).
+        run: cargo build --release --features server --bin accelerator-server
       - name: Package and checksum
         run: |
           cd target/release

--- a/.github/workflows/release-accelerator.yml
+++ b/.github/workflows/release-accelerator.yml
@@ -117,6 +117,33 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
+      # Bundle-structure invariant: every desktop .app MUST contain EXACTLY
+      # the binaries we declare. A stowaway (extra bin) or a missing required
+      # one (e.g. `bb` sidecar dropped) is a hard fail — this exact bug
+      # broke the 1.0.0 → 1.0.1 macOS auto-update (Tauri auto-included
+      # `accelerator-server` because Cargo's bin auto-discovery picked up
+      # `src/bin/accelerator-server.rs`). Cheap CI guard so it never recurs.
+      - name: Assert bundle structure (macOS only)
+        if: startsWith(matrix.target, 'aarch64-apple-darwin') || startsWith(matrix.target, 'x86_64-apple-darwin')
+        working-directory: packages/accelerator/src-tauri/target/${{ matrix.target }}/release/bundle/macos
+        run: |
+          APP=$(find . -maxdepth 1 -name '*.app' | head -1)
+          if [ -z "$APP" ]; then
+            echo "::error::No .app bundle found"
+            exit 1
+          fi
+          EXPECTED=$(printf 'aztec-accelerator\nbb\n' | sort)
+          ACTUAL=$(cd "$APP/Contents/MacOS" && find . -maxdepth 1 -mindepth 1 -type f -exec basename {} \; | sort)
+          echo "Expected MacOS/ contents:"
+          echo "$EXPECTED"
+          echo "Actual MacOS/ contents:"
+          echo "$ACTUAL"
+          if ! diff <(echo "$EXPECTED") <(echo "$ACTUAL") > /dev/null; then
+            echo "::error::Bundle MacOS/ contents drifted — see above. Update Cargo.toml [[bin]] declarations + this invariant if the change is intentional."
+            exit 1
+          fi
+          echo "Bundle structure OK"
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -171,7 +198,12 @@ jobs:
 
       - name: Build accelerator-server
         working-directory: packages/accelerator/src-tauri
-        run: cargo build --release --bin accelerator-server --target ${{ matrix.target }}
+        # `--features server` is REQUIRED — without it the bin has
+        # `required-features = ["server"]` and cargo refuses to build it.
+        # The feature gate also keeps `accelerator-server` from being
+        # auto-included in the desktop .app's MacOS/ folder during the
+        # parallel `build` job (which builds with default features).
+        run: cargo build --release --features server --bin accelerator-server --target ${{ matrix.target }}
 
       - name: Package and checksum
         env:

--- a/packages/accelerator/src-tauri/Cargo.lock
+++ b/packages/accelerator/src-tauri/Cargo.lock
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "aztec-accelerator"
-version = "1.0.1-rc.1"
+version = "1.0.2-rc.1"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/packages/accelerator/src-tauri/Cargo.toml
+++ b/packages/accelerator/src-tauri/Cargo.toml
@@ -5,10 +5,32 @@ description = "Native proving accelerator for Aztec transactions"
 edition = "2021"
 rust-version = "1.77.2"
 default-run = "aztec-accelerator"
+# Disable Cargo's `src/bin/*` auto-discovery. `tauri build` bundles every
+# cargo-built binary into the desktop `.app`'s `MacOS/` folder, so a stray
+# entry under `src/bin/` would silently change the bundle signature shape
+# between releases. That is the root cause of the 1.0.1 macOS auto-update
+# breakage — the `accelerator-server` bin was auto-discovered and stowed
+# inside the .app alongside the main binary, which broke amfid's
+# in-place-update revalidation for users on 1.0.0.
+autobins = false
 
 [features]
 default = []
 webdriver = ["dep:tauri-plugin-webdriver"]
+# `server` gates the standalone `accelerator-server` binary. Enable it ONLY
+# for the `build-headless` release job that produces the standalone tarball.
+# Desktop `tauri build` runs without this feature, so the binary is not
+# compiled and therefore cannot be bundled into the .app.
+server = []
+
+[[bin]]
+name = "aztec-accelerator"
+path = "src/main.rs"
+
+[[bin]]
+name = "accelerator-server"
+path = "src/bin/accelerator-server.rs"
+required-features = ["server"]
 
 [dependencies]
 tauri = { version = "2", features = ["tray-icon", "image-png"] }


### PR DESCRIPTION
## URGENT — fixes broken 1.0.0 → 1.0.1 macOS auto-update

Every user who auto-updated to 1.0.1 on macOS has a hung app: `amfid` gets stuck revalidating the new bundle because `tauri build` silently bundled `accelerator-server` into the desktop `.app/Contents/MacOS/` directory alongside the main binary + `bb` sidecar. The in-place swap from a 2-binary bundle to a 3-binary bundle invalidates amfid's cached signature mid-launch, and the new process hangs forever at `_dyld_start`.

## Fix

1. **`Cargo.toml`** — `autobins = false` + explicit `[[bin]]` blocks with `accelerator-server` gated on `required-features = ["server"]`. Default `cargo build` (what `tauri build` runs) no longer produces the server binary, so it can't be bundled.
2. **`release-accelerator.yml`** `build-headless` step now passes `--features server`.
3. **Bundle-structure invariant** in the release `build` job — asserts the macOS `.app/Contents/MacOS/` contains exactly `{aztec-accelerator, bb}`. Fails the build with a clear error message on drift. Prevents this exact bug class from ever reaching prod again.

## Stranded 1.0.1 users

Anyone who already auto-updated cannot launch the app, so they cannot auto-update forward to 1.0.2. They need manual reinstall: drag `/Applications/Aztec Accelerator.app` to Trash, redownload the 1.0.2 DMG when this ships.

## Test plan

- [x] `actionlint` clean
- [ ] PR-gate green
- [ ] Release Smoke (macOS Tauri build + DMG mount + launch) confirms the new bundle structure
- [ ] The new bundle-structure assertion runs cleanly on macOS matrix entries
- [ ] `1.0.2` release fired after merge; new DMG launches; auto-update from a manually-installed 1.0.0 succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)