### PR TITLE
ci(release): advisory Linux AppImage updater-smoke leg (Phase A2b)

### DIFF
--- a/.github/workflows/_e2e-updater-linux.yml
+++ b/.github/workflows/_e2e-updater-linux.yml
@@ -1,0 +1,137 @@
+name: _Updater Smoke Linux (reusable)
+
+# ADVISORY Linux/AppImage sibling of _e2e-updater.yml. Installs the previous
+# stable (N-1) AppImage, lets it auto-update to the just-built+signed build (N)
+# via a local feed impersonating the prod endpoint, and asserts it relaunches
+# reporting version N. Answers the open `v1Compatible` question: does Tauri's
+# Linux updater actually apply a RAW .AppImage in place? NOT in `tag.needs` —
+# a red here is signal about the Linux update path, not a release blocker.
+#
+# Needs no signing key: it serves the already-prod-signed N .AppImage and N-1
+# validates it against its embedded pubkey. See updater-smoke-linux.sh.
+
+on:
+  workflow_call:
+    inputs:
+      n-version:
+        description: The version being released (N)
+        required: true
+        type: string
+      n-artifact:
+        description: This run's Linux build artifact name (accelerator-linux-x86_64)
+        required: false
+        default: accelerator-linux-x86_64
+        type: string
+      platform-key:
+        description: Tauri updater platform key
+        required: false
+        default: linux-x86_64
+        type: string
+      n1-appimage-glob:
+        description: Glob for the N-1 release AppImage asset
+        required: false
+        default: "*Linux-x86_64.AppImage"
+        type: string
+      mode:
+        description: "positive (expect the update to apply) | negative (serve a tampered AppImage, expect rejection)"
+        required: false
+        default: positive
+        type: string
+
+jobs:
+  updater-smoke-linux:
+    name: Updater Smoke Linux
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # FUSE (AppImage runtime) + headless display + tray host + dbus. Running the
+      # AppImage natively (via FUSE) sets $APPIMAGE, which the Tauri Linux updater
+      # replaces in place — `--appimage-extract-and-run` would NOT, breaking the
+      # swap path under test. libfuse2 is `libfuse2t64` on 24.04 (ubuntu-latest).
+      - name: Install FUSE + display + tray deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libfuse2t64 || sudo apt-get install -y libfuse2
+          sudo apt-get install -y xvfb stalonetray dbus-x11
+
+      - name: Setup display
+        run: |
+          Xvfb :99 -screen 0 1280x1024x24 &
+          sleep 1
+          eval "$(dbus-launch --sh-syntax)"
+          stalonetray -d none --geometry 1x1+0+0 --kludges force_icons_size &
+          sleep 1
+          {
+            echo "DISPLAY=:99"
+            echo "NO_AT_BRIDGE=1"
+            echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS"
+            echo "DBUS_SESSION_BUS_PID=$DBUS_SESSION_BUS_PID"
+          } >> "$GITHUB_ENV"
+
+      - name: Download N artifacts (this run)
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.n-artifact }}
+          path: n-artifacts
+
+      - name: Download latest stable (N-1) AppImage
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          N_VERSION: ${{ inputs.n-version }}
+        run: |
+          N1_TAG=$(gh release list --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName')
+          if [ -z "$N1_TAG" ]; then
+            echo "::error::no stable release found to use as N-1"
+            exit 1
+          fi
+          echo "N-1 = $N1_TAG"
+          # Guard against a no-op pass: if N-1 resolves to the SAME version under
+          # test, the updater has nothing to do and /health == N passes trivially.
+          # Exact tag compare (tags are `accelerator-v<version>`).
+          if [ "$N1_TAG" = "accelerator-v$N_VERSION" ]; then
+            echo "::error::N-1 ($N1_TAG) is the version under test (accelerator-v$N_VERSION) — no-op no-update would pass trivially. Aborting."
+            exit 1
+          fi
+          mkdir -p n1
+          gh release download "$N1_TAG" --pattern "${{ inputs.n1-appimage-glob }}" --dir n1
+
+      # ADVISORY: continue-on-error so a Linux-updater failure does NOT fail this
+      # job (and thus never reds the release run via the caller). The result is
+      # downgraded to a warning in the next step. To make this BLOCKING later,
+      # delete `continue-on-error` here and add this job to `tag.needs`.
+      - name: Updater smoke (install N-1 → auto-update to N → assert /health == N)
+        id: smoke
+        continue-on-error: true
+        env:
+          UPDATER_SMOKE_MODE: ${{ inputs.mode }}
+        run: |
+          APPIMAGE=$(find n1 -name '*.AppImage' | head -1)
+          if [ -z "$APPIMAGE" ]; then echo "::error::N-1 AppImage not found"; exit 1; fi
+          bash packages/accelerator/scripts/updater-smoke-linux.sh \
+            "${{ inputs.n-version }}" \
+            "${{ inputs.platform-key }}" \
+            n-artifacts \
+            "$APPIMAGE" \
+            "$GITHUB_WORKSPACE"
+
+      # Surface the advisory outcome WITHOUT failing the run: a green job here
+      # means "the advisory ran", not "the update worked" — read this step.
+      - name: Advisory result (never fails the run)
+        if: always()
+        run: |
+          if [ "${{ steps.smoke.outcome }}" = "success" ]; then
+            echo "✅ Linux AppImage updater smoke PASSED — Tauri applied the raw .AppImage and relaunched on N." >> "$GITHUB_STEP_SUMMARY"
+            echo "Linux AppImage updater smoke PASSED"
+          else
+            echo "::warning::Linux AppImage updater smoke FAILED (ADVISORY — not a release blocker). Signals Tauri's v1Compatible Linux updater may not apply a raw .AppImage in place, or a FUSE/display harness issue. See the smoke step log."
+            echo "⚠️ Linux AppImage updater smoke FAILED (advisory) — see the 'Updater smoke' step log for the FUSE-vs-updater-reject signal." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/_e2e-updater-linux.yml
+++ b/.github/workflows/_e2e-updater-linux.yml
@@ -56,10 +56,18 @@ jobs:
       # AppImage natively (via FUSE) sets $APPIMAGE, which the Tauri Linux updater
       # replaces in place — `--appimage-extract-and-run` would NOT, breaking the
       # swap path under test. libfuse2 is `libfuse2t64` on 24.04 (ubuntu-latest).
-      - name: Install FUSE + display + tray deps
+      - name: Install FUSE + GUI runtime + display + tray deps
         run: |
           sudo apt-get update
           sudo apt-get install -y libfuse2t64 || sudo apt-get install -y libfuse2
+          # GUI runtime libs the AppImage needs at launch (libEGL/libGL come in via
+          # the gtk/webkit stack). This is the SAME set setup-accelerator installs
+          # for the Linux WebDriver job — which is why that job's app launches
+          # headlessly. Without them the AppImage dies on
+          # `libEGL.so.1: cannot open shared object file` before it can update.
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev \
+            patchelf libssl-dev libgtk-3-dev
           sudo apt-get install -y xvfb stalonetray dbus-x11
 
       - name: Setup display

--- a/.github/workflows/release-accelerator.yml
+++ b/.github/workflows/release-accelerator.yml
@@ -469,6 +469,22 @@ jobs:
       n1-dmg-glob: ${{ matrix.n1-dmg-glob }}
       mode: ${{ matrix.mode }}
 
+  # Linux/AppImage updater smoke — ADVISORY. Deliberately ABSENT from `tag.needs`
+  # / `release.needs`, so it never blocks the ship. The advisory semantics live
+  # INSIDE the reusable workflow (the smoke step is `continue-on-error` and a
+  # failure is downgraded to a ::warning:: + step summary) because GitHub forbids
+  # `continue-on-error` on a `uses:` caller job — so this job stays green while
+  # still surfacing the signal. It answers the open `v1Compatible` question (does
+  # Tauri apply a raw .AppImage in place?) on a real runner; it flips to blocking
+  # (move into `tag.needs`, make the step hard-fail) only after a proving run.
+  update-smoke-linux:
+    name: Updater Smoke (linux-x86_64 / positive, advisory)
+    needs: [validate, build, e2e-webdriver]
+    if: ${{ !cancelled() && needs.validate.result == 'success' }}
+    uses: ./.github/workflows/_e2e-updater-linux.yml
+    with:
+      n-version: ${{ needs.validate.outputs.version }}
+
   tag:
     name: Create Git Tag
     needs: [validate, build, build-headless, smoke, smoke-intel, update-smoke, e2e-webdriver]

--- a/implementations-plan/ci-release-overhaul-2026-06-01/lessons/phase-a2b.md
+++ b/implementations-plan/ci-release-overhaul-2026-06-01/lessons/phase-a2b.md
@@ -1,0 +1,46 @@
+# Phase A2b — Linux AppImage updater-smoke (advisory)
+
+PR #250. Branch `ci/phase-a2b-updater-smoke-linux`. Validated via 1.0.3-rc dry-runs.
+
+## What landed
+- `packages/accelerator/scripts/updater-smoke-linux.sh` — Linux sibling of the macOS `updater-smoke.sh`.
+- `.github/workflows/_e2e-updater-linux.yml` — reusable workflow (FUSE + Xvfb + dbus + stalonetray).
+- `release-accelerator.yml` — `update-smoke-linux` advisory job (absent from `tag.needs`).
+
+## Resolved unknowns (researched locally, before any CI cycle)
+
+### 1. TLS trust — the determinative blocker, GREEN
+The whole local-CA impersonation hinges on the Linux updater reading the **system trust store**.
+- `reqwest = "0.12"` with no explicit TLS feature → default-tls (native-tls → OpenSSL → `/etc/ssl/certs`).
+- Cargo.lock has **no `webpki-roots`** in the tree, but **does** have `rustls-native-certs`. So even if tauri-plugin-updater pulls the rustls path, roots come from the OS store, **not** bundled Mozilla roots.
+- ⇒ Either path reads the system store. `update-ca-certificates` makes the local CA trusted. Conclusion: the macOS keychain-trust approach ports directly. (high confidence)
+
+### 2. Config dir — IDENTICAL to macOS
+`config.rs:75` → `dirs::home_dir().join(".aztec-accelerator").join("config.json")` on **both** OSes (not XDG). So preseeding `auto_update:true` at `$HOME/.aztec-accelerator/config.json` works unchanged.
+
+### 3. Updater trigger
+`updater.rs::check_for_update()` runs in a background loop (main.rs); `auto_update==true` ⇒ `perform_update()` auto-applies. The N-1 AppImage is a **release** build (updater compiled IN — unlike `--features webdriver` builds, which compile the check OUT), so the check is live.
+
+### 4. Single minisign pubkey, platform-agnostic
+`tauri.conf.json` has one `pubkey` for all platforms ⇒ serving the already-signed N `.AppImage` needs **no signing key** (same secretless property as macOS).
+
+## Implementation gotchas
+
+### actionlint: `continue-on-error` is forbidden on a `uses:` caller job
+```
+when a reusable workflow is called with "uses", "continue-on-error" is not available.
+```
+So "advisory" can't be expressed on the caller. Fix: push the semantics **inside** the reusable workflow — `continue-on-error: true` on the smoke **step** + a follow-up "Advisory result" step that downgrades a failure to `::warning::` + `$GITHUB_STEP_SUMMARY`. Net: the job stays green (production releases never red on a Linux-updater fault), the signal is surfaced (warning annotation + summary), and the smoke **step** log carries the real pass/fail. To make it blocking later: delete `continue-on-error` + add the job to `tag.needs`.
+
+### FUSE vs extract-and-run — must be native
+AppImage self-update replaces the file at `$APPIMAGE` in place. `--appimage-extract-and-run` does **not** set `$APPIMAGE` the same way ⇒ would test the wrong path. So install `libfuse2` (`libfuse2t64` on 24.04 / ubuntu-latest, with a `|| libfuse2` fallback) and run **natively** — the AppImage runtime then sets `$APPIMAGE` itself (don't override it manually; a forced value risks a path mismatch vs the runtime's canonicalization).
+
+### Don't touch the blocking macOS path
+macOS `update-smoke` is in `tag.needs` and proven green (rc.8). Linux is a **separate** script + reusable workflow + job, not a parameterization of `_e2e-updater.yml`, specifically so an advisory experiment can't regress the blocking gate. Refactor to share only after Linux is itself proven.
+
+## Hardening (plan security items, folded into the merge candidate)
+- **In-place-swap proof**: assert the on-disk AppImage sha256 **changed** from N-1 (and ideally equals the served N). A version flip with an unchanged file = a non-in-place mechanism worth knowing about.
+- **Run-unique CA** (`updater-smoke-local-CA-$GITHUB_RUN_ID-$ATTEMPT`): cleanup removes only this run's anchor — a fixed name could clobber a concurrent/leftover entry on a non-ephemeral self-hosted runner. (The macOS script still uses a fixed name — retro-harden as a follow-up.)
+
+## Open question this leg EXISTS to answer
+Does Tauri's `v1Compatible` Linux updater apply a **raw `.AppImage`** (what the shipped `latest.json` points at) in place? The artifact-format spike confirmed the shipped feed is self-consistent (raw `.AppImage` + `.AppImage.sig`), but whether the updater *applies* it is empirical. The advisory leg surfaces it on a real runner; if red, the script log distinguishes a **FUSE/harness** failure from a genuine **updater rejection**. A red here may mean Linux auto-update is broken in production — which would reframe this from a gate into a bug-fix + gate.

--- a/packages/accelerator/UPDATER_TESTING.md
+++ b/packages/accelerator/UPDATER_TESTING.md
@@ -65,10 +65,23 @@ retried step, so the chronic GH-runner DMG flake can't suppress updater signal;
 the N-1 selection aborts if it resolves to the same version under test (no
 no-op pass).
 
-**Status:** macOS (Apple Silicon + Intel) positive + an arm64 negative leg,
-**advisory** until validated on a `1.0.3-rc` dry-run, then promoted to
-release-blocking. A follow-up adds the Linux AppImage leg. Until macOS is
-blocking, run the manual steps above before promoting an rc to stable.
+**Status:** macOS (Apple Silicon + Intel) positive + an arm64 negative leg are
+**release-blocking** (in `tag.needs`) — validated on a `1.0.3-rc` dry-run, plus
+an Intel-DMG notarization check (`smoke-intel`). The macOS manual runbook above
+is therefore covered by CI; run it only as a belt-and-suspenders sanity check.
+
+**Linux (AppImage) — ADVISORY.** A Linux sibling (`update-smoke-linux` →
+`_e2e-updater-linux.yml` + `scripts/updater-smoke-linux.sh`) runs the same
+install-N-1 → auto-update → relaunch → `/health == N` check on `ubuntu-latest`
+(FUSE-native AppImage exec under Xvfb + dbus + a tray host; the local CA is
+trusted via `update-ca-certificates`, which both OpenSSL and
+`rustls-native-certs` read). It additionally asserts the on-disk AppImage's
+checksum changed (in-place swap). It is **advisory**: absent from `tag.needs`
+and `continue-on-error` inside the reusable workflow, with a failure downgraded
+to a `::warning::` + step-summary line — so it never blocks or reds a release.
+It exists to answer an open question: does Tauri's `v1Compatible` Linux updater
+actually apply a **raw `.AppImage`** in place? It flips to blocking (into
+`tag.needs`, hard-fail the step) after a proving green `-rc` dry-run.
 
 A `-rc` dry-run is safe for real users: prereleases skip the S3 `latest.json`
 upload and are marked `--prerelease --latest=false`, so the prod updater feed

--- a/packages/accelerator/scripts/updater-smoke-linux.sh
+++ b/packages/accelerator/scripts/updater-smoke-linux.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# Release-time updater smoke test (Linux / AppImage) — ADVISORY.
+#
+# Linux sibling of updater-smoke.sh (macOS). Proves a user on the previous stable
+# (N-1) AppImage can auto-update to the just-built, just-signed build (N) AND the
+# result relaunches reporting version N. This is the open question Tauri's
+# `v1Compatible` Linux updater raises: the shipped feed serves a RAW `.AppImage`
+# (+ `.AppImage.sig`) — does the updater actually apply it in place and re-exec?
+# This test answers that on a real runner. Advisory (NOT in `tag.needs`) until a
+# proving run; a red here is a SIGNAL about the Linux update path, not a release
+# blocker.
+#
+# How it works (no signing key needed — identical trust model to macOS):
+#   - We serve the ALREADY prod-signed N `.AppImage` from a local HTTPS server
+#     impersonating aztec-accelerator.dev (hosts entry + a local CA trusted via
+#     `update-ca-certificates`). The updater fetches over reqwest, whose Linux
+#     TLS (native-tls→OpenSSL OR rustls→rustls-native-certs — NO bundled
+#     webpki-roots in our tree) reads the SYSTEM trust store, so the local CA is
+#     honored. N-1 (unmodified) downloads N, verifies the `.sig` against its
+#     embedded prod minisign pubkey, swaps in place, and relaunches. We poll
+#     /health until it reports version == N.
+#
+# Differences from macOS (updater-smoke.sh):
+#   - CA trust   : update-ca-certificates (system store) vs keychain
+#   - install    : cp + chmod +x a writable `.AppImage` vs hdiutil/ditto a .app
+#   - execution  : AppImage runtime (needs FUSE — set up by the caller workflow)
+#                  sets $APPIMAGE, which the Tauri Linux updater replaces in place
+#   - no Gatekeeper/quarantine; GNU `sed -i` (no BSD '' arg)
+#   - display    : the caller workflow provides Xvfb + dbus + a tray host
+#
+# Usage:
+#   updater-smoke-linux.sh <n-version> <platform-key> <n-artifacts-dir> <n1-appimage> <repo-root>
+#     n-version       e.g. 1.0.3-rc.1   (the version being released)
+#     platform-key    linux-x86_64
+#     n-artifacts-dir dir with N's *.AppImage + *.AppImage.sig
+#     n1-appimage     path to the downloaded N-1 .AppImage
+#     repo-root       repo root (to locate the feed server script)
+set -euo pipefail
+
+N_VERSION="$1"
+PLATFORM_KEY="$2"
+N_ARTIFACTS_DIR="$3"
+N1_APPIMAGE="$4"
+REPO_ROOT="$5"
+
+# positive (default): expect the update to apply (/health reports N).
+# negative: serve a TAMPERED AppImage and assert the update is REJECTED. Set via
+#           UPDATER_SMOKE_MODE. (The macOS gate already proves signature teeth
+#           arch-independently; Linux ships positive-only first, but the mode is
+#           wired so a negative leg is a one-line matrix add later.)
+MODE="${UPDATER_SMOKE_MODE:-positive}"
+
+HEALTH="http://127.0.0.1:59833/health"
+HOST="aztec-accelerator.dev"
+CONFIG_DIR="$HOME/.aztec-accelerator"
+APP_DIR="$HOME/Applications"
+APP_BIN="$APP_DIR/aztec-accelerator.AppImage"
+CA_DEST="/usr/local/share/ca-certificates/updater-smoke-local-CA.crt"
+WORK="$(mktemp -d)"
+SERVE_DIR="$WORK/serve"
+mkdir -p "$SERVE_DIR" "$APP_DIR"
+
+FEED_PID=""
+APP_PID=""
+
+log() { echo "── $* ──"; }
+
+# shellcheck disable=SC2329  # invoked indirectly via `trap cleanup EXIT`
+cleanup() {
+  set +e
+  [ -n "$APP_PID" ] && kill "$APP_PID" 2>/dev/null
+  pkill -f "aztec-accelerator.AppImage" 2>/dev/null
+  pkill -f "aztec-accelerator" 2>/dev/null
+  [ -n "$FEED_PID" ] && sudo kill "$FEED_PID" 2>/dev/null
+  # best-effort: drop ONLY the exact line we added (anchored + dots escaped, so
+  # the host's literal '.' can't match an arbitrary char) — avoids clobbering an
+  # unrelated entry on a self-hosted runner.
+  host_re="${HOST//./\\.}"
+  sudo sed -i "/^127\\.0\\.0\\.1 $host_re\$/d" /etc/hosts 2>/dev/null
+  # best-effort: drop the test CA (matters only on non-ephemeral / self-hosted
+  # runners; GH-hosted VMs are torn down after the job).
+  sudo rm -f "$CA_DEST" 2>/dev/null
+  sudo update-ca-certificates --fresh >/dev/null 2>&1
+}
+trap cleanup EXIT
+
+# ── Locate N's signed updater artifact ──
+N_APPIMAGE="$(find "$N_ARTIFACTS_DIR" -name '*.AppImage' | head -1)"
+N_SIG_FILE="$(find "$N_ARTIFACTS_DIR" -name '*.AppImage.sig' | head -1)"
+[ -n "$N_APPIMAGE" ] || { echo "::error::no *.AppImage in $N_ARTIFACTS_DIR"; exit 1; }
+[ -n "$N_SIG_FILE" ] || { echo "::error::no *.AppImage.sig in $N_ARTIFACTS_DIR"; exit 1; }
+N_BASENAME="$(basename "$N_APPIMAGE")"
+cp "$N_APPIMAGE" "$SERVE_DIR/$N_BASENAME"
+N_SIG="$(cat "$N_SIG_FILE")"
+log "N artifact: $N_BASENAME"
+
+# Negative control: serve the GENUINE signature but a TAMPERED AppImage (append a
+# byte). The updater downloads the artifact, then the minisign check over the
+# tampered bytes MUST fail against the embedded pubkey — exercising real
+# cryptographic verification (not a malformed-base64 parse error). The genuine
+# sig is left untouched so the only fault is the artifact↔signature mismatch.
+if [ "$MODE" = "negative" ]; then
+  printf 'x' >> "$SERVE_DIR/$N_BASENAME"
+  log "NEGATIVE mode: serving a TAMPERED AppImage with the genuine signature — expecting REJECTION (no update)"
+fi
+
+# ── Local CA + leaf cert (SAN = the prod host) ──
+log "generating local CA + leaf (SAN=$HOST)"
+openssl req -x509 -newkey rsa:2048 -nodes -keyout "$WORK/ca.key" -out "$WORK/ca.pem" \
+  -days 2 -subj "/CN=updater-smoke-local-CA" >/dev/null 2>&1
+openssl req -newkey rsa:2048 -nodes -keyout "$WORK/leaf.key" -out "$WORK/leaf.csr" \
+  -subj "/CN=$HOST" >/dev/null 2>&1
+cat > "$WORK/leaf.ext" <<EXT
+subjectAltName=DNS:$HOST
+extendedKeyUsage=serverAuth
+EXT
+openssl x509 -req -in "$WORK/leaf.csr" -CA "$WORK/ca.pem" -CAkey "$WORK/ca.key" \
+  -CAcreateserial -out "$WORK/leaf.pem" -days 2 -extfile "$WORK/leaf.ext" >/dev/null 2>&1
+
+# ── Trust the CA (system store) + impersonate the host ──
+# update-ca-certificates regenerates /etc/ssl/certs/ca-certificates.crt, which
+# BOTH OpenSSL (native-tls) and rustls-native-certs read — so whichever TLS path
+# reqwest takes inside tauri-plugin-updater, the local CA is trusted.
+log "trusting CA (update-ca-certificates) + adding hosts entry"
+sudo cp "$WORK/ca.pem" "$CA_DEST"
+sudo update-ca-certificates >/dev/null 2>&1
+echo "127.0.0.1 $HOST" | sudo tee -a /etc/hosts >/dev/null
+
+# ── Synthesize latest.json for N ──
+jq -n --arg v "$N_VERSION" --arg key "$PLATFORM_KEY" --arg sig "$N_SIG" \
+  --arg url "https://$HOST/releases/download/$N_BASENAME" \
+  '{version:$v, notes:("updater smoke "+$v), pub_date:"2026-01-01T00:00:00Z",
+    platforms: { ($key): { signature:$sig, url:$url } }}' > "$WORK/latest.json"
+log "latest.json:"; cat "$WORK/latest.json"
+
+# ── Start the local HTTPS feed on :443 ──
+log "starting feed server on :443"
+# sudo for :443; the redirect is opened by this (user) shell so feed.log lands in
+# the user-owned workdir — intended, hence SC2024 is not a concern here.
+# shellcheck disable=SC2024
+sudo "$(command -v bun)" "$REPO_ROOT/packages/accelerator/scripts/updater-feed-server.ts" \
+  --cert "$WORK/leaf.pem" --key "$WORK/leaf.key" \
+  --latest-json "$WORK/latest.json" --serve-dir "$SERVE_DIR" > "$WORK/feed.log" 2>&1 &
+FEED_PID=$!
+for _ in $(seq 1 20); do
+  curl -sf "https://$HOST/releases/latest.json" >/dev/null 2>&1 && break
+  sleep 0.5
+done
+curl -sf "https://$HOST/releases/latest.json" >/dev/null || { echo "::error::feed server not reachable"; cat "$WORK/feed.log"; exit 1; }
+
+# ── Install N-1 to a writable path + make it executable ──
+# A real user's AppImage lives at a writable path; the Tauri Linux updater
+# replaces the file at $APPIMAGE in place, so this MUST be user-writable (it is —
+# $HOME/Applications). Run natively (FUSE, provided by the caller workflow) so
+# the AppImage runtime sets $APPIMAGE for the in-place swap.
+log "installing N-1 → $APP_BIN"
+rm -f "$APP_BIN"
+cp "$N1_APPIMAGE" "$APP_BIN"
+chmod +x "$APP_BIN"
+
+# ── Pre-seed auto-update so N-1 updates without UI ──
+mkdir -p "$CONFIG_DIR"
+echo '{"config_version":1,"safari_support":false,"approved_origins":[],"speed":"full","auto_update":true}' > "$CONFIG_DIR/config.json"
+
+# ── Launch N-1; it should auto-update to N and relaunch ──
+log "launching N-1 (expecting auto-update → N)"
+"$APP_BIN" > "$WORK/app.log" 2>&1 &
+APP_PID=$!
+
+dump_logs() {
+  echo "── app log ──"; cat "$WORK/app.log" 2>/dev/null || true
+  echo "── feed log ──"; cat "$WORK/feed.log" 2>/dev/null || true
+  echo "── last /health ──"; curl -s "$HEALTH" 2>/dev/null || true
+  # AppImage/FUSE failures surface here (e.g. "dlopen(): error loading libfuse")
+  # — distinguishes a harness/FUSE problem from a genuine updater rejection.
+  if ! kill -0 "$APP_PID" 2>/dev/null; then
+    echo "── NOTE: N-1 process exited (crash or FUSE/AppImage launch failure — see app log above) ──"
+  fi
+}
+
+if [ "$MODE" = "negative" ]; then
+  # Teeth check: the tampered AppImage MUST be rejected. /health must NEVER report
+  # N (no swap). If it ever does, signature verification has no teeth.
+  log "NEGATIVE: asserting /health never reports $N_VERSION (tampered artifact rejected), 120s"
+  for _ in $(seq 1 60); do
+    GOT="$(curl -sf "$HEALTH" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || true)"
+    if [ "$GOT" = "$N_VERSION" ]; then
+      echo "::error::NEGATIVE FAILED — a TAMPERED artifact was ACCEPTED; app updated to $N_VERSION. The updater is not verifying signatures."
+      dump_logs
+      exit 1
+    fi
+    sleep 2
+  done
+  if ! grep -q "/releases/download/" "$WORK/feed.log" 2>/dev/null; then
+    echo "::error::NEGATIVE inconclusive — the updater never downloaded the artifact (no download/ hit), so signature rejection was not actually exercised."
+    dump_logs
+    exit 1
+  fi
+  log "SUCCESS (negative) — updater downloaded the tampered artifact and refused to update to $N_VERSION"
+  dump_logs
+  exit 0
+fi
+
+# ── Positive: poll /health until version == N (N-1 also answers /health 'ok'
+#    with its OWN version, so only version==N counts) ──
+log "polling $HEALTH for version == $N_VERSION (up to 300s)"
+for _ in $(seq 1 150); do
+  GOT="$(curl -sf "$HEALTH" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || true)"
+  if [ "$GOT" = "$N_VERSION" ]; then
+    # Guard against a no-op pass: the version flip must have come from OUR feed.
+    # Assert a /releases/download/ hit — the app only requests that when it
+    # actually downloads N. (We do NOT assert latest.json: our own readiness
+    # probe curls it, so it can't prove the app fetched the feed.)
+    if ! grep -q "/releases/download/" "$WORK/feed.log" 2>/dev/null; then
+      echo "::error::/health reports $N_VERSION but the feed log has no download/ hit — the update did not flow through our feed."
+      dump_logs
+      exit 1
+    fi
+    log "SUCCESS — updated to $GOT via the local feed (artifact downloaded)"
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "::error::updater smoke failed — /health never reported version $N_VERSION (advisory: this may indicate Tauri's Linux updater does not apply a raw .AppImage — see app log for FUSE vs updater-reject signal)"
+dump_logs
+exit 1

--- a/packages/accelerator/scripts/updater-smoke-linux.sh
+++ b/packages/accelerator/scripts/updater-smoke-linux.sh
@@ -55,7 +55,12 @@ HOST="aztec-accelerator.dev"
 CONFIG_DIR="$HOME/.aztec-accelerator"
 APP_DIR="$HOME/Applications"
 APP_BIN="$APP_DIR/aztec-accelerator.AppImage"
-CA_DEST="/usr/local/share/ca-certificates/updater-smoke-local-CA.crt"
+# Run-unique CA name (CN + on-disk filename) so cleanup removes only THIS run's
+# trust anchor — a fixed name could clobber a concurrent/leftover entry on a
+# non-ephemeral self-hosted runner. (Plan security item; the macOS script's
+# fixed-name retro-hardening is tracked as a separate follow-up.)
+CA_ID="updater-smoke-local-CA-${GITHUB_RUN_ID:-$$}-${GITHUB_RUN_ATTEMPT:-0}"
+CA_DEST="/usr/local/share/ca-certificates/${CA_ID}.crt"
 WORK="$(mktemp -d)"
 SERVE_DIR="$WORK/serve"
 mkdir -p "$SERVE_DIR" "$APP_DIR"
@@ -90,9 +95,12 @@ N_SIG_FILE="$(find "$N_ARTIFACTS_DIR" -name '*.AppImage.sig' | head -1)"
 [ -n "$N_APPIMAGE" ] || { echo "::error::no *.AppImage in $N_ARTIFACTS_DIR"; exit 1; }
 [ -n "$N_SIG_FILE" ] || { echo "::error::no *.AppImage.sig in $N_ARTIFACTS_DIR"; exit 1; }
 N_BASENAME="$(basename "$N_APPIMAGE")"
+# Genuine N checksum, captured BEFORE the optional negative-mode tamper, so the
+# positive path can assert the on-disk swap landed exactly N's bytes.
+N_SUM="$(sha256sum "$N_APPIMAGE" | awk '{print $1}')"
 cp "$N_APPIMAGE" "$SERVE_DIR/$N_BASENAME"
 N_SIG="$(cat "$N_SIG_FILE")"
-log "N artifact: $N_BASENAME"
+log "N artifact: $N_BASENAME (sha256=$N_SUM)"
 
 # Negative control: serve the GENUINE signature but a TAMPERED AppImage (append a
 # byte). The updater downloads the artifact, then the minisign check over the
@@ -107,7 +115,7 @@ fi
 # ── Local CA + leaf cert (SAN = the prod host) ──
 log "generating local CA + leaf (SAN=$HOST)"
 openssl req -x509 -newkey rsa:2048 -nodes -keyout "$WORK/ca.key" -out "$WORK/ca.pem" \
-  -days 2 -subj "/CN=updater-smoke-local-CA" >/dev/null 2>&1
+  -days 2 -subj "/CN=$CA_ID" >/dev/null 2>&1
 openssl req -newkey rsa:2048 -nodes -keyout "$WORK/leaf.key" -out "$WORK/leaf.csr" \
   -subj "/CN=$HOST" >/dev/null 2>&1
 cat > "$WORK/leaf.ext" <<EXT
@@ -157,6 +165,11 @@ log "installing N-1 → $APP_BIN"
 rm -f "$APP_BIN"
 cp "$N1_APPIMAGE" "$APP_BIN"
 chmod +x "$APP_BIN"
+# Baseline on-disk checksum — the positive path asserts this CHANGED after the
+# update (proves the in-place swap physically replaced the file, not just that
+# /health happens to report N from some other process).
+N1_SUM="$(sha256sum "$APP_BIN" | awk '{print $1}')"
+log "N-1 on-disk sha256=$N1_SUM"
 
 # ── Pre-seed auto-update so N-1 updates without UI ──
 mkdir -p "$CONFIG_DIR"
@@ -216,7 +229,21 @@ for _ in $(seq 1 150); do
       dump_logs
       exit 1
     fi
-    log "SUCCESS — updated to $GOT via the local feed (artifact downloaded)"
+    # In-place-swap proof: the on-disk AppImage must have CHANGED from N-1. A
+    # version flip with an unchanged file would mean Tauri reported N without
+    # actually replacing $APPIMAGE (a non-in-place path we'd want to know about).
+    POST_SUM="$(sha256sum "$APP_BIN" 2>/dev/null | awk '{print $1}')"
+    if [ "$POST_SUM" = "$N1_SUM" ]; then
+      echo "::error::/health reports $N_VERSION and the feed was hit, but the on-disk AppImage ($APP_BIN) is UNCHANGED (sha256 still $N1_SUM) — the in-place swap did not happen."
+      dump_logs
+      exit 1
+    fi
+    if [ "$POST_SUM" = "$N_SUM" ]; then
+      log "in-place swap confirmed — $APP_BIN now matches the served N artifact (sha256=$N_SUM)"
+    else
+      log "NOTE: post-update sha256=$POST_SUM changed from N-1 but differs from the served N ($N_SUM) — swapped via a re-pack path; /health==N + download hit still confirm the update applied"
+    fi
+    log "SUCCESS — updated to $GOT via the local feed (artifact downloaded + in-place swap)"
     exit 0
   fi
   sleep 2


### PR DESCRIPTION
## Phase A2b — Linux AppImage updater-smoke (ADVISORY)

Final leg of the CI/release overhaul. Adds a Linux/AppImage sibling of the proven macOS updater smoke, wired as an **advisory** release leg.

### What it does
Installs the previous stable (N-1) `.AppImage`, serves the just-built+signed **N** `.AppImage` from a local HTTPS feed impersonating `aztec-accelerator.dev`, and asserts N-1 **auto-updates to N and relaunches reporting `/health == N`** — the Linux analogue of the macOS amfid-class check.

### Why advisory (for now)
It answers an **open question**: does Tauri's `v1Compatible` Linux updater actually apply a *raw* `.AppImage` in place? The shipped feed serves a raw `.AppImage` + `.sig`, but whether the updater applies it (vs erroring) is unproven. So a red here is **signal about the Linux update path, not a release blocker**:

- absent from `tag.needs` / `release.needs` (cannot block the ship)
- `continue-on-error` on the smoke step inside the reusable workflow, with a `::warning::` + step-summary downgrade (GitHub forbids `continue-on-error` on a `uses:` caller job)
- the script's log disambiguates a **FUSE/harness** failure from a genuine **updater rejection**

Flips to blocking (into `tag.needs`, hard-fail the step) after a proving run.

### Trust model (no signing key needed)
Serves the already-prod-signed N artifact; N-1 verifies the `.sig` against its **embedded minisign pubkey**. The local CA is trusted via `update-ca-certificates` — Linux `reqwest` TLS reads the **system store** (native-tls→OpenSSL or rustls→`rustls-native-certs`; **no `webpki-roots`** in the dep tree), so host impersonation works exactly like the macOS keychain path.

### Files
- `packages/accelerator/scripts/updater-smoke-linux.sh` — FUSE-native exec (sets `$APPIMAGE` for the in-place swap), GNU `sed`, system-CA trust; positive + negative modes
- `.github/workflows/_e2e-updater-linux.yml` — `libfuse2` + Xvfb + dbus + stalonetray; N-1 no-op guard
- `release-accelerator.yml` — `update-smoke-linux` advisory job

### Validation
- `shellcheck` + `actionlint` clean
- rc dry-run (in flight) to observe the advisory leg's real behavior on a runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)
