### PR TITLE
ci(release): macOS updater-validation smoke gate (advisory, first increment)

### DIFF
--- a/.github/workflows/_e2e-updater.yml
+++ b/.github/workflows/_e2e-updater.yml
@@ -1,0 +1,80 @@
+name: _Updater Smoke (reusable)
+
+# Release-time gate: install the previous stable (N-1), let it auto-update to
+# the just-built+signed build (N) via a local feed impersonating the prod
+# endpoint, and assert it relaunches reporting version N. Reproduces the 1.0.1
+# failure class (macOS amfid hang after the in-place .app swap). macOS only in
+# this first increment; Linux (AppImage) + a standing negative test land in a
+# follow-up once this is proven on a 1.0.3-rc dry-run.
+#
+# Needs no signing key: it serves the already-prod-signed N artifact and N-1
+# validates it against its embedded pubkey. See updater-smoke.sh.
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: GitHub runner (macos-latest | macos-15-intel)
+        required: true
+        type: string
+      platform-key:
+        description: Tauri updater platform key (darwin-aarch64 | darwin-x86_64)
+        required: true
+        type: string
+      n-version:
+        description: The version being released (N)
+        required: true
+        type: string
+      n-artifact:
+        description: This run's build artifact name (e.g. accelerator-macos-arm64)
+        required: true
+        type: string
+      n1-dmg-glob:
+        description: Glob for the N-1 release DMG asset (e.g. *macOS-Apple-Silicon.dmg)
+        required: true
+        type: string
+
+jobs:
+  updater-smoke:
+    name: Updater Smoke
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Download N artifacts (this run)
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.n-artifact }}
+          path: n-artifacts
+
+      - name: Download latest stable (N-1) DMG
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          N1_TAG=$(gh release list --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName')
+          if [ -z "$N1_TAG" ]; then
+            echo "::error::no stable release found to use as N-1"
+            exit 1
+          fi
+          echo "N-1 = $N1_TAG"
+          mkdir -p n1
+          gh release download "$N1_TAG" --pattern "${{ inputs.n1-dmg-glob }}" --dir n1
+
+      - name: Updater smoke (install N-1 → auto-update to N → assert /health == N)
+        run: |
+          DMG=$(find n1 -name '*.dmg' | head -1)
+          if [ -z "$DMG" ]; then echo "::error::N-1 DMG not found"; exit 1; fi
+          bash packages/accelerator/scripts/updater-smoke.sh \
+            "${{ inputs.n-version }}" \
+            "${{ inputs.platform-key }}" \
+            n-artifacts \
+            "$DMG" \
+            "$GITHUB_WORKSPACE"

--- a/.github/workflows/release-accelerator.yml
+++ b/.github/workflows/release-accelerator.yml
@@ -318,6 +318,35 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  # Release-time updater gate (macOS, first increment). ADVISORY for now —
+  # intentionally NOT in `tag.needs`, so it runs + reports on every release
+  # (incl. -rc dry-runs) without blocking, until proven on a 1.0.3-rc dry-run.
+  # Follow-up will add Linux (AppImage) + a standing negative test and promote
+  # macOS to release-blocking (add to tag.needs). See
+  # implementations-plan/updater-validation-2026-05-29/plan.md.
+  update-smoke:
+    name: Updater Smoke (${{ matrix.platform-key }})
+    needs: [validate, build]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-latest
+            platform-key: darwin-aarch64
+            n-artifact: accelerator-macos-arm64
+            n1-dmg-glob: "*macOS-Apple-Silicon.dmg"
+          - runner: macos-15-intel
+            platform-key: darwin-x86_64
+            n-artifact: accelerator-macos-x86_64
+            n1-dmg-glob: "*macOS-Intel.dmg"
+    uses: ./.github/workflows/_e2e-updater.yml
+    with:
+      runner: ${{ matrix.runner }}
+      platform-key: ${{ matrix.platform-key }}
+      n-version: ${{ needs.validate.outputs.version }}
+      n-artifact: ${{ matrix.n-artifact }}
+      n1-dmg-glob: ${{ matrix.n1-dmg-glob }}
+
   tag:
     name: Create Git Tag
     needs: [validate, build, build-headless, smoke]

--- a/implementations-plan/updater-validation-2026-05-29/plan.md
+++ b/implementations-plan/updater-validation-2026-05-29/plan.md
@@ -87,7 +87,10 @@ Update `packages/accelerator/UPDATER_TESTING.md` (currently stale per codex — 
 
 ## Sequencing
 
-Own PR (`ci/updater-validation`), after the ci-speed PR (independent, but lands second to keep release-path changes isolated). Validate on a `1.0.3-rc` dry-run before relying on it to gate a stable cut.
+- **PR1 (this branch, `ci/updater-validation`)** — macOS-first increment, **advisory** (not in `tag.needs`): `updater-feed-server.ts` + `updater-smoke.sh` + `_e2e-updater.yml` + the `update-smoke` matrix job (macOS arm64 + Intel). Validated by a `1.0.3-rc` dry-run (safe: prereleases don't touch the prod feed).
+- **PR2 (follow-up)** — once the dry-run is green: add the Linux AppImage leg + the standing negative test (corrupt `.sig` must fail), and promote macOS to **release-blocking** (add `update-smoke` to `tag.needs`).
+
+Lands after the ci-speed PR to keep release-path changes isolated.
 
 ## Open questions (final pass)
 

--- a/packages/accelerator/UPDATER_TESTING.md
+++ b/packages/accelerator/UPDATER_TESTING.md
@@ -31,11 +31,25 @@ macOS install.
 6. **Confirm:** the app downloads, swaps, and **relaunches without hanging**. The tray icon returns; `curl -s http://127.0.0.1:59833/health` still answers; the version now reflects **N** (check the tray "vX.Y.Z" line, or `accelerator-server --version` for the headless build).
 7. If the app hangs at launch after the swap (no tray, process stuck at 0% CPU): **do not promote.** That is the 1.0.1 failure mode — investigate the bundle shape / signature before shipping.
 
-## Future automation (own plan)
+## Automated gate (`update-smoke`)
 
-An automated updater-path E2E would need to run **post-build** (after the
-signed bundle exists — the current release E2E gate runs before signing) and
-either (a) as a privileged release smoke using the real artifacts + feed, or
-(b) with a test-only, Rust-only updater endpoint/pubkey override signed by a
-throwaway key (never exposed to the frontend or HTTP surface). Tracked as a
-separate effort; not blocking releases today given the bundle invariant above.
+This is now partly automated. The `update-smoke` job in `release-accelerator.yml`
+(reusable `_e2e-updater.yml` + `scripts/updater-smoke.sh` + `updater-feed-server.ts`)
+runs the macOS install→update→relaunch check during every release, post-build.
+
+**It needs no signing key.** It serves the **already prod-signed** N artifact
+from a local HTTPS server impersonating `aztec-accelerator.dev` (an `/etc/hosts`
+entry + a per-run local CA trusted on the runner), and N-1 verifies it against
+its **embedded prod pubkey**. No private key, no throwaway key — the job is
+`contents: read` only.
+
+**Status:** macOS (Apple Silicon + Intel), **advisory** until validated on a
+`1.0.3-rc` dry-run, then promoted to release-blocking. A follow-up adds the
+Linux AppImage leg + a standing negative test (a corrupted `.sig` must be
+rejected). Until macOS is blocking, run the manual steps above before promoting
+an rc to stable.
+
+A `-rc` dry-run is safe for real users: prereleases skip the S3 `latest.json`
+upload and are marked `--prerelease --latest=false`, so the prod updater feed
+keeps pointing at the current stable — auto-update users never see the rc. The
+gate's feed is also local-only.

--- a/packages/accelerator/scripts/updater-feed-server.ts
+++ b/packages/accelerator/scripts/updater-feed-server.ts
@@ -1,0 +1,67 @@
+/**
+ * Local HTTPS feed server for the release-time updater smoke test.
+ *
+ * Impersonates `https://aztec-accelerator.dev` on the CI runner (paired with an
+ * `/etc/hosts` entry + a trusted local CA — see updater-smoke.sh). Serves:
+ *   - GET /releases/latest.json        → the synthesized feed for version N
+ *   - GET /releases/download/<file>    → the (already prod-signed) N artifacts
+ *
+ * The Tauri updater in the N-1 binary fetches the hardcoded endpoint
+ * (https://aztec-accelerator.dev/releases/latest.json), then downloads the
+ * artifact URL from the feed and verifies its `.sig` against the embedded
+ * prod pubkey. We serve the real signed artifacts, so NO signing key is needed.
+ *
+ * Usage:
+ *   bun updater-feed-server.ts \
+ *     --cert <leaf.pem> --key <leaf.key> \
+ *     --latest-json <latest.json> --serve-dir <artifacts-dir> [--port 443]
+ */
+
+function arg(name: string, fallback?: string): string {
+  const i = process.argv.indexOf(`--${name}`);
+  if (i !== -1 && process.argv[i + 1]) return process.argv[i + 1];
+  if (fallback !== undefined) return fallback;
+  throw new Error(`missing required --${name}`);
+}
+
+const certPath = arg("cert");
+const keyPath = arg("key");
+const latestJsonPath = arg("latest-json");
+const serveDir = arg("serve-dir");
+const port = Number(arg("port", "443"));
+
+const server = Bun.serve({
+  port,
+  tls: {
+    cert: Bun.file(certPath),
+    key: Bun.file(keyPath),
+  },
+  async fetch(req) {
+    const url = new URL(req.url);
+    const path = url.pathname;
+
+    if (path === "/releases/latest.json") {
+      const body = await Bun.file(latestJsonPath).text();
+      return new Response(body, {
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    // Any other path → serve the basename from the artifacts dir.
+    // (latest.json points download URLs at /releases/download/<file>.)
+    const name = path.split("/").pop() ?? "";
+    if (name) {
+      const file = Bun.file(`${serveDir}/${name}`);
+      if (await file.exists()) {
+        return new Response(file, {
+          headers: { "content-type": "application/octet-stream" },
+        });
+      }
+    }
+
+    console.error(`feed-server: 404 ${path}`);
+    return new Response("not found", { status: 404 });
+  },
+});
+
+console.log(`updater feed server listening on https://localhost:${server.port}`);

--- a/packages/accelerator/scripts/updater-smoke.sh
+++ b/packages/accelerator/scripts/updater-smoke.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Release-time updater smoke test (macOS).
+#
+# Proves a user on the previous stable (N-1) can auto-update to the just-built,
+# just-signed build (N) AND the result relaunches successfully — the exact
+# failure class that shipped in 1.0.1 (amfid hang after the in-place .app swap),
+# which fresh-install smoke does not catch.
+#
+# How it works (no signing key needed):
+#   - We serve the ALREADY prod-signed N artifact from a local HTTPS server
+#     impersonating aztec-accelerator.dev (hosts entry + a trusted local CA).
+#   - N-1 (unmodified, as shipped) fetches its hardcoded endpoint, downloads N,
+#     verifies the .sig against its embedded prod pubkey, swaps in place, and
+#     restarts. We then poll /health until it reports version == N.
+#
+# Usage:
+#   updater-smoke.sh <n-version> <platform-key> <n-artifacts-dir> <n1-dmg> <repo-root>
+#     n-version       e.g. 1.0.3-rc.1   (the version being released)
+#     platform-key    darwin-aarch64 | darwin-x86_64
+#     n-artifacts-dir dir with N's *.app.tar.gz + *.app.tar.gz.sig
+#     n1-dmg          path to the downloaded N-1 .dmg
+#     repo-root       repo root (to locate the feed server script)
+set -euo pipefail
+
+N_VERSION="$1"
+PLATFORM_KEY="$2"
+N_ARTIFACTS_DIR="$3"
+N1_DMG="$4"
+REPO_ROOT="$5"
+
+APP="/Applications/Aztec Accelerator.app"
+APP_BIN="$APP/Contents/MacOS/aztec-accelerator"
+HEALTH="http://127.0.0.1:59833/health"
+HOST="aztec-accelerator.dev"
+CONFIG_DIR="$HOME/.aztec-accelerator"
+WORK="$(mktemp -d)"
+SERVE_DIR="$WORK/serve"
+mkdir -p "$SERVE_DIR"
+
+FEED_PID=""
+APP_PID=""
+
+log() { echo "── $* ──"; }
+
+# shellcheck disable=SC2329  # invoked indirectly via `trap cleanup EXIT`
+cleanup() {
+  set +e
+  [ -n "$APP_PID" ] && kill "$APP_PID" 2>/dev/null
+  pkill -f "Aztec Accelerator.app" 2>/dev/null
+  [ -n "$FEED_PID" ] && sudo kill "$FEED_PID" 2>/dev/null
+  hdiutil detach "/Volumes/AztecAccelerator-N1" 2>/dev/null
+  # best-effort: drop the hosts line we added
+  sudo sed -i '' "/$HOST/d" /etc/hosts 2>/dev/null
+}
+trap cleanup EXIT
+
+# ── Locate N's signed updater artifact ──
+N_TARBALL="$(find "$N_ARTIFACTS_DIR" -name '*.app.tar.gz' | head -1)"
+N_SIG_FILE="$(find "$N_ARTIFACTS_DIR" -name '*.app.tar.gz.sig' | head -1)"
+[ -n "$N_TARBALL" ] || { echo "::error::no *.app.tar.gz in $N_ARTIFACTS_DIR"; exit 1; }
+[ -n "$N_SIG_FILE" ] || { echo "::error::no *.app.tar.gz.sig in $N_ARTIFACTS_DIR"; exit 1; }
+N_BASENAME="$(basename "$N_TARBALL")"
+cp "$N_TARBALL" "$SERVE_DIR/$N_BASENAME"
+N_SIG="$(cat "$N_SIG_FILE")"
+log "N artifact: $N_BASENAME"
+
+# ── Local CA + leaf cert (SAN = the prod host) ──
+log "generating local CA + leaf (SAN=$HOST)"
+openssl req -x509 -newkey rsa:2048 -nodes -keyout "$WORK/ca.key" -out "$WORK/ca.pem" \
+  -days 2 -subj "/CN=updater-smoke-local-CA" >/dev/null 2>&1
+openssl req -newkey rsa:2048 -nodes -keyout "$WORK/leaf.key" -out "$WORK/leaf.csr" \
+  -subj "/CN=$HOST" >/dev/null 2>&1
+cat > "$WORK/leaf.ext" <<EXT
+subjectAltName=DNS:$HOST
+extendedKeyUsage=serverAuth
+EXT
+openssl x509 -req -in "$WORK/leaf.csr" -CA "$WORK/ca.pem" -CAkey "$WORK/ca.key" \
+  -CAcreateserial -out "$WORK/leaf.pem" -days 2 -extfile "$WORK/leaf.ext" >/dev/null 2>&1
+
+# ── Trust the CA (System keychain) + impersonate the host ──
+log "trusting CA + adding hosts entry"
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "$WORK/ca.pem"
+echo "127.0.0.1 $HOST" | sudo tee -a /etc/hosts >/dev/null
+
+# ── Synthesize latest.json for N ──
+jq -n --arg v "$N_VERSION" --arg key "$PLATFORM_KEY" --arg sig "$N_SIG" \
+  --arg url "https://$HOST/releases/download/$N_BASENAME" \
+  '{version:$v, notes:("updater smoke "+$v), pub_date:"2026-01-01T00:00:00Z",
+    platforms: { ($key): { signature:$sig, url:$url } }}' > "$WORK/latest.json"
+log "latest.json:"; cat "$WORK/latest.json"
+
+# ── Start the local HTTPS feed on :443 ──
+log "starting feed server on :443"
+# sudo for :443; the redirect is opened by this (user) shell so feed.log lands
+# in the user-owned workdir — intended, hence SC2024 is not a concern here.
+# shellcheck disable=SC2024
+sudo "$(command -v bun)" "$REPO_ROOT/packages/accelerator/scripts/updater-feed-server.ts" \
+  --cert "$WORK/leaf.pem" --key "$WORK/leaf.key" \
+  --latest-json "$WORK/latest.json" --serve-dir "$SERVE_DIR" > "$WORK/feed.log" 2>&1 &
+FEED_PID=$!
+for _ in $(seq 1 20); do
+  curl -sf "https://$HOST/releases/latest.json" >/dev/null 2>&1 && break
+  sleep 0.5
+done
+curl -sf "https://$HOST/releases/latest.json" >/dev/null || { echo "::error::feed server not reachable"; cat "$WORK/feed.log"; exit 1; }
+
+# ── Install N-1 into /Applications (writable — so the in-place swap + amfid
+#    revalidation path that broke 1.0.1 is actually exercised; NOT the
+#    read-only DMG-mount pattern the existing smoke job uses) ──
+log "installing N-1 from $N1_DMG → /Applications"
+rm -rf "$APP"
+hdiutil attach "$N1_DMG" -nobrowse -mountpoint /Volumes/AztecAccelerator-N1 >/dev/null
+N1_APP="$(find /Volumes/AztecAccelerator-N1 -maxdepth 1 -name '*.app' | head -1)"
+ditto "$N1_APP" "$APP"
+hdiutil detach /Volumes/AztecAccelerator-N1 >/dev/null
+# Approximate the post-Gatekeeper state of a Finder-dragged notarized install
+# so N-1 launches headlessly (the update path to N is what we're testing).
+xattr -dr com.apple.quarantine "$APP" 2>/dev/null || true
+
+# ── Pre-seed auto-update so N-1 updates without UI ──
+mkdir -p "$CONFIG_DIR"
+echo '{"config_version":1,"safari_support":false,"approved_origins":[],"speed":"full","auto_update":true}' > "$CONFIG_DIR/config.json"
+
+# ── Launch N-1; it should auto-update to N and relaunch ──
+log "launching N-1 (expecting auto-update → N)"
+"$APP_BIN" > "$WORK/app.log" 2>&1 &
+APP_PID=$!
+
+# ── Poll /health until version == N (the strict success criterion: N-1 also
+#    answers /health 'ok' with its OWN version, so only version==N counts) ──
+log "polling $HEALTH for version == $N_VERSION (up to 300s)"
+for _ in $(seq 1 150); do
+  GOT="$(curl -sf "$HEALTH" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || true)"
+  if [ "$GOT" = "$N_VERSION" ]; then
+    log "SUCCESS — updated app reports version $GOT"
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "::error::updater smoke failed — /health never reported version $N_VERSION"
+echo "── app log ──"; cat "$WORK/app.log" 2>/dev/null || true
+echo "── last /health ──"; curl -s "$HEALTH" 2>/dev/null || true
+exit 1


### PR DESCRIPTION
First increment of `implementations-plan/updater-validation-2026-05-29/` (Tier A; codex + opus audited; final codex: "technically sound, ship macOS-blocking / Linux advisory").

## What

A release-time `update-smoke` job that installs the previous stable (N-1), lets it **auto-update** to the just-built+signed build (N) via a local feed impersonating the prod endpoint, and asserts the relaunched app reports `/health.version == N`. This reproduces the **1.0.1 failure class** (macOS amfid hang after the in-place `.app` swap) that fresh-install smoke can't catch.

- `updater-feed-server.ts` — bun HTTPS server (synthesized `latest.json` + N artifact, :443).
- `updater-smoke.sh` — per-run local CA + leaf (SAN `aztec-accelerator.dev`), trust it, `/etc/hosts` → localhost, install N-1 into **`/Applications`** (writable, so the swap+amfid path is real — not the read-only-DMG `smoke` pattern), pre-seed `auto_update:true`, launch, poll `/health` until `version == N`.
- `_e2e-updater.yml` — reusable (downloads this run's signed N artifact + latest-stable N-1 DMG).
- `release-accelerator.yml` — `update-smoke` matrix (macOS arm64 + Intel).

## No signing key
Serves the already-prod-signed N artifact; N-1 verifies against its embedded pubkey. `contents: read` only. (rustls-platform-verifier uses the OS trust store → the runner-trusted local CA is honored.)

## Advisory (deliberate)
**Not in `tag.needs`** — runs + reports without blocking until a `1.0.3-rc` dry-run proves it green. A `-rc` dry-run is safe for real users (prereleases skip the prod `latest.json` upload; the gate's feed is local-only). Follow-up: Linux AppImage leg + standing negative test (corrupt `.sig` must fail) + promote macOS to blocking.

## Test plan
- [x] shellcheck + actionlint + biome clean
- [ ] PR-gate green (lint only — `update-smoke` runs on release dispatch, not PRs)
- [ ] **Validation = a `1.0.3-rc` dry-run** you trigger; we fix whatever the open questions surface (Gatekeeper on the gh-downloaded N-1, `app.restart()` in CI, timing), then promote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)