### PR TITLE
fix(accelerator): retry server bind on EADDRINUSE to survive updater restart

### DIFF
--- a/packages/accelerator/src-tauri/src/server.rs
+++ b/packages/accelerator/src-tauri/src/server.rs
@@ -61,11 +61,14 @@ pub async fn start(state: AppState) -> Result<(), Box<dyn std::error::Error + Se
 /// so a genuine conflict — a second instance the user started — still fails
 /// fast with the port-in-use signal (surfaced by main.rs) instead of hanging.
 async fn bind_with_retry(addr: SocketAddr) -> std::io::Result<TcpListener> {
-    bind_with_retry_inner(addr, Duration::from_millis(500), Duration::from_secs(10)).await
+    // 100ms polling, 5s budget: the restart overlap clears in well under a
+    // second, so this is responsive AND fails a genuine second-instance
+    // conflict reasonably fast (it surfaces "port in use" rather than stalling).
+    bind_with_retry_inner(addr, Duration::from_millis(100), Duration::from_secs(5)).await
 }
 
-/// Inner form with injectable timings so tests can exercise both the
-/// wait-it-out and give-up paths without real-time sleeps.
+/// Inner form with injectable timings so tests can exercise the wait-it-out,
+/// hard-deadline, and immediate-propagation paths without real-time sleeps.
 async fn bind_with_retry_inner(
     addr: SocketAddr,
     interval: Duration,
@@ -76,13 +79,17 @@ async fn bind_with_retry_inner(
     loop {
         match TcpListener::bind(addr).await {
             Ok(listener) => return Ok(listener),
-            // Retry only on AddrInUse, and only within the budget — any other
-            // bind error (or a timed-out conflict) propagates so the caller can
-            // surface it instead of silently looping.
-            Err(e)
-                if e.kind() == std::io::ErrorKind::AddrInUse
-                    && std::time::Instant::now() < deadline =>
-            {
+            Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+                // Hard deadline: sleep only the time actually left, so we give up
+                // at ~max_wait rather than overshooting by a full `interval`.
+                let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+                if remaining.is_zero() {
+                    tracing::warn!(
+                        "port {} still in use after {max_wait:?} — giving up",
+                        addr.port()
+                    );
+                    return Err(e);
+                }
                 if !warned {
                     tracing::warn!(
                         "port {} in use — retrying for up to {max_wait:?} (waiting out a prior instance, e.g. an in-place updater restart)",
@@ -90,8 +97,9 @@ async fn bind_with_retry_inner(
                     );
                     warned = true;
                 }
-                tokio::time::sleep(interval).await;
+                tokio::time::sleep(interval.min(remaining)).await;
             }
+            // Any non-AddrInUse error propagates immediately — never masked by the retry.
             Err(e) => return Err(e),
         }
     }
@@ -565,20 +573,47 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bind_with_retry_gives_up_on_a_persistent_conflict() {
+    async fn bind_with_retry_gives_up_on_a_persistent_conflict_at_a_hard_deadline() {
         // A second instance, not a restart overlap: a port held for the whole
-        // window must fail fast with AddrInUse (so main.rs surfaces "port in
-        // use") rather than hang.
+        // window must fail with AddrInUse (so main.rs surfaces "port in use").
+        // `interval` is deliberately LARGER than `budget` so a HARD deadline caps
+        // at ~budget (sleeping only the remaining time) while a SOFT one would
+        // sleep a full interval and overshoot — the elapsed assertion catches
+        // that regression.
         let probe = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
             .await
             .unwrap();
         let addr = probe.local_addr().unwrap();
-        let err =
-            bind_with_retry_inner(addr, Duration::from_millis(20), Duration::from_millis(150))
-                .await
-                .expect_err("should give up while the port stays held");
+        let budget = Duration::from_millis(200);
+        let interval = Duration::from_millis(500);
+        let started = std::time::Instant::now();
+        let err = bind_with_retry_inner(addr, interval, budget)
+            .await
+            .expect_err("should give up while the port stays held");
+        let elapsed = started.elapsed();
         assert_eq!(err.kind(), std::io::ErrorKind::AddrInUse);
+        assert!(
+            elapsed < budget + Duration::from_millis(150),
+            "hard deadline overshot: {elapsed:?} (budget {budget:?}, interval {interval:?}) — a soft deadline would sleep a full interval past the budget"
+        );
         drop(probe);
+    }
+
+    #[tokio::test]
+    async fn bind_with_retry_propagates_non_addrinuse_immediately() {
+        // An unassigned TEST-NET-1 address (RFC 5737) can't be bound →
+        // AddrNotAvailable, NOT AddrInUse. It must return at once, never entering
+        // the retry budget (a 10s budget would expose a wrongful retry).
+        let bad = SocketAddr::from(([192, 0, 2, 1], 0));
+        let started = std::time::Instant::now();
+        let err = bind_with_retry_inner(bad, Duration::from_millis(100), Duration::from_secs(10))
+            .await
+            .expect_err("binding an unassigned address must fail");
+        assert_ne!(err.kind(), std::io::ErrorKind::AddrInUse);
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "a non-AddrInUse error must propagate immediately, not retry for the budget"
+        );
     }
 
     #[tokio::test]

--- a/packages/accelerator/src-tauri/src/server.rs
+++ b/packages/accelerator/src-tauri/src/server.rs
@@ -113,7 +113,11 @@ pub async fn start_https(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let app = router(state);
     let addr = SocketAddr::from(([127, 0, 0, 1], HTTPS_PORT));
-    let listener = match TcpListener::bind(addr).await {
+    // Same restart race as the HTTP listener: an in-place update relaunches while
+    // the old process still holds 59834. Retry first; only fall back to HTTP-only
+    // if the port is genuinely unavailable past the budget (HTTPS must never
+    // crash the app — it's optional Safari support).
+    let listener = match bind_with_retry(addr).await {
         Ok(l) => l,
         Err(e) => {
             tracing::warn!("HTTPS port {HTTPS_PORT} unavailable: {e} — continuing HTTP-only");

--- a/packages/accelerator/src-tauri/src/server.rs
+++ b/packages/accelerator/src-tauri/src/server.rs
@@ -45,10 +45,56 @@ pub struct AppState {
 pub async fn start(state: AppState) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let app = router(state);
     let addr = SocketAddr::from(([127, 0, 0, 1], PORT));
-    let listener = TcpListener::bind(addr).await?;
+    let listener = bind_with_retry(addr).await?;
     tracing::info!("Accelerator server listening on {addr}");
     axum::serve(listener, app).await?;
     Ok(())
+}
+
+/// Bind the HTTP listener, retrying briefly on `AddrInUse`.
+///
+/// During an in-place updater restart the just-exited previous instance can
+/// still hold port 59833 for a moment. Without a retry the freshly-relaunched
+/// app permanently fails to bind and the accelerator server stays down — the
+/// new process binds once, hits `EADDRINUSE`, and never recovers (observed on
+/// Linux auto-update; macOS happens to dodge it on timing). The wait is bounded
+/// so a genuine conflict — a second instance the user started — still fails
+/// fast with the port-in-use signal (surfaced by main.rs) instead of hanging.
+async fn bind_with_retry(addr: SocketAddr) -> std::io::Result<TcpListener> {
+    bind_with_retry_inner(addr, Duration::from_millis(500), Duration::from_secs(10)).await
+}
+
+/// Inner form with injectable timings so tests can exercise both the
+/// wait-it-out and give-up paths without real-time sleeps.
+async fn bind_with_retry_inner(
+    addr: SocketAddr,
+    interval: Duration,
+    max_wait: Duration,
+) -> std::io::Result<TcpListener> {
+    let deadline = std::time::Instant::now() + max_wait;
+    let mut warned = false;
+    loop {
+        match TcpListener::bind(addr).await {
+            Ok(listener) => return Ok(listener),
+            // Retry only on AddrInUse, and only within the budget — any other
+            // bind error (or a timed-out conflict) propagates so the caller can
+            // surface it instead of silently looping.
+            Err(e)
+                if e.kind() == std::io::ErrorKind::AddrInUse
+                    && std::time::Instant::now() < deadline =>
+            {
+                if !warned {
+                    tracing::warn!(
+                        "port {} in use — retrying for up to {max_wait:?} (waiting out a prior instance, e.g. an in-place updater restart)",
+                        addr.port()
+                    );
+                    warned = true;
+                }
+                tokio::time::sleep(interval).await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
 }
 
 /// Start an HTTPS listener using the provided TLS config.
@@ -498,6 +544,42 @@ mod tests {
     use axum::body::Body;
     use axum::http::Request;
     use tower::util::ServiceExt;
+
+    #[tokio::test]
+    async fn bind_with_retry_waits_out_a_transient_holder() {
+        // The in-place-restart case: hold a freshly-chosen port, release it
+        // shortly, and assert the retry binds once it frees.
+        let probe = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .await
+            .unwrap();
+        let addr = probe.local_addr().unwrap();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(80)).await;
+            drop(probe);
+        });
+        let listener =
+            bind_with_retry_inner(addr, Duration::from_millis(20), Duration::from_secs(2))
+                .await
+                .expect("should bind once the transient holder releases the port");
+        assert_eq!(listener.local_addr().unwrap().port(), addr.port());
+    }
+
+    #[tokio::test]
+    async fn bind_with_retry_gives_up_on_a_persistent_conflict() {
+        // A second instance, not a restart overlap: a port held for the whole
+        // window must fail fast with AddrInUse (so main.rs surfaces "port in
+        // use") rather than hang.
+        let probe = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .await
+            .unwrap();
+        let addr = probe.local_addr().unwrap();
+        let err =
+            bind_with_retry_inner(addr, Duration::from_millis(20), Duration::from_millis(150))
+                .await
+                .expect_err("should give up while the port stays held");
+        assert_eq!(err.kind(), std::io::ErrorKind::AddrInUse);
+        drop(probe);
+    }
 
     #[tokio::test]
     async fn health_returns_ok() {


### PR DESCRIPTION
## Fix: retry the accelerator-server bind on `EADDRINUSE`

The CI/release overhaul's **Linux advisory updater-smoke** (`update-smoke-linux`, just landed in #250) found a real bug on its first proving run (1.0.3-rc.10):

Tauri's `v1Compatible` Linux updater **works** — it applies a raw `.AppImage` in place and relaunches. But the relaunched process fails to rebind `127.0.0.1:59833`:

```
Update installed, restarting
Logging initialized                  ← new (rc.10) process
ERROR Accelerator server error: Address already in use (os error 98)
```

The just-exited previous instance still holds the port during the restart overlap, the server binds **once** (`server.rs::start`), hits `EADDRINUSE`, and never recovers — so the accelerator server stays **down** on the freshly-updated app until a manual restart. macOS dodges it on timing; Linux's slower restart makes it deterministic (CI runners widen the window).

### Fix
Wrap the bind in a **bounded retry** (`bind_with_retry`): 500 ms interval, up to 10 s.
- Retries **only** on `AddrInUse` and **only** within the budget.
- Any other bind error, or a conflict that outlives the budget (a genuinely second running instance), **propagates** so `main.rs` surfaces the existing `"Error: port 59833 in use"` tray message instead of hanging.
- `SO_REUSEADDR` would **not** help here: the old socket is a still-*open* listener (not a closed/`TIME_WAIT` socket), so only waiting it out works.

### Tests
- `bind_with_retry_waits_out_a_transient_holder` — holds an ephemeral port, releases it mid-window, asserts the bind succeeds (the restart case).
- `bind_with_retry_gives_up_on_a_persistent_conflict` — port held the whole window → fails fast with `AddrInUse` (the second-instance case).

Both use ephemeral ports (parallel-safe; never touch the real `:59833`), run in <2 s.

### Follow-up
Unblocks flipping the Linux updater-smoke leg from **advisory → blocking** once a dry-run confirms it now goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
