### PR TITLE
ci(cache): share the Rust cache across PR + release (Phase B1)

### DIFF
--- a/.github/actions/setup-accelerator/action.yml
+++ b/.github/actions/setup-accelerator/action.yml
@@ -14,11 +14,21 @@ inputs:
     default: ""
   rust-cache-key:
     description: |
-      Extra cache key suffix for `Swatinem/rust-cache`. Used to isolate caches between build
-      kinds (e.g. `release-${target}` vs `headless-${target}` vs empty for PR-gate).
-      Append-only — rust-cache adds it after its automatic key.
+      `Swatinem/rust-cache` `shared-key` — replaces the per-job auto key so caches are SHARED
+      across jobs that pass the same value (the actual cross-warming mechanism). Scope it per
+      crate × target, e.g. `accelerator-desktop-${target}` or `accelerator-server-${target}`.
+      Jobs with the same shared-key + same rustc + same Cargo.lock restore each other's cache.
     required: false
     default: ""
+  rust-workspaces:
+    description: |
+      `Swatinem/rust-cache` `workspaces:` value — which crate's `target` to cache. Pass only the
+      one a job actually builds (desktop = src-tauri, server = server) to keep cache entries
+      small + stable. Defaults to both for back-compat with callers that don't specify.
+    required: false
+    default: |
+      packages/accelerator/src-tauri -> target
+      packages/accelerator/server -> target
   rust-components:
     description: |
       Comma-separated Rust components. Default `clippy,rustfmt` preserves PR-gate behavior;
@@ -77,10 +87,8 @@ runs:
 
     - uses: Swatinem/rust-cache@v2
       with:
-        workspaces: |
-          packages/accelerator/src-tauri -> target
-          packages/accelerator/server -> target
-        key: ${{ inputs.rust-cache-key }}
+        workspaces: ${{ inputs.rust-workspaces }}
+        shared-key: ${{ inputs.rust-cache-key }}
 
     - name: Copy bb sidecar
       shell: bash

--- a/.github/workflows/_e2e.yml
+++ b/.github/workflows/_e2e.yml
@@ -61,14 +61,14 @@ jobs:
 
       # This job builds the server crate FROM packages/accelerator/server, so
       # Cargo writes all artifacts (incl. the src-tauri path-dep) under
-      # server/target. Cache that dir — caching src-tauri/target here is dead
-      # weight (nothing builds into it in this job). NOTE: keep in sync with the
-      # setup-accelerator composite if this is ever refactored to share setup.
+      # server/target. Cache that dir only. Use the SAME `shared-key` as the
+      # other linux server builds (smoke / release-smoke / release build-headless
+      # + setup-accelerator) so they cross-warm one shared server cache.
       - uses: Swatinem/rust-cache@v2
         if: inputs.build_accelerator
         with:
           workspaces: packages/accelerator/server -> target
-          key: e2e-accelerator
+          shared-key: accelerator-server-x86_64-unknown-linux-gnu
 
       - name: Build headless accelerator server
         if: inputs.build_accelerator

--- a/.github/workflows/accelerator.yml
+++ b/.github/workflows/accelerator.yml
@@ -52,6 +52,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-accelerator
+        with:
+          rust-cache-key: accelerator-desktop-x86_64-unknown-linux-gnu
+          rust-workspaces: packages/accelerator/src-tauri -> target
       - run: cargo fmt --check
       - run: cargo clippy --all-targets -- -D warnings
 
@@ -67,6 +70,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-accelerator
+        with:
+          rust-cache-key: accelerator-desktop-x86_64-unknown-linux-gnu
+          rust-workspaces: packages/accelerator/src-tauri -> target
+          rust-components: ""
       - run: cargo test
 
   lint:
@@ -100,6 +107,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-accelerator
+        with:
+          rust-cache-key: accelerator-server-x86_64-unknown-linux-gnu
+          rust-workspaces: packages/accelerator/server -> target
+          rust-components: ""
       - name: Build headless server
         # `accelerator-server` lives in a sibling crate at `../server/`
         # — see Cargo.toml docs.
@@ -153,6 +164,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-accelerator
+        with:
+          rust-cache-key: accelerator-server-x86_64-unknown-linux-gnu
+          rust-workspaces: packages/accelerator/server -> target
+          rust-components: ""
       - name: Build release headless server (linux-x86_64)
         # `accelerator-server` lives in a sibling crate at `../server/`.
         run: cargo build --release --manifest-path ../server/Cargo.toml

--- a/.github/workflows/release-accelerator.yml
+++ b/.github/workflows/release-accelerator.yml
@@ -104,7 +104,8 @@ jobs:
       - uses: ./.github/actions/setup-accelerator
         with:
           rust-target: ${{ matrix.target }}
-          rust-cache-key: release-${{ matrix.target }}
+          rust-cache-key: accelerator-desktop-${{ matrix.target }}
+          rust-workspaces: packages/accelerator/src-tauri -> target
           rust-components: ""
 
       - name: Patch version in Cargo.toml
@@ -243,7 +244,8 @@ jobs:
       - uses: ./.github/actions/setup-accelerator
         with:
           rust-target: ${{ matrix.target }}
-          rust-cache-key: headless-${{ matrix.target }}
+          rust-cache-key: accelerator-server-${{ matrix.target }}
+          rust-workspaces: packages/accelerator/server -> target
           rust-components: ""
 
       - name: Patch version in Cargo.toml

--- a/.github/workflows/warm-rust-cache.yml
+++ b/.github/workflows/warm-rust-cache.yml
@@ -1,0 +1,60 @@
+name: Warm Rust Cache
+
+# Warms the shared LINUX Rust caches on `main` so PR jobs RESTORE them instead of
+# cold-compiling the dependency graph. PR runs can only restore caches from
+# main/base, and nothing else runs Rust on push-to-main (PR gates are
+# `pull_request`; the release is `workflow_dispatch`) — so without this, the
+# shared-key caches are only ever written by the rare release dispatch and PRs
+# stay cold. Builds the DEBUG profile (what clippy/test/smoke/_e2e use); release
+# jobs still benefit from the shared `~/.cargo` registry under the same key.
+on:
+  push:
+    branches: [main]
+    paths:
+      - packages/accelerator/src-tauri/**
+      - packages/accelerator/server/**
+      - .github/actions/setup-accelerator/action.yml
+      - .github/workflows/warm-rust-cache.yml
+  schedule:
+    - cron: "0 6 * * 1,4" # Mon + Thu 06:00 UTC — keep the cache inside the 7-day eviction window
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: warm-rust-cache
+  cancel-in-progress: true
+
+jobs:
+  desktop:
+    name: Warm desktop Rust cache (linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: packages/accelerator/src-tauri
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-accelerator
+        with:
+          rust-cache-key: accelerator-desktop-x86_64-unknown-linux-gnu
+          rust-workspaces: packages/accelerator/src-tauri -> target
+      # Debug + all-targets to warm what `clippy --all-targets` and `cargo test` compile.
+      - run: cargo build --all-targets
+
+  server:
+    name: Warm server Rust cache (linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: packages/accelerator/server
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-accelerator
+        with:
+          rust-cache-key: accelerator-server-x86_64-unknown-linux-gnu
+          rust-workspaces: packages/accelerator/server -> target
+          rust-components: ""
+      - run: cargo build


### PR DESCRIPTION
**Phase B1** of the [CI/release overhaul](../blob/main/implementations-plan/ci-release-overhaul-2026-06-01/plan.md).

The Rust cache was fragmented across 4 non-overlapping scopes → nothing cross-warmed → cold compiles. Now:
- `setup-accelerator` uses `Swatinem/rust-cache` **`shared-key`** (the actual cross-job sharing mechanism) + a `rust-workspaces` input → each job caches only the crate it builds.
- Per-component-per-target keys (`accelerator-desktop-<target>` / `accelerator-server-<target>`): PR clippy/test share with the release linux desktop build; smoke/release-smoke/`_e2e` share with build-headless-linux.
- `rust-components: ""` on test/smoke/release-smoke.
- New **`warm-rust-cache.yml`** — seeds the shared linux caches on main push + weekly (without it nothing warms main's Rust cache; same fix as the Playwright warmer).

⚠️ **Expected:** this PR + the rc.7 dry-run **cold-miss** the new keys (one-time, slower) — validating *correctness* (green with new keys). The warming benefit shows on the next PR after merge, once the warmer seeds main. Commit unsigned (1Password locked, autonomous run) — to re-sign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)