### PR TITLE
ci(release): flip Linux updater-smoke to blocking

### DIFF
--- a/.github/workflows/_e2e-updater-linux.yml
+++ b/.github/workflows/_e2e-updater-linux.yml
@@ -112,13 +112,13 @@ jobs:
           mkdir -p n1
           gh release download "$N1_TAG" --pattern "${{ inputs.n1-appimage-glob }}" --dir n1
 
-      # ADVISORY: continue-on-error so a Linux-updater failure does NOT fail this
-      # job (and thus never reds the release run via the caller). The result is
-      # downgraded to a warning in the next step. To make this BLOCKING later,
-      # delete `continue-on-error` here and add this job to `tag.needs`.
+      # BLOCKING: this job is in release-accelerator.yml's `tag.needs` /
+      # `release.needs`, so a failure here fails the job → blocks the release.
+      # Validated green on a 1.0.3-rc dry-run before the flip. To revert to
+      # advisory: restore `continue-on-error` here + drop the job from tag/release
+      # `needs`. The script's own ::error:: (and the FUSE-vs-updater-reject log
+      # disambiguation) explain any failure.
       - name: Updater smoke (install N-1 → auto-update to N → assert /health == N)
-        id: smoke
-        continue-on-error: true
         env:
           UPDATER_SMOKE_MODE: ${{ inputs.mode }}
         run: |
@@ -131,15 +131,6 @@ jobs:
             "$APPIMAGE" \
             "$GITHUB_WORKSPACE"
 
-      # Surface the advisory outcome WITHOUT failing the run: a green job here
-      # means "the advisory ran", not "the update worked" — read this step.
-      - name: Advisory result (never fails the run)
-        if: always()
-        run: |
-          if [ "${{ steps.smoke.outcome }}" = "success" ]; then
-            echo "✅ Linux AppImage updater smoke PASSED — Tauri applied the raw .AppImage and relaunched on N." >> "$GITHUB_STEP_SUMMARY"
-            echo "Linux AppImage updater smoke PASSED"
-          else
-            echo "::warning::Linux AppImage updater smoke FAILED (ADVISORY — not a release blocker). Signals Tauri's v1Compatible Linux updater may not apply a raw .AppImage in place, or a FUSE/display harness issue. See the smoke step log."
-            echo "⚠️ Linux AppImage updater smoke FAILED (advisory) — see the 'Updater smoke' step log for the FUSE-vs-updater-reject signal." >> "$GITHUB_STEP_SUMMARY"
-          fi
+      - name: Result summary
+        if: success()
+        run: echo "✅ Linux AppImage updater smoke PASSED — Tauri applied the raw .AppImage and relaunched on N." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-accelerator.yml
+++ b/.github/workflows/release-accelerator.yml
@@ -469,16 +469,14 @@ jobs:
       n1-dmg-glob: ${{ matrix.n1-dmg-glob }}
       mode: ${{ matrix.mode }}
 
-  # Linux/AppImage updater smoke — ADVISORY. Deliberately ABSENT from `tag.needs`
-  # / `release.needs`, so it never blocks the ship. The advisory semantics live
-  # INSIDE the reusable workflow (the smoke step is `continue-on-error` and a
-  # failure is downgraded to a ::warning:: + step summary) because GitHub forbids
-  # `continue-on-error` on a `uses:` caller job — so this job stays green while
-  # still surfacing the signal. It answers the open `v1Compatible` question (does
-  # Tauri apply a raw .AppImage in place?) on a real runner; it flips to blocking
-  # (move into `tag.needs`, make the step hard-fail) only after a proving run.
+  # Linux/AppImage updater smoke — BLOCKING (in `tag.needs` + `release.needs`).
+  # Proves a user on the previous stable AppImage auto-updates to N AND the
+  # relaunched app rebinds :59833 — the EADDRINUSE restart race fixed by the
+  # server's bind-retry (#251). Started advisory; flipped to blocking after a
+  # green 1.0.3-rc dry-run. To revert: drop it from tag/release `needs` and
+  # restore `continue-on-error` on the smoke step in _e2e-updater-linux.yml.
   update-smoke-linux:
-    name: Updater Smoke (linux-x86_64 / positive, advisory)
+    name: Updater Smoke (linux-x86_64 / positive)
     needs: [validate, build, e2e-webdriver]
     if: ${{ !cancelled() && needs.validate.result == 'success' }}
     uses: ./.github/workflows/_e2e-updater-linux.yml
@@ -487,7 +485,7 @@ jobs:
 
   tag:
     name: Create Git Tag
-    needs: [validate, build, build-headless, smoke, smoke-intel, update-smoke, e2e-webdriver]
+    needs: [validate, build, build-headless, smoke, smoke-intel, update-smoke, update-smoke-linux, e2e-webdriver]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -510,7 +508,7 @@ jobs:
 
   release:
     name: Create GitHub Release
-    needs: [validate, build, build-headless, smoke, smoke-intel, update-smoke, tag, e2e-webdriver]
+    needs: [validate, build, build-headless, smoke, smoke-intel, update-smoke, update-smoke-linux, tag, e2e-webdriver]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
## Flip Linux updater-smoke: advisory → blocking

Final step of the Linux updater work. With the [bind-retry fix (#251)](https://github.com/alejoamiras/aztec-accelerator/pull/251) and the [smoke self-kill fix (#252)](https://github.com/alejoamiras/aztec-accelerator/pull/252) merged, the Linux updater-smoke leg goes **cleanly green** — proven on the **1.0.3-rc.12** dry-run (smoke step conclusion `success`, in-place swap confirmed, `/health == N`).

### Change
- `update-smoke-linux` added to `tag.needs` + `release.needs` → a Linux auto-update regression now **blocks the release** (same bar as the macOS legs).
- Dropped `continue-on-error` on the smoke step in `_e2e-updater-linux.yml` (failures now hard-fail); replaced the advisory failure-downgrade with a success-only summary.

### Validation
- `actionlint` clean.
- **rc.13** dry-run (this branch) confirms the now-blocking leg passes *and* the release still tags/releases green before merge.

### Revert
Drop the job from tag/release `needs` + restore `continue-on-error` on the smoke step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
