### PR TITLE
ci: fix shellcheck SC2317/SC2329 in the release-bot smoke

### DIFF
--- a/.github/workflows/release-bot-token-check.yml
+++ b/.github/workflows/release-bot-token-check.yml
@@ -45,7 +45,10 @@ jobs:
           set -euo pipefail
           PR_NUM=""
 
-          # shellcheck disable=SC2329  # invoked via `trap cleanup EXIT`
+          # cleanup runs indirectly via `trap cleanup EXIT`, so shellcheck's
+          # reachability analysis flags its body — SC2329 (never invoked) and
+          # SC2317 (unreachable) are both false positives here.
+          # shellcheck disable=SC2317,SC2329
           cleanup() {
             set +e
             [ -n "$PR_NUM" ] && GH_TOKEN="$APP_TOKEN" gh pr close "$PR_NUM" --repo "$REPO" 2>/dev/null


### PR DESCRIPTION
Follow-up to #257: CI's bundled shellcheck flags the `trap cleanup EXIT` handler's body as SC2317 (unreachable) — a false positive. #257 merged with it red because Actionlint isn't a required check (the ruleset gates only on the `*-status` aggregators). Disable both SC2317 + SC2329 on the function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)