### PR TITLE
TEST: verify Actionlint gate blocks (auto-closing, DO NOT MERGE)

### DIFF
--- a/.github/workflows/_lint-block-test.yml
+++ b/.github/workflows/_lint-block-test.yml
@@ -1,0 +1,8 @@
+name: Lint Block Test (throwaway)
+on: workflow_dispatch
+jobs:
+  a:
+    needs: [ghost-job-that-does-not-exist]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi


### PR DESCRIPTION
Throwaway — deliberately broken workflow (needs a non-existent job) to prove the now-required Actionlint Status check blocks merge. Will be closed.