### PR TITLE
fix(ci): harden updater gate per post-merge codex audit

### DIFF
--- a/.github/workflows/_e2e-updater.yml
+++ b/.github/workflows/_e2e-updater.yml
@@ -74,12 +74,12 @@ jobs:
           # Guard against a no-op pass: if N-1 resolves to the SAME version under
           # test (e.g. a re-run after N is already the latest stable), the updater
           # has nothing to do and `/health == N` would pass trivially (false pass).
-          case "$N1_TAG" in
-            *"$N_VERSION")
-              echo "::error::N-1 ($N1_TAG) matches the version under test ($N_VERSION) — no-op no-update would pass trivially. Aborting."
-              exit 1
-              ;;
-          esac
+          # Exact tag compare (tags are `accelerator-v<version>`) — a suffix match
+          # would false-trip on e.g. accelerator-v11.0.3 vs 1.0.3.
+          if [ "$N1_TAG" = "accelerator-v$N_VERSION" ]; then
+            echo "::error::N-1 ($N1_TAG) is the version under test (accelerator-v$N_VERSION) — no-op no-update would pass trivially. Aborting."
+            exit 1
+          fi
           mkdir -p n1
           gh release download "$N1_TAG" --pattern "${{ inputs.n1-dmg-glob }}" --dir n1
 

--- a/.github/workflows/release-accelerator.yml
+++ b/.github/workflows/release-accelerator.yml
@@ -308,6 +308,17 @@ jobs:
             find /Volumes/AztecAccelerator -type f
             exit 1
           fi
+
+          # Gatekeeper / notarization verification: an unstapled or improperly
+          # signed DMG can still "launch fine" in CI yet be REJECTED on a real
+          # user's first double-click. These offline checks catch that class
+          # (which a launch-only smoke misses).
+          APP_PATH=$(find /Volumes/AztecAccelerator -maxdepth 1 -name '*.app' | head -1)
+          echo "Verifying signature + stapled notarization of $APP_PATH..."
+          codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+          xcrun stapler validate "$APP_PATH"
+          echo "Signature + stapled notarization OK"
+
           echo "Launching $APP_BIN..."
           "$APP_BIN" > /tmp/smoke.log 2>&1 &
           echo "SMOKE_PID=$!" >> "$GITHUB_ENV"

--- a/implementations-plan/updater-validation-2026-05-29/lessons/phase-decouple-harden.md
+++ b/implementations-plan/updater-validation-2026-05-29/lessons/phase-decouple-harden.md
@@ -114,3 +114,36 @@ sig-rejection" to "proven detection of a 1.0.1-class hang."
   DMG retry (while the .app still exists); remove the standalone step.
 - Note: rc.4 will exercise the amfid swap+relaunch crux for the FIRST time
   (rc.1 404'd pre-download, rc.2 never built, rc.3 never uploaded the artifact).
+
+## Post-merge codex audit (session 019e7554) — hardening PR
+
+Audited the merged state. Codex confirmed the split is sound and the positive
+path + bundle-shape invariant are solid, but found real holes (all fixed on
+`ci/updater-gate-audit-hardening`):
+
+1. **[SHIPPED-ARTIFACT]** No regression from the split (verified empirically:
+   1.0.2 combined-build and rc.4 split-build are IDENTICAL — `.app` stapled +
+   `spctl` "accepted, Notarized Developer ID"; `.dmg` unstapled in BOTH, which
+   is tauri's normal posture, Gatekeeper assesses the `.app`). But the smoke job
+   never verified notarization → added `codesign --verify --deep --strict` +
+   `xcrun stapler validate` on the `.app` (catches a future unstapled/unsigned
+   ship that "launches fine" yet fails a real user's Gatekeeper).
+2. **[FALSE-PASS]** The negative leg's anti-vacuous guard grepped the feed log
+   for `latest.json` — but the script's OWN readiness probe curls latest.json,
+   so it was always true. Switched the proof to a `/releases/download/` hit
+   (only the app requests that). Same fix applied to the positive guard (dropped
+   the vacuous latest.json clause).
+3. **[FALSE-PASS]** Negative corruption used `rev` on the `.sig`, which can fail
+   as malformed-base64 BEFORE crypto verification. Switched to serving the
+   GENUINE signature with a TAMPERED tarball (append a byte) → the app downloads
+   it and the minisign check over the tampered bytes fails → real verification
+   teeth.
+4. **[SECURITY]** Tightened the `/etc/hosts` cleanup to delete only the exact
+   anchored line (not any line mentioning the host) — self-hosted hygiene.
+5. **[CORRECTNESS]** Rerun guard was a suffix glob (false-matches
+   accelerator-v11.0.3 vs 1.0.3) → exact tag compare `accelerator-v$N_VERSION`.
+
+Empirical stapling check (local, on the real artifacts):
+- 1.0.2 .app: `stapler validate` OK, `spctl` accepted; .dmg unstapled.
+- 1.0.3-rc.4 .app: `stapler validate` OK, `spctl` accepted; .dmg unstapled.
+→ split is byte-equivalent in notarization posture; no user-facing regression.

--- a/packages/accelerator/UPDATER_TESTING.md
+++ b/packages/accelerator/UPDATER_TESTING.md
@@ -49,9 +49,12 @@ signed-updater path works end-to-end (endpoint → TLS → download → signatur
 verify → in-place swap → bare-spawn relaunch → `/health == N`). It does **not**
 by itself prove the gate would *catch* a 1.0.1-class regression — the
 deterministic guard for that exact class is the **bundle-shape invariant** in
-the `build` job. To give the gate some teeth, a **negative** leg serves a
-corrupted `.sig` and asserts the update is **rejected** (`/health` never reports
-N) — proving the gate can fail, not just pass. Full detection of a
+the `build` job. To give the gate some teeth, a **negative** leg serves the
+**genuine signature with a tampered tarball** (one appended byte) and asserts
+the update is **rejected** — proven by an actual `download/` hit in the feed log
+(the app fetched the artifact) followed by `/health` *never* reporting N (the
+cryptographic check over the tampered bytes failed). This exercises real
+signature verification, not a malformed-blob parse error. Full detection of a
 *validly-signed but bad* bundle would require an ephemeral CI signing key + a
 CI-keyed N-1 (deferred).
 

--- a/packages/accelerator/scripts/updater-smoke.sh
+++ b/packages/accelerator/scripts/updater-smoke.sh
@@ -55,8 +55,9 @@ cleanup() {
   pkill -f "Aztec Accelerator.app" 2>/dev/null
   [ -n "$FEED_PID" ] && sudo kill "$FEED_PID" 2>/dev/null
   hdiutil detach "/Volumes/AztecAccelerator-N1" 2>/dev/null
-  # best-effort: drop the hosts line we added
-  sudo sed -i '' "/$HOST/d" /etc/hosts 2>/dev/null
+  # best-effort: drop ONLY the exact line we added (anchored), not any line
+  # mentioning the host — avoids clobbering an unrelated entry on self-hosted.
+  sudo sed -i '' "/^127\\.0\\.0\\.1 $HOST\$/d" /etc/hosts 2>/dev/null
   # best-effort: remove the test CA we trusted (matters only on non-ephemeral /
   # self-hosted runners; GH-hosted VMs are torn down after the job).
   sudo security delete-certificate -c "updater-smoke-local-CA" \
@@ -74,12 +75,15 @@ cp "$N_TARBALL" "$SERVE_DIR/$N_BASENAME"
 N_SIG="$(cat "$N_SIG_FILE")"
 log "N artifact: $N_BASENAME"
 
-# Negative control: corrupt the signature so it cannot validate against the
-# embedded pubkey. The tarball itself is the real one — only the .sig is bad,
-# so the updater downloads it and MUST reject it at verification (no swap).
+# Negative control: serve the GENUINE signature but a TAMPERED tarball (append a
+# byte). The updater downloads the artifact, then the minisign check over the
+# tampered bytes MUST fail against the embedded pubkey — exercising real
+# cryptographic verification (not a malformed-base64 parse error, which a
+# corrupted .sig would hit before any verification). The genuine sig is left
+# untouched so the only thing wrong is the artifact↔signature mismatch.
 if [ "$MODE" = "negative" ]; then
-  N_SIG="$(printf '%s' "$N_SIG" | rev)"
-  log "NEGATIVE mode: serving a CORRUPTED signature — expecting REJECTION (no update)"
+  printf 'x' >> "$SERVE_DIR/$N_BASENAME"
+  log "NEGATIVE mode: serving a TAMPERED tarball with the genuine signature — expecting REJECTION (no update)"
 fi
 
 # ── Local CA + leaf cert (SAN = the prod host) ──
@@ -151,27 +155,27 @@ dump_logs() {
 }
 
 if [ "$MODE" = "negative" ]; then
-  # Teeth check: the corrupted signature MUST be rejected. /health must NEVER
-  # report N (no swap). If it ever does, signature verification has no teeth.
-  log "NEGATIVE: asserting /health never reports $N_VERSION (corrupt sig rejected), 120s"
+  # Teeth check: the tampered tarball MUST be rejected. /health must NEVER report
+  # N (no swap). If it ever does, signature verification has no teeth.
+  log "NEGATIVE: asserting /health never reports $N_VERSION (tampered artifact rejected), 120s"
   for _ in $(seq 1 60); do
     GOT="$(curl -sf "$HEALTH" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || true)"
     if [ "$GOT" = "$N_VERSION" ]; then
-      echo "::error::NEGATIVE FAILED — a CORRUPTED signature was ACCEPTED; app updated to $N_VERSION. The updater is not verifying signatures."
+      echo "::error::NEGATIVE FAILED — a TAMPERED artifact was ACCEPTED; app updated to $N_VERSION. The updater is not verifying signatures."
       dump_logs
       exit 1
     fi
     sleep 2
   done
-  # Rule out a vacuous pass: the updater must actually have queried our feed
-  # (and thus received the corrupted sig). If it never hit latest.json, the
-  # "no update" result proves nothing.
-  if ! grep -q "/releases/latest.json" "$WORK/feed.log" 2>/dev/null; then
-    echo "::error::NEGATIVE inconclusive — the updater never queried the feed (no latest.json hit), so rejection was not actually exercised."
+  # Rule out a VACUOUS pass: the app must actually have DOWNLOADED the artifact
+  # (then rejected it). We assert a /releases/download/ hit — NOT latest.json,
+  # which our own readiness probe above curls, so it can't prove the app ran.
+  if ! grep -q "/releases/download/" "$WORK/feed.log" 2>/dev/null; then
+    echo "::error::NEGATIVE inconclusive — the updater never downloaded the artifact (no download/ hit), so signature rejection was not actually exercised."
     dump_logs
     exit 1
   fi
-  log "SUCCESS (negative) — updater queried the feed, got the bad sig, and refused to update to $N_VERSION"
+  log "SUCCESS (negative) — updater downloaded the tampered artifact and refused to update to $N_VERSION"
   dump_logs
   exit 0
 fi
@@ -184,15 +188,15 @@ for _ in $(seq 1 150); do
   GOT="$(curl -sf "$HEALTH" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || true)"
   if [ "$GOT" = "$N_VERSION" ]; then
     # Guard against a no-op pass: the version flip must have come from OUR feed.
-    # The updater downloads the artifact then verifies it, so a real update hits
-    # both latest.json and the download URL.
-    if ! grep -q "/releases/latest.json" "$WORK/feed.log" 2>/dev/null \
-       || ! grep -q "/releases/download/" "$WORK/feed.log" 2>/dev/null; then
-      echo "::error::/health reports $N_VERSION but the feed log lacks latest.json and/or download/ hits — the update did not flow through our feed."
+    # Assert a /releases/download/ hit — the app only requests that when it
+    # actually downloads N. (We do NOT assert latest.json: our own readiness
+    # probe curls it, so it can't prove the app fetched the feed.)
+    if ! grep -q "/releases/download/" "$WORK/feed.log" 2>/dev/null; then
+      echo "::error::/health reports $N_VERSION but the feed log has no download/ hit — the update did not flow through our feed."
       dump_logs
       exit 1
     fi
-    log "SUCCESS — updated to $GOT via the local feed (latest.json + download/ both served)"
+    log "SUCCESS — updated to $GOT via the local feed (artifact downloaded)"
     exit 0
   fi
   sleep 2


### PR DESCRIPTION
Post-merge codex audit (session `019e7554`) of the updater gate. **The split build is sound** — verified empirically that 1.0.2 (combined) and 1.0.3-rc.4 (split) ship an *identical* notarization posture (stapled `.app`, `spctl`-accepted "Notarized Developer ID", unstapled `.dmg` in both — Tauri's normal). No shipped-artifact regression. Fixes for the real holes codex found:

- **Negative test now has real teeth.** Two problems: (a) the anti-vacuous guard grepped the feed log for `latest.json`, but the script's *own* readiness probe curls that — always true; (b) it corrupted the `.sig` with `rev`, which can fail as malformed base64 *before* any crypto check. Now it serves the **genuine signature with a tampered tarball** (one appended byte) and requires a `/releases/download/` hit — so the app downloads it and the **minisign verification over the tampered bytes fails**. Same `download/` proof applied to the positive guard (dropped the vacuous `latest.json` clause).
- **Smoke job now verifies notarization.** Added `codesign --verify --deep --strict` + `xcrun stapler validate` on the `.app` — an unstapled/improperly-signed DMG that "launches fine" in CI but is rejected on a real user's first double-click can no longer ship green. (Validated locally against the real 1.0.2 + rc.4 artifacts; both pass.)
- **Rerun guard** is now an exact tag compare (`accelerator-v$N_VERSION`) instead of a suffix glob that false-matched e.g. `accelerator-v11.0.3`.
- **`/etc/hosts` cleanup** deletes only the exact anchored line (self-hosted hygiene).

## Validation
shellcheck + actionlint clean. Being validated on a `1.0.3-rc.5` dry-run from this branch (the corrected negative leg must still go green via genuine rejection; the new smoke notarization checks must pass).

Detail: `implementations-plan/updater-validation-2026-05-29/lessons/phase-decouple-harden.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
