### PR TITLE
fix(ci): stop the Linux updater smoke from SIGTERMing itself

### DIFF
--- a/packages/accelerator/scripts/updater-smoke-linux.sh
+++ b/packages/accelerator/scripts/updater-smoke-linux.sh
@@ -74,8 +74,12 @@ log() { echo "── $* ──"; }
 cleanup() {
   set +e
   [ -n "$APP_PID" ] && kill "$APP_PID" 2>/dev/null
-  pkill -f "aztec-accelerator.AppImage" 2>/dev/null
-  pkill -f "aztec-accelerator" 2>/dev/null
+  # Kill the (possibly relaunched) app by its AppImage path ONLY, dot escaped.
+  # A broad `pkill -f aztec-accelerator` ALSO matches THIS script's own argv —
+  # the repo checkout path contains "aztec-accelerator" — so it SIGTERMs the
+  # script itself mid-cleanup (exit 143), turning a real PASS into a spurious
+  # failure. (That false failure was observed on the 1.0.3-rc.11 dry-run.)
+  pkill -f "aztec-accelerator\.AppImage" 2>/dev/null
   [ -n "$FEED_PID" ] && sudo kill "$FEED_PID" 2>/dev/null
   # best-effort: drop ONLY the exact line we added (anchored + dots escaped, so
   # the host's literal '.' can't match an arbitrary char) — avoids clobbering an


### PR DESCRIPTION
## Fix: Linux updater smoke SIGTERMs itself (false failure)

The 1.0.3-rc.11 dry-run validated the [server bind-retry fix](https://github.com/alejoamiras/aztec-accelerator/pull/251) end-to-end — the smoke reached its `SUCCESS` line:

```
in-place swap confirmed — AppImage matches the served N (sha256 216f…)
SUCCESS — updated to 1.0.3-rc.11 (artifact downloaded + in-place swap)
##[error]Process completed with exit code 143      ← SIGTERM, AFTER success
```

…then exited **143** (SIGTERM), which flipped a real PASS into a spurious step failure and a **false advisory `FAILED` warning**.

### Cause
The cleanup trap ran `pkill -f "aztec-accelerator"`. The script's own argv contains the repo checkout path (`…/aztec-accelerator/…`), so `pkill` matched and **SIGTERMed the script itself** mid-cleanup. macOS was never affected — its pattern is `"Aztec Accelerator.app"`, which its script path doesn't contain.

### Fix
Drop the broad pattern; keep only the AppImage-path-specific `pkill -f "aztec-accelerator\.AppImage"` (dot escaped → literal match), which matches the relaunched app process but never the script.

### Impact
This is a **CI-harness** fix only — no product code. It's the last thing between the Linux advisory leg and a true green; with #251 (app fix) + this merged, the leg passes cleanly and can flip advisory → blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
