### PR TITLE
docs(ci): fix stale negative-test comments + escape /etc/hosts cleanup dot

### DIFF
--- a/.github/workflows/_e2e-updater.yml
+++ b/.github/workflows/_e2e-updater.yml
@@ -34,7 +34,7 @@ on:
         required: true
         type: string
       mode:
-        description: "positive (expect the update to apply) | negative (serve a corrupted .sig, expect rejection)"
+        description: "positive (expect the update to apply) | negative (serve a tampered tarball, expect rejection)"
         required: false
         default: positive
         type: string

--- a/.github/workflows/release-accelerator.yml
+++ b/.github/workflows/release-accelerator.yml
@@ -390,10 +390,10 @@ jobs:
             n-artifact: accelerator-macos-x86_64
             n1-dmg-glob: "*macOS-Intel.dmg"
             mode: positive
-          # Negative control (teeth): serve a CORRUPTED .sig and assert the
-          # updater REJECTS it (never reaches version N). Proves the gate can
-          # actually fail — without this, a green positive run is consistent with
-          # a test that always passes. arm64 only: the signature-verification
+          # Negative control (teeth): serve a TAMPERED tarball (genuine signature)
+          # and assert the updater REJECTS it (never reaches version N). Proves the
+          # gate can actually fail — without this, a green positive run is consistent
+          # with a test that always passes. arm64 only: the signature-verification
           # path is arch-independent, no need to also burn the flakier Intel runner.
           - runner: macos-latest
             platform-key: darwin-aarch64

--- a/implementations-plan/updater-validation-2026-05-29/lessons/phase-decouple-harden.md
+++ b/implementations-plan/updater-validation-2026-05-29/lessons/phase-decouple-harden.md
@@ -147,3 +147,27 @@ Empirical stapling check (local, on the real artifacts):
 - 1.0.2 .app: `stapler validate` OK, `spctl` accepted; .dmg unstapled.
 - 1.0.3-rc.4 .app: `stapler validate` OK, `spctl` accepted; .dmg unstapled.
 → split is byte-equivalent in notarization posture; no user-facing regression.
+
+## Second codex re-audit (resumed session 019e7554) — fixes confirmed
+
+Re-audited the merged state (5ca4ba1). Codex confirmed ALL 5 prior-finding
+fixes are correct (the build split is solid; no new bugs introduced):
+- #2 download/ proof, #3 tampered-tarball, #5 exact-tag guard: fully correct.
+- #1 notarization checks: right target (.app), local/read-only, "no new flake
+  vector".
+- #4 hosts anchor: safer but the host's '.' was still an unescaped regex meta →
+  fixed here (escape dots via `${HOST//./\\.}`; verified a decoy
+  `aztecXacceleratorXdev` line survives).
+
+Residual (polish PR `ci/updater-gate-audit-polish`):
+- Escaped the /etc/hosts dot (above).
+- Fixed 3 stale "corrupted .sig" comments → "tampered tarball" (the code tampers
+  the tarball now). Left the one intentional contrast comment that explains WHY.
+
+DEFERRED to the promote-to-blocking follow-up (codex's one substantive open
+item): **Intel direct-download DMG is not on a blocking path** — the release-
+blocking `smoke` job only downloads + verifies the arm64 DMG; Intel's shipped
+DMG is covered only by advisory update-smoke (updater tarball, not the DMG).
+Low probability (Intel shares arm64's signing config, which we verify) but a
+real gap. Cheap close: also run codesign/stapler on the Intel `.app` in the
+existing smoke job (arch-agnostic; no Intel runner/launch needed).

--- a/packages/accelerator/scripts/updater-smoke.sh
+++ b/packages/accelerator/scripts/updater-smoke.sh
@@ -29,7 +29,7 @@ N1_DMG="$4"
 REPO_ROOT="$5"
 
 # positive (default): expect the update to apply (/health reports N).
-# negative: serve a CORRUPTED .sig and assert the update is REJECTED — proves
+# negative: serve a TAMPERED tarball and assert the update is REJECTED — proves
 #           the gate has teeth (a green positive run alone is consistent with a
 #           test that can never fail). Set via UPDATER_SMOKE_MODE.
 MODE="${UPDATER_SMOKE_MODE:-positive}"
@@ -55,9 +55,11 @@ cleanup() {
   pkill -f "Aztec Accelerator.app" 2>/dev/null
   [ -n "$FEED_PID" ] && sudo kill "$FEED_PID" 2>/dev/null
   hdiutil detach "/Volumes/AztecAccelerator-N1" 2>/dev/null
-  # best-effort: drop ONLY the exact line we added (anchored), not any line
+  # best-effort: drop ONLY the exact line we added (anchored + dots escaped, so
+  # the host's literal '.' can't match an arbitrary char), not any line
   # mentioning the host — avoids clobbering an unrelated entry on self-hosted.
-  sudo sed -i '' "/^127\\.0\\.0\\.1 $HOST\$/d" /etc/hosts 2>/dev/null
+  host_re="${HOST//./\\.}"
+  sudo sed -i '' "/^127\\.0\\.0\\.1 $host_re\$/d" /etc/hosts 2>/dev/null
   # best-effort: remove the test CA we trusted (matters only on non-ephemeral /
   # self-hosted runners; GH-hosted VMs are torn down after the job).
   sudo security delete-certificate -c "updater-smoke-local-CA" \


### PR DESCRIPTION
Polish from the second codex re-audit (which confirmed all 5 hardening fixes are correct). Two zero-risk items:

- **Stale comments** — the negative leg now tampers the served tarball (genuine signature), but three comments still said "corrupted `.sig`". Updated to "tampered tarball". (Left the one comment that intentionally contrasts the two.)
- **`/etc/hosts` cleanup dot** — the anchored line interpolated `$HOST` with literal dots unescaped (regex any-char). Now escaped via `${HOST//./\\.}` so only the exact line matches (verified a decoy `aztecXacceleratorXdev` line survives).

No behavior change to the gate; comment + regex-safety only. Intel direct-download DMG verification (codex's one substantive open item) is deferred to the promote-update-smoke-to-blocking follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)