### PR TITLE
fix(accelerator): gate background update check out of webdriver/dev builds

### DIFF
--- a/.github/workflows/_e2e-webdriver.yml
+++ b/.github/workflows/_e2e-webdriver.yml
@@ -93,6 +93,21 @@ jobs:
       - name: Run WebDriver E2E tests
         run: bun run test:e2e:webdriver
 
+      # ── Regression guard: the background update check MUST be compiled out
+      #    of webdriver builds. If the prompt window ever appears, it steals the
+      #    active WebDriver context mid-test (see the 1.0.2 CI flake). Runs even
+      #    on test failure so it always gives signal.
+      - name: Assert no update prompt fired
+        if: always()
+        working-directory: .
+        run: |
+          if grep -q "Showing update prompt" /tmp/tauri.log 2>/dev/null; then
+            echo "::error::Update prompt fired in a webdriver build — the update check is not gated. See implementations-plan/ci-reliability-2026-05-29/diagnosis.md"
+            grep -n "Showing update prompt\|Update available" /tmp/tauri.log || true
+            exit 1
+          fi
+          echo "OK — no update prompt in webdriver build"
+
       # ── Artifacts on failure ──
       - name: Upload logs
         if: failure()

--- a/implementations-plan/ci-reliability-2026-05-29/diagnosis.md
+++ b/implementations-plan/ci-reliability-2026-05-29/diagnosis.md
@@ -1,0 +1,40 @@
+# WebDriver Linux flake — root cause (CONFIRMED)
+
+**Date**: 2026-05-29
+**Symptom**: `E2E WebDriver (linux) / WebDriver E2E (dev)` started failing on every PR from ~2026-05-29 morning. `settings.spec.ts` fails all 3 tests with `element ("#speed-label") still not existing after 5000ms` / `WebDriverError: null is not an object (evaluating 'el.value="2"')`. `smoke.spec.ts` and `auth-flow.spec.ts` pass.
+
+## Decisive evidence
+
+`#speed-label` is a **static** element in `settings.html:43` (`<span class="speed-value" id="speed-label">Full</span>`). It exists at parse time, before any JS/IPC. `waitForExist` failing ⇒ WebDriver's active window is NOT the Settings window.
+
+`smoke.spec` checks the same `#speed-label` and PASSES; `settings.spec` (runs next, per `wdio.conf.ts:16` explicit order `smoke → settings → auth-flow`) FAILS. So the active window changes between them.
+
+Failing-run `tauri.log` (artifact `webdriver-e2e-logs-Linux-dev`, run 26636261687):
+
+```
+12:21:27.499 updater: Update available current=1.0.2-rc.1 new=1.0.2
+12:21:27.500 updater: Auto-update preference auto_update_pref=None
+12:21:27.500 Showing update prompt ... version=1.0.2
+12:21:30.115 ERROR tauri::manager: asset not found: settings.html
+```
+
+## Root cause
+
+`main.rs:345-354` spawns an **ungated** background update check: sleeps 5s, calls `run_update_check`, which polls the production updater feed. It runs even under `--features webdriver` / debug builds.
+
+1. The dev/webdriver build's source version is `1.0.2-rc.1`.
+2. Until we shipped **1.0.2 stable** (latest.json pub_date `2026-05-28T20:56:44Z`), the feed's newest was `1.0.1` (< `1.0.2-rc.1`) ⇒ no update ⇒ tests green. PR #234's WebDriver ran `20:57:26Z`, ~40s after publish but before the CloudFront `max-age=300` feed propagated — so it still saw no update and passed (last green run).
+3. Once 1.0.2 propagated, every dev build (`1.0.2-rc.1`) detects `→ 1.0.2 available`. With no config file in CI, `auto_update_pref=None` ⇒ it **opens the update-prompt window** ~5s after launch.
+4. The new window steals WebDriver's active browsing context. `smoke` runs in the first ~3s (window still Settings → passes); `settings` runs after the 5s prompt (active window is now update-prompt → static `#speed-label` not found).
+
+This is **self-inflicted by the 1.0.2 release** and will recur on every dev/CI build whose version is ≤ the latest published release. It is a real product bug, not merely a test bug: a dev/CI build polls the prod updater and interrupts with a modal.
+
+## Why "same runner image, same WebKitGTK, identical UI code, opposite result"
+
+Not an environment regression (verified: both #234 and #235 used `ubuntu24/20260525.161` + libwebkit2gtk `2.52.3-0ubuntu0.24.04.1`). The only thing that changed between the last green run and the first red run was **external state**: 1.0.2 appeared on the updater feed.
+
+## Fix directions (for the plan)
+
+1. **Primary (product)**: gate the background update check so it does not run under `#[cfg(feature = "webdriver")]` (and reconsider debug/dev + a `CI`/test env override). A test/dev build must never poll the prod updater or pop a modal.
+2. **Defense-in-depth (test)**: make `smoke.spec` + `settings.spec` self-anchor to the Settings window in a `before` hook (capture/known handle, dismiss stray windows, `waitForExist`) instead of trusting ambient active-window state. A stray window then can't break an assumed-active-window assertion.
+3. **Note the circular trap**: merging bump-source #234 (→ `1.0.3-rc.1` > `1.0.2`) would incidentally mask the flake (dev version then exceeds latest published), but that is luck, not a fix — the next stable release reintroduces it. Gate the check.

--- a/implementations-plan/ci-reliability-2026-05-29/eli5.html
+++ b/implementations-plan/ci-reliability-2026-05-29/eli5.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>CI Reliability Plan — ELI5</title>
+<style>
+  :root { --ink:#1a1a1a; --muted:#666; --line:#e5e5e5; --accent:#2a6; --warn:#b85; --bg:#fcfcfa; --code:#f3f3f0; }
+  * { box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    color: var(--ink); background: var(--bg); line-height: 1.65;
+    max-width: 760px; margin: 0 auto; padding: 48px 24px 96px;
+  }
+  h1 { font-size: 28px; line-height: 1.25; margin: 0 0 4px; }
+  .sub { color: var(--muted); margin: 0 0 32px; font-size: 15px; }
+  h2 { font-size: 20px; margin: 44px 0 12px; padding-top: 20px; border-top: 1px solid var(--line); }
+  h3 { font-size: 16px; margin: 28px 0 6px; }
+  p, li { font-size: 16px; }
+  .lead { font-size: 17px; }
+  code { background: var(--code); padding: 1px 5px; border-radius: 4px; font-size: 13.5px;
+         font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  .card { background: #fff; border: 1px solid var(--line); border-radius: 10px; padding: 18px 20px; margin: 16px 0; }
+  .tag { display: inline-block; font-size: 12px; font-weight: 600; letter-spacing: .02em;
+         padding: 2px 9px; border-radius: 999px; margin-right: 8px; vertical-align: 2px; }
+  .t-fix  { background: #e6f4ec; color: #1d7a46; }
+  .t-hard { background: #eef0fb; color: #3a4cb0; }
+  .t-defer{ background: #f0efe9; color: #8a7d4e; }
+  .t-drop { background: #f6e9e9; color: #9a4b4b; }
+  .analogy { border-left: 3px solid var(--accent); padding: 4px 0 4px 16px; margin: 12px 0; color:#333; }
+  .why { color: var(--muted); font-size: 15px; }
+  .q { font-weight: 600; margin-top: 18px; }
+  a { color: #2a6; }
+  .foot { margin-top: 40px; color: var(--muted); font-size: 14px; }
+  .pill { font-size:12.5px; color:var(--muted); }
+  ul { padding-left: 22px; }
+</style>
+</head>
+<body>
+
+<h1>What broke CI, and how we're fixing it</h1>
+<p class="sub">Plain-language companion to <a href="plan.md">plan.md</a> · evidence in <a href="diagnosis.md">diagnosis.md</a> · 2026-05-29</p>
+
+<p class="lead">Short version: <strong>shipping version 1.0.2 accidentally broke our own test pipeline.</strong> The fix is small and safe. This page explains why it happened and what each change does, without jargon.</p>
+
+<h2>The story: how releasing 1.0.2 broke the tests</h2>
+
+<p>The desktop app checks for updates in the background. When it finds a newer version, it pops up a little "Update available" window.</p>
+
+<div class="analogy">
+Think of our automated UI tests like a robot clicking through the app. The robot is told: "look at the <em>Settings</em> window and check the speed label is there." It works fine — <em>until</em> a surprise pop-up window jumps in front. Now the robot is staring at the pop-up, not Settings, and reports "I can't find the speed label!" — and the test fails.
+</div>
+
+<p>Here's the twist that made it happen <em>now</em>:</p>
+<ul>
+  <li>Our test builds carry the in-development version number <code>1.0.2-rc.1</code>.</li>
+  <li>For weeks, the newest <em>published</em> release was <code>1.0.1</code> — older than our test build — so the update check found nothing and stayed quiet.</li>
+  <li>The moment we published <strong>1.0.2</strong>, our test build (<code>1.0.2-rc.1</code>) suddenly saw "1.0.2 is newer than me!" and started popping the update window mid-test.</li>
+</ul>
+
+<p class="why">That's why nothing in our code changed but the tests started failing: the trigger was <em>external</em> — a new release appearing on the update server. Same test runners, same browser engine, same code. Only the outside world changed.</p>
+
+<p>We confirmed this exactly from the test machine's own log: it printed <code>Update available 1.0.2-rc.1 → 1.0.2</code>, then <code>Showing update prompt</code>, and right after, <code>asset not found: settings.html</code> — the robot lost the Settings window.</p>
+
+<h2>The fixes, one at a time</h2>
+
+<div class="card">
+<span class="tag t-fix">THE FIX · PR-A</span>
+<h3>WS1 — Stop test/dev builds from checking for updates</h3>
+<p>A throwaway test build has no business phoning the real update server or popping a window. We switch the update check <strong>off</strong> for two kinds of builds: the ones used by the robot tests, and the ones developers run on their own machines while coding.</p>
+<p class="why"><strong>Why this also un-jams everything:</strong> the robot test build is exactly one of the builds we're switching off. So the moment this fix runs, the pop-up can't appear, the test passes, and the whole pipeline goes green again — no special admin override needed.</p>
+<p class="why">There are two off-switches kept as safety valves: an emergency "never update" flag, and an opt-in "yes, actually check" flag for the rare developer who <em>wants</em> to test updates locally. The normal shipped app is untouched — it still auto-updates exactly as before.</p>
+</div>
+
+<div class="card">
+<span class="tag t-hard">SAFETY NET · PR-B</span>
+<h3>WS2 — Make the robot re-find the Settings window itself</h3>
+<p>Even with pop-ups gone, we teach the test robot to explicitly look for the Settings window before checking it — instead of assuming it's already looking at the right one. And if Settings genuinely isn't there, the test <em>fails loudly</em> rather than papering over it.</p>
+<p class="why">This is insurance: any future stray window can't silently break the tests the same way.</p>
+</div>
+
+<div class="card">
+<span class="tag t-hard">SUPPLY CHAIN · PR-B</span>
+<h3>WS3 — Pin the headless server's ingredients list</h3>
+<p>The standalone "headless server" we ship for other teams' CI didn't have a locked-down ingredients list (a <code>Cargo.lock</code>). That means its exact dependency versions were decided fresh at build time instead of from a reviewed, committed file. We commit that list and build strictly against it.</p>
+<p class="why">Reviewed + reproducible builds = a smaller window for a supply-chain surprise to sneak in.</p>
+</div>
+
+<div class="card">
+<span class="tag t-hard">GUARD RAIL · PR-B</span>
+<h3>WS5 — Make the "what's inside the app bundle" check stricter</h3>
+<p>Remember the 1.0.1 disaster? An extra binary sneaked into the macOS app bundle and broke auto-update. We already added a guard that checks the bundle's contents — but it only looked at regular files and could miss, say, a sneaky shortcut or folder. We tighten it to check <em>everything</em> at that level, exactly.</p>
+<p class="why">This guard is also why we're comfortable <em>not</em> building a giant automated update test right now — it already catches that whole class of bug for free (see below).</p>
+</div>
+
+<div class="card">
+<span class="tag t-defer">DOCUMENT NOW, AUTOMATE LATER</span>
+<h3>WS6 — How we'll test the actual update path</h3>
+<p>The dream is an automated test that installs the old version, lets it update, and confirms it still launches. It turns out that's genuinely hard to automate safely: the updater cryptographically checks every download against a built-in key, so a fake test-server download would either need the real production signing key (too risky for CI) or a fake key (then you're not testing the real thing).</p>
+<p class="why">So for now we write a short <strong>manual checklist</strong> to run before each release, and leave the automated version as its own future project. The stricter bundle check (WS5) already guards the specific failure that bit us in 1.0.1.</p>
+</div>
+
+<div class="card">
+<span class="tag t-drop">DROPPED</span>
+<h3>WS4 — A fix we discovered we didn't need</h3>
+<p>We thought the headless server might report the wrong version number. On closer inspection (and a second opinion that corrected an earlier one), the version it reports actually comes from a shared component we <em>already</em> stamp correctly at release time. So there was no real bug. We dropped it, keeping only an optional tiny nicety if we ever want a <code>--version</code> command.</p>
+</div>
+
+<h2>Two things we deliberately are NOT doing</h2>
+<ul>
+  <li><strong>No release.</strong> We're landing fixes onto the main branch and cutting a version another day. No rush.</li>
+  <li><strong>No big architectural refactor yet.</strong> The headless server still quietly drags the desktop UI framework along for the ride. Cleaning that up ("a shared core library both can use") is real work and gets its own plan later — not bundled into this firefight.</li>
+</ul>
+
+<h2>How we checked our own thinking</h2>
+<p>Per our usual process, three independent plans were drafted — ours, one from a different AI model family (codex), and one from a separate reviewer agent — then merged. They caught real things we'd have gotten wrong:</p>
+<ul>
+  <li>Our first instinct (switch off updates only for robot builds) would have left an unused chunk of code that trips the linter. Corrected.</li>
+  <li>We almost used a too-strict build flag (<code>--frozen</code>) that fails on cold caches; switched to the right one (<code>--locked</code>).</li>
+  <li>The "wrong version number" fix (WS4) was based on a misunderstanding; dropped.</li>
+</ul>
+<p class="why">Final verdict from the cross-check: <em>"ship-to-approval: the plan is sound."</em></p>
+
+<h2>Open questions for the human</h2>
+
+<p class="q">1. The dropped fix (WS4) — really drop it, or add a small <code>accelerator-server --version</code> command?</p>
+<p class="why">Context: nothing is broken either way. A <code>--version</code> command is a minor convenience for people running the headless server. Low value. The recommendation is to drop it.</p>
+
+<p class="q">2. Do we trust the "self-unblocking" claim enough to leave branch protection untouched?</p>
+<p class="why">Context: we believe the fix makes its own pull-request pass the checks normally, so we never have to weaken the merge rules. If that prediction is somehow wrong, the fallback is a one-time manual override on that single PR — never a standing change. Recommendation: proceed as planned, keep the rules intact.</p>
+
+<p class="q">3. Where should the manual update-testing checklist live, and should the release workflow link to it?</p>
+<p class="why">Context: a small doc-placement choice. Leaning: a <code>UPDATER_TESTING.md</code> next to the app, with a one-line reminder in the release pipeline.</p>
+
+<p class="foot">Sequence: PR-A (the fix, un-jams the pipeline) → PR-B (the three safety/hardening changes) → the checklist doc. Nothing ships to users until a future, deliberate release.</p>
+
+</body>
+</html>

--- a/implementations-plan/ci-reliability-2026-05-29/plan.md
+++ b/implementations-plan/ci-reliability-2026-05-29/plan.md
@@ -1,0 +1,147 @@
+# CI Reliability — WebDriver flake fix + codex post-1.0.2 hardening
+
+**Status**: v2 — final codex pass returned **"ship-to-approval: v2 is sound"** (cfg matrix walked, no dead-code, no residual prompt path, security clean). Pending user approval.
+**Date**: 2026-05-29
+**Type**: Tier A (cross-cutting: product bug + CI/test infra + release hardening)
+**No release**: per user — land fixes to `main`, cut a version another day.
+
+## Context
+
+`E2E WebDriver (linux)` fails on every PR since `accelerator-v1.0.2` shipped, wedging `main` (required `Accelerator Status` aggregator red). Root cause fully diagnosed in `diagnosis.md`: the **ungated background update check** (`main.rs:345-354`) pops the update-prompt window ~5s into every `--features webdriver` run now that `1.0.2` is on the prod updater feed, stealing WebDriver's active window so `settings.spec` can't find the Settings DOM. Plus codex post-1.0.2 audit follow-ups (server lock, version patch, bundle invariant, updater E2E).
+
+## Consolidation trace (which decision came from where)
+
+- **WS1 self-unblock claim TRUE** — verified by both codex + opus against `_e2e-webdriver.yml:54` (dev `bunx tauri dev --features webdriver`, release `cargo build --release --features webdriver`). No ruleset change needed.
+- **Gate `debug_assertions` too, not just `webdriver`** — codex (opus wanted feature-only). Adopted codex: a human's `cargo tauri dev` shouldn't get a prod modal, and it kills the latent `_e2e.yml cargo run` variant opus separately flagged.
+- **Also `#[cfg]` the `run_update_check` fn, not just the spawn** — opus (dead-code under feature). Adopted.
+- **`--locked` not `--frozen`** — both. Adopted.
+- **No cargo workspace this round** — both (a workspace would NOT reintroduce the 1.0.2 bundle bug — that was same-package bin auto-discovery, not workspace membership — but it changes lock/target/metadata semantics during a hotfix for little payoff). Adopted: keep separate crates + separate `server/Cargo.lock`.
+- **WS4 reframed/demoted** — codex proved `/health` version comes from the shared lib (`server.rs:145`, `env!` of `aztec-accelerator` = `src-tauri/Cargo.toml`, already patched), NOT `server/Cargo.toml`. So WS4 as a correctness fix is **rejected**. Kept only as optional metadata hygiene + an optional real `--version` observable.
+- **WS6 downgraded to manual runbook + deferred automation** — both. The updater verifies Ed25519 against the embedded pubkey and enforces TLS; a published N-1 binary can't be redirected to a throwaway-key localhost feed without new Rust override code, and the gate must be post-build. WS5's bundle invariant already catches the specific 1.0.1 signature-shape regression deterministically.
+- **WS2 out of the unblock PR; anchor must FAIL (not mask)** — codex. Adopted: WS2 → PR-B, and the anchor switches-to-Settings-if-present but fails if the bootstrap window is absent (no `navigateTo` masking, no auto-dismiss in smoke).
+
+## Goal / success criteria
+
+1. `E2E WebDriver (linux)` green + deterministic — no prod update check in webdriver/dev/CI builds.
+2. Fix PR self-unblocks `main` (no branch-protection change; `Accelerator Status` stays required).
+3. codex must-fix landed: `server/Cargo.lock` committed + built `--locked`.
+4. Bundle invariant asserts the exact `Contents/MacOS` entry set (any type).
+5. A documented manual pre-release updater runbook exists; automated updater-E2E scoped as a future plan.
+
+## Non-goals (deferred)
+
+- Shared-core crate extraction (server keeps its path-dep on `aztec-accelerator`).
+- Cutting a release.
+- Automated updater-path E2E (own future plan; needs post-build privileged smoke or a test-only Rust updater override + throwaway key).
+- Cargo workspace conversion.
+
+## Workstreams
+
+### WS1 — Gate the background update check [PR-A, the fix]
+
+`main.rs:345-354` spawns the poller unconditionally. Changes (all in `main.rs`):
+
+```rust
+// Defined only for non-webdriver builds — avoids dead_code under the feature.
+#[cfg(not(feature = "webdriver"))]
+async fn run_update_check(app: &AppHandle, config_state: &ConfigState) { /* unchanged body */ }
+
+// Decide whether the background poller should run at all.
+#[cfg(not(feature = "webdriver"))]
+fn should_poll_for_updates() -> bool {
+    if std::env::var("AZTEC_ACCEL_NO_UPDATE").is_ok() {
+        tracing::warn!("AZTEC_ACCEL_NO_UPDATE set — background update checks suppressed");
+        return false;
+    }
+    // A dev build (`cargo tauri dev`) must not poll the PROD feed or pop a modal
+    // unless explicitly opted in. This also covers `_e2e.yml`'s debug `cargo run`.
+    if cfg!(debug_assertions) && std::env::var("AZTEC_ACCEL_FORCE_UPDATE_CHECK").is_err() {
+        tracing::info!("Debug build — background update checks disabled (set AZTEC_ACCEL_FORCE_UPDATE_CHECK=1 to enable)");
+        return false;
+    }
+    true
+}
+
+// In setup():
+#[cfg(not(feature = "webdriver"))]
+{
+    if should_poll_for_updates() {
+        let update_handle = app.handle().clone();
+        let update_config = config_state.clone();
+        tauri::async_runtime::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            loop {
+                run_update_check(&update_handle, &update_config).await;
+                tokio::time::sleep(Duration::from_secs(12 * 3600)).await;
+            }
+        });
+    }
+}
+```
+
+- Gate axis = **`webdriver` feature (compile-time) ∪ `debug_assertions` (runtime, opt-in override) ∪ `AZTEC_ACCEL_NO_UPDATE` kill switch**. Kills the entire "non-prod build polls prod feed" class.
+- Do **NOT** gate `check_for_update` (the shared primitive) — it's reused by the manual "Update Now" path via `commands.rs respond_update_prompt` + `PendingUpdate`. The guard lives at the background poller only (opus's concern).
+- Prod release desktop build (no `webdriver`, release profile, no env) → polls normally. Unchanged behavior.
+
+**Regression coverage (PR-A)**: in `_e2e-webdriver.yml`, after the test step (with `if: always()` so it still signals when tests fail for another reason — codex final nit), assert the runtime log contains **no** `Showing update prompt` (grep `/tmp/tauri.log`). Loud failure if the gate ever regresses.
+
+**PR-A scope = WS1 + that assertion ONLY** (codex: keep the unblock PR minimal).
+
+### WS2 — Self-anchor specs to the Settings window [PR-B]
+
+Add `ensureSettingsWindow()` to `helpers.ts`: enumerate handles, switch to the one whose title is `"Aztec Accelerator Settings"` (or URL ends `settings.html`), then `waitForExist("#speed-label")`. **If no such window exists, FAIL** (do not `navigateTo` / auto-create — that would mask a real bootstrap regression). Call it in `before()` of `smoke.spec` + `settings.spec`. Do **not** auto-dismiss stray windows in smoke. `auth-flow.spec` keeps its existing explicit handle management.
+
+### WS3 — Commit `server/Cargo.lock` + build `--locked` [PR-B, codex must-fix]
+
+- `cargo generate-lockfile --manifest-path packages/accelerator/server/Cargo.toml`; commit `server/Cargo.lock`.
+- Build the server with `--locked` (not `--frozen` — frozen forbids network on cold caches) in:
+  - `release-accelerator.yml` build-headless
+  - `accelerator.yml` Smoke + Release Smoke
+  - `_e2e.yml`: replace `cargo run` (recompiles) with `cargo build --locked` once + run the produced binary (codex).
+- Keep separate crates (no workspace). Accept manual lock sync; add a brief note in `server/Cargo.toml` that its lock must be regenerated when `src-tauri` deps change.
+
+### WS4 — headless version observable [PR-B, APPROVED]
+
+Not a correctness fix (`/health` already reports the patched `src-tauri` lib version), but the user approved adding it as a real observable: add `accelerator-server --version` (prints the `accelerator-server` crate version) and patch `server/Cargo.toml` version in **both** the `build-headless` step and the `bump-source` job so the observable is accurate per release. CI can assert `accelerator-server --version` == release version in the release dry-run.
+
+### WS5 — Harden the bundle invariant [PR-B, codex should-fix]
+
+`release-accelerator.yml` bundle check: replace `find … -type f` with depth-1 `find -mindepth 1 -maxdepth 1` (any type) → `basename` → sort → exact-diff against `{aztec-accelerator, bb}`. Fail on any deviation (incl. stray symlink/dir). Unit-fixture test: a dir with a stray symlink must fail the check.
+
+### WS6 — (DEFERRED) updater-path validation
+
+- **Now**: write `packages/accelerator/UPDATER_TESTING.md` — a manual pre-release runbook: install the N-1 stable from the real GitHub release, click Update, confirm relaunch + `/health` reports the new version, on macOS. Gate promoting an rc → stable on this check.
+- **Note**: WS5's bundle invariant already catches the 1.0.1 signature-shape regression deterministically and for free.
+- **Future plan**: automated updater-E2E as a **post-build** privileged release smoke (after the signed bundle exists; current E2E gate runs before patching/signing per `release-accelerator.yml:51`), OR a test-only Rust updater-endpoint/pubkey override (Rust-only, never exposed to frontend/HTTP) signed with a throwaway key. Own design + plan.
+
+## Sequencing
+
+1. **PR-A** — WS1 + the `tauri.log` no-prompt assertion. Minimal, self-unblocking. Merge first → `main` green.
+2. **PR-B** — WS2 + WS3 + WS5 (+ optional WS4). Hardening; independent.
+3. **Docs** — WS6 manual runbook (can ride PR-B or its own tiny PR).
+
+No release. Branch all off `main` after PR-A merges.
+
+## Test strategy
+
+| WS | Validation |
+|----|-----------|
+| WS1 | PR-A's own `E2E WebDriver (linux+macos)` green (proves self-unblock) + `tauri.log` shows no `Showing update prompt`. |
+| WS2 | Specs fail loudly if the Settings bootstrap window is absent; pass when present. |
+| WS3 | Server builds `--locked`; removing the committed lock fails CI. |
+| WS5 | Fixture dir with stray symlink fails the invariant; clean `{aztec-accelerator,bb}` passes. |
+| WS6 | Manual runbook executed before any future rc→stable promotion. |
+
+## Security & Adversarial Considerations
+
+- **Update gating (WS1)**: gating dev/webdriver does not weaken prod (shipped binary is release + no `webdriver`). `AZTEC_ACCEL_NO_UPDATE` could suppress security updates, but the setter already has code-exec; we `warn!`-log when it fires for auditability. `AZTEC_ACCEL_FORCE_UPDATE_CHECK` only *enables* checks (no downside).
+- **`--locked` (WS3)**: committing `server/Cargo.lock` makes the headless tarball's deps reviewed + reproducible — supply-chain improvement. Manual sync risk with `src-tauri`'s lock is mitigated by the shared path-dep deduping; note it for reviewers.
+- **Bundle invariant (WS5)**: stronger guard on what ships in the signed `.app`. Pure win; also the standing guard for the 1.0.1 regression class.
+- **Updater test override (WS6, future)**: any endpoint/pubkey override must be Rust-only + test-only, never reachable from frontend or the HTTP server. A throwaway-key test build is not the shipped artifact — document that limitation. No prod signing key in CI.
+- **No ruleset change**: `Accelerator Status` stays required throughout — strictly better than de-requiring.
+
+## Open questions (for approval gate)
+
+1. WS4: implement the `--version` observable, or drop entirely? (Lean: drop / defer — low value.)
+2. WS6 runbook location + whether to also add a CI reminder comment in `release-accelerator.yml`.
+3. Confirm we skip the ruleset change (contingent on PR-A's gate going green as predicted — fallback is a one-time admin-bypass of PR-A only).

--- a/implementations-plan/index.md
+++ b/implementations-plan/index.md
@@ -2,5 +2,6 @@
 
 - [maintenance-2026-05-27](maintenance-2026-05-27/plan.md) — completed — non-aztec dep bumps + dependabot removal + headless server release artifacts (PRs #223 #224 #225 merged)
 - [release-2026-05-27](release-2026-05-27/plan.md) — completed — automation deprecation + branch cleanup + @aztec 4.2.0 forward-roll + SDK 4.2.0 release + accelerator 1.0.1 release (first headless)
-- [ci-dedup-2026-05-28](ci-dedup-2026-05-28/plan.md) — planning — extend setup-accelerator composite to cover release `build` + `build-headless` (kills the drift class PR #228 fixed)
-- [verified-sites-2026-05-28](verified-sites-2026-05-28/plan.md) — planning — friendly name + green ✓ in authorization popup for curated origins (Nulo Wallet, Nulo Wallet extension, Playground)
+- [ci-dedup-2026-05-28](ci-dedup-2026-05-28/plan.md) — completed — extended setup-accelerator composite to cover release `build` + `build-headless` + `_e2e-webdriver` (PR #230; validated by 1.0.2-rc.2 dry-run)
+- [verified-sites-2026-05-28](verified-sites-2026-05-28/plan.md) — in review — friendly name + green ✓ in authorization popup for curated origins (PR #231 open; Nulo extension entry parked pending real Chrome Web Store ID)
+- [ci-reliability-2026-05-29](ci-reliability-2026-05-29/plan.md) — approved-pending — WebDriver flake (ungated update check pops prompt mid-E2E after 1.0.2 shipped) + codex post-1.0.2 hardening; see [diagnosis.md](ci-reliability-2026-05-29/diagnosis.md) + [eli5.html](ci-reliability-2026-05-29/eli5.html)

--- a/packages/accelerator/src-tauri/src/main.rs
+++ b/packages/accelerator/src-tauri/src/main.rs
@@ -12,9 +12,14 @@ use parking_lot::RwLock;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+// Only the background update loop uses Duration; that loop is gated off for webdriver builds.
+#[cfg(not(feature = "webdriver"))]
 use std::time::Duration;
 use tauri::menu::MenuItemBuilder;
-use tauri::{AppHandle, Manager};
+use tauri::Manager;
+// AppHandle is only referenced by the (webdriver-gated) update-check fn.
+#[cfg(not(feature = "webdriver"))]
+use tauri::AppHandle;
 use tauri_plugin_autostart::MacosLauncher;
 use tracing_subscriber::fmt;
 use tracing_subscriber::layer::SubscriberExt;
@@ -94,8 +99,41 @@ fn try_start_https(state: &AppState) -> Option<u16> {
 
 // ── Auto-update ──────────────────────────────────────────────────────────
 
+/// Whether the background update poller should run.
+///
+/// A non-production build must never poll the prod updater feed or pop the
+/// update-prompt window:
+/// - `webdriver` builds are handled at compile time (this fn + the spawn site
+///   are `#[cfg(not(feature = "webdriver"))]`), so the poller cannot exist there.
+/// - `debug_assertions` (a developer's `cargo tauri dev`, and the `_e2e.yml`
+///   `cargo run` desktop app) are disabled by default — opt back in with
+///   `AZTEC_ACCEL_FORCE_UPDATE_CHECK=1`.
+/// - `AZTEC_ACCEL_NO_UPDATE=1` is a universal kill switch (logged, for audit).
+///
+/// The shipped release desktop binary (release profile, no `webdriver`, no env
+/// overrides) returns `true` — auto-update behavior is unchanged.
+#[cfg(not(feature = "webdriver"))]
+fn should_poll_for_updates() -> bool {
+    if std::env::var("AZTEC_ACCEL_NO_UPDATE").is_ok() {
+        tracing::warn!("AZTEC_ACCEL_NO_UPDATE set — background update checks suppressed");
+        return false;
+    }
+    if cfg!(debug_assertions) && std::env::var("AZTEC_ACCEL_FORCE_UPDATE_CHECK").is_err() {
+        tracing::info!(
+            "Debug build — background update checks disabled (set AZTEC_ACCEL_FORCE_UPDATE_CHECK=1 to enable)"
+        );
+        return false;
+    }
+    true
+}
+
 /// Background update check wrapper. Calls the shared updater module and
 /// shows the prompt window if an update is available and the user hasn't chosen yet.
+///
+/// Not compiled for `webdriver` builds: the prompt window would steal the
+/// active WebDriver browsing context mid-test (see
+/// implementations-plan/ci-reliability-2026-05-29/diagnosis.md).
+#[cfg(not(feature = "webdriver"))]
 async fn run_update_check(app: &AppHandle, config_state: &ConfigState) {
     if let Some(update) = aztec_accelerator::updater::check_for_update(app, config_state).await {
         let auto_update_pref = { config_state.read().auto_update };
@@ -343,15 +381,22 @@ fn main() {
             });
 
             // ── Background update check ──
-            let update_handle = app.handle().clone();
-            let update_config = config_state.clone();
-            tauri::async_runtime::spawn(async move {
-                tokio::time::sleep(Duration::from_secs(5)).await;
-                loop {
-                    run_update_check(&update_handle, &update_config).await;
-                    tokio::time::sleep(Duration::from_secs(12 * 3600)).await;
-                }
-            });
+            // Compile-gated off for `webdriver` builds (the prompt window would
+            // steal WebDriver's active context mid-test); runtime-gated off for
+            // dev/CI builds via `should_poll_for_updates`. The shipped release
+            // desktop binary polls normally.
+            #[cfg(not(feature = "webdriver"))]
+            if should_poll_for_updates() {
+                let update_handle = app.handle().clone();
+                let update_config = config_state.clone();
+                tauri::async_runtime::spawn(async move {
+                    tokio::time::sleep(Duration::from_secs(5)).await;
+                    loop {
+                        run_update_check(&update_handle, &update_config).await;
+                        tokio::time::sleep(Duration::from_secs(12 * 3600)).await;
+                    }
+                });
+            }
 
             Ok(())
         })

--- a/packages/accelerator/src-tauri/src/windows.rs
+++ b/packages/accelerator/src-tauri/src/windows.rs
@@ -81,6 +81,10 @@ pub fn show_auth_popup_window(
 }
 
 /// Show the update prompt window.
+///
+/// Only called from the background update check, which is compiled out for
+/// `webdriver` builds — so this is too, to keep those builds warning-clean.
+#[cfg(not(feature = "webdriver"))]
 pub fn show_update_prompt_window(app: &AppHandle, current_version: &str, new_version: &str) {
     if app.get_webview_window("update-prompt").is_some() {
         return;


### PR DESCRIPTION
## The flake, root-caused

`E2E WebDriver (linux)` has failed on every PR since we published **1.0.2**. Full evidence in `implementations-plan/ci-reliability-2026-05-29/diagnosis.md`. Short version:

- The dev/webdriver build carries source version `1.0.2-rc.1`. The background update check in `main.rs` was **ungated**.
- Once `1.0.2` reached the prod updater feed, the check fired ~5s after launch and (no config → `auto_update=None`) **opened the update-prompt window**, stealing WebDriver's active browsing context.
- `smoke.spec` runs in the first ~3s (passed); `settings.spec` ran after the prompt and couldn't find the static `#speed-label` (active window was now the prompt → all 3 settings tests fail).
- Not an environment regression: same runner image + WebKitGTK between the last green and first red run. The only change was 1.0.2 appearing on the feed. Confirmed from the failing run's `tauri.log`: `Update available 1.0.2-rc.1 → 1.0.2` → `Showing update prompt` → `asset not found: settings.html`.

## Fix (WS1 of the deep plan)

Gate the background poller so non-production builds never poll the prod feed or pop a modal:
- `#[cfg(not(feature = "webdriver"))]` on the spawn site + `run_update_check` + `should_poll_for_updates` → the WebDriver build (which always sets `--features webdriver`) compiles the poller out. **This makes the fix self-unblocking** — this PR's own WebDriver legs go green; no branch-protection change needed.
- `should_poll_for_updates()` also disables polling under `debug_assertions` (a dev's `cargo tauri dev`, and `_e2e.yml`'s `cargo run`) unless `AZTEC_ACCEL_FORCE_UPDATE_CHECK=1`, and honors `AZTEC_ACCEL_NO_UPDATE=1` (warn-logged kill switch).
- `check_for_update` (shared primitive for the manual "Update Now" path) is deliberately **not** gated.
- Shipped release desktop binary is unchanged — auto-update works exactly as before.

Imports + `show_update_prompt_window` are cfg-gated too; `cargo check` is warning-clean in **both** default and `--features webdriver`.

## Regression guard

`_e2e-webdriver.yml` now asserts (`if: always()`) that the runtime log contains no `Showing update prompt`. A future regression of the gate fails loudly.

## Plan package

`implementations-plan/ci-reliability-2026-05-29/` — `plan.md` (Tier A: main + codex xhigh + opus subagent, consolidated; final codex "ship-to-approval: sound"), `diagnosis.md`, `eli5.html`. This is PR-A; PR-B (test self-anchoring + server Cargo.lock + bundle-invariant hardening + `--version`) follows.

## Test plan

- [x] `cargo check` clean — default **and** `--features webdriver`
- [x] 86 Rust lib tests pass; `bun run lint` + `actionlint` + `cargo fmt --check` clean
- [ ] This PR's own `E2E WebDriver (linux + macos)` go green (proves self-unblock)
- [ ] `Assert no update prompt fired` step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)