### PR TITLE
chore(security): enforce 7-day minimumReleaseAge at repo root

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,11 @@
+# Supply-chain hardening. Refuse installing any dependency version published
+# less than 7 days ago, so a freshly-published malicious release (e.g. a hijacked
+# popular package — the May 2026 @tanstack worm compromised 42 packages within 6
+# minutes of publish) is never pulled into a build during the window before the
+# compromise is typically caught and yanked.
+#
+# Affects dependency RESOLUTION (bun add / bun update). Already-locked installs
+# (`bun install --frozen-lockfile`, what CI runs) are unaffected — they install
+# exactly what bun.lock pins.
+[install]
+minimumReleaseAge = 604800 # 7 days, in seconds


### PR DESCRIPTION
The 7-day supply-chain min-age default (per CLAUDE.md) was configured **nowhere** in the repo. Add it to a new root `bunfig.toml`.

**Verified (not assumed):** bun 1.3.13 reads + enforces the `[install] minimumReleaseAge` key — a dry-run with an absurd value blocks resolution with no CLI flag. It gates *new* dependency resolution only, so `bun install --frozen-lockfile` (CI) is unaffected (confirmed locally, 1324 installs, no changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)