### PR TITLE
test(accelerator): Windows updater-smoke — synthetic-N-1 bootstrap (P4)

### DIFF
--- a/.github/workflows/_e2e-updater-windows.yml
+++ b/.github/workflows/_e2e-updater-windows.yml
@@ -1,0 +1,108 @@
+name: _Updater Smoke Windows (reusable)
+
+# ADVISORY Windows/NSIS sibling of _e2e-updater-linux.yml. There is NO prior Windows
+# release to update FROM, so this BOOTSTRAPS with a synthetic N-1: it builds two app
+# versions in-job with ONE ephemeral minisign key (N-1 embeds the pubkey; N's updater
+# artifact is signed with the matching private key), installs N-1, lets it auto-update
+# to N via a local feed impersonating the prod host, and asserts it relaunches on N.
+# No prod signing key is involved. Once a real Windows stable exists, switch to the
+# Linux pattern (download N-1, serve the prod-signed N). See updater-smoke-windows.ps1.
+
+on:
+  workflow_call:
+    inputs:
+      n-version:
+        description: The version under test (N)
+        required: false
+        default: "9.9.9"
+        type: string
+      n1-version:
+        description: The synthetic previous version (N-1)
+        required: false
+        default: "0.0.1"
+        type: string
+      mode:
+        description: "positive (expect the update) | negative (tamper the artifact, expect rejection)"
+        required: false
+        default: positive
+        type: string
+  workflow_dispatch:
+
+jobs:
+  updater-smoke-windows:
+    name: Updater Smoke Windows (${{ inputs.mode || 'positive' }})
+    runs-on: windows-latest
+    timeout-minutes: 60 # two release builds + the smoke
+    permissions:
+      contents: read
+    env:
+      N_VERSION: ${{ inputs.n-version || '9.9.9' }}
+      N1_VERSION: ${{ inputs.n1-version || '0.0.1' }}
+      SMOKE_MODE: ${{ inputs.mode || 'positive' }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-accelerator
+        with:
+          rust-cache-key: accelerator-desktop-x86_64-pc-windows-msvc
+          rust-workspaces: packages/accelerator/src-tauri -> target
+          rust-components: ""
+
+      - name: Generate one ephemeral updater key (N-1 trusts it; N is signed with it)
+        shell: bash
+        working-directory: packages/accelerator
+        run: |
+          set -euo pipefail
+          bunx tauri signer generate --ci -p "" -w ./smoke.key
+          {
+            echo "TAURI_SIGNING_PRIVATE_KEY=$(cat ./smoke.key)"
+            echo "TAURI_SIGNING_PRIVATE_KEY_PASSWORD="
+            echo "SMOKE_PUBKEY=$(cat ./smoke.key.pub)"
+          } >> "$GITHUB_ENV"
+          rm -f ./smoke.key ./smoke.key.pub
+
+      # Build a version at the given version with the ephemeral pubkey embedded.
+      # Outputs land in target/release/bundle/nsis; we copy them out per version.
+      - name: Build N-1 (${{ inputs.n1-version || '0.0.1' }})
+        shell: bash
+        working-directory: packages/accelerator/src-tauri
+        run: |
+          set -euo pipefail
+          # Patch version (Cargo.toml + tauri.conf) + the updater pubkey to the ephemeral one.
+          sed -i "s/^version = \".*\"/version = \"$N1_VERSION\"/" Cargo.toml
+          bun -e "const f='tauri.conf.json';const c=JSON.parse(await Bun.file(f).text());c.version=process.env.N1_VERSION;c.plugins.updater.pubkey=process.env.SMOKE_PUBKEY;await Bun.write(f,JSON.stringify(c,null,2)+'\n')"
+          ( cd .. && bunx tauri build --bundles nsis )
+          mkdir -p "$RUNNER_TEMP/n1"
+          cp target/release/bundle/nsis/*-setup.exe "$RUNNER_TEMP/n1/"
+          # Restore the working tree so the N build patches cleanly.
+          git checkout -- Cargo.toml tauri.conf.json
+
+      - name: Build N (${{ inputs.n-version || '9.9.9' }})
+        shell: bash
+        working-directory: packages/accelerator/src-tauri
+        run: |
+          set -euo pipefail
+          sed -i "s/^version = \".*\"/version = \"$N_VERSION\"/" Cargo.toml
+          bun -e "const f='tauri.conf.json';const c=JSON.parse(await Bun.file(f).text());c.version=process.env.N_VERSION;c.plugins.updater.pubkey=process.env.SMOKE_PUBKEY;await Bun.write(f,JSON.stringify(c,null,2)+'\n')"
+          ( cd .. && bunx tauri build --bundles nsis )
+          mkdir -p "$RUNNER_TEMP/n"
+          cp target/release/bundle/nsis/*-setup.nsis.zip "$RUNNER_TEMP/n/"
+          cp target/release/bundle/nsis/*-setup.nsis.zip.sig "$RUNNER_TEMP/n/"
+          git checkout -- Cargo.toml tauri.conf.json
+
+      # BLOCKING once proven (mirrors the Linux flip). Advisory until a green dry-run.
+      - name: Updater smoke (install N-1 → auto-update to N → assert /health == N)
+        shell: pwsh
+        env:
+          UPDATER_SMOKE_MODE: ${{ inputs.mode || 'positive' }}
+        run: |
+          $n1 = Get-ChildItem -Path "$env:RUNNER_TEMP\n1" -Filter "*-setup.exe" | Select-Object -First 1
+          if (-not $n1) { Write-Error "N-1 installer not found"; exit 1 }
+          & packages/accelerator/scripts/updater-smoke-windows.ps1 `
+            -NVersion $env:N_VERSION `
+            -NArtifactsDir "$env:RUNNER_TEMP\n" `
+            -N1Installer $n1.FullName `
+            -RepoRoot $env:GITHUB_WORKSPACE
+
+      - name: Result summary
+        if: success()
+        run: echo "✅ Windows updater smoke PASSED ($env:SMOKE_MODE) — N-1 auto-updated to N via the local feed." >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/_e2e-updater-windows.yml
+++ b/.github/workflows/_e2e-updater-windows.yml
@@ -73,6 +73,9 @@ jobs:
           ( cd .. && bunx tauri build --bundles nsis )
           mkdir -p "$RUNNER_TEMP/n1"
           cp target/release/bundle/nsis/*-setup.exe "$RUNNER_TEMP/n1/"
+          # Wipe the bundle dir so N-1's *.nsis.zip can't linger into the N build and get
+          # copied as "N" (it would serve N-1's own 0.0.1 artifact = a no-op update).
+          rm -rf target/release/bundle/nsis
           # Restore the working tree so the N build patches cleanly.
           git checkout -- Cargo.toml tauri.conf.json
 

--- a/.github/workflows/accelerator.yml
+++ b/.github/workflows/accelerator.yml
@@ -380,6 +380,15 @@ jobs:
     with:
       mode: positive
 
+  # Teeth check: a TAMPERED .nsis.zip (genuine sig) must be REJECTED (no update).
+  updater-smoke-windows-negative:
+    name: Updater Smoke Windows (negative, advisory)
+    needs: changes
+    if: needs.changes.outputs.desktop == 'true'
+    uses: ./.github/workflows/_e2e-updater-windows.yml
+    with:
+      mode: negative
+
   accelerator-status:
     name: Accelerator Status
     if: always()

--- a/.github/workflows/accelerator.yml
+++ b/.github/workflows/accelerator.yml
@@ -369,6 +369,17 @@ jobs:
           }
           Write-Host "OK: the Windows app installs, launches, and serves /health on the runner"
 
+  # ADVISORY while iterating (NOT in accelerator-status). Builds a synthetic N-1 + N and
+  # proves N-1 auto-updates to N via a local feed. Permanent home is the release pipeline
+  # (P5); this per-PR wiring is to get it green. Flip to blocking once proven.
+  updater-smoke-windows:
+    name: Updater Smoke Windows (advisory)
+    needs: changes
+    if: needs.changes.outputs.desktop == 'true'
+    uses: ./.github/workflows/_e2e-updater-windows.yml
+    with:
+      mode: positive
+
   accelerator-status:
     name: Accelerator Status
     if: always()

--- a/.github/workflows/accelerator.yml
+++ b/.github/workflows/accelerator.yml
@@ -369,25 +369,10 @@ jobs:
           }
           Write-Host "OK: the Windows app installs, launches, and serves /health on the runner"
 
-  # ADVISORY while iterating (NOT in accelerator-status). Builds a synthetic N-1 + N and
-  # proves N-1 auto-updates to N via a local feed. Permanent home is the release pipeline
-  # (P5); this per-PR wiring is to get it green. Flip to blocking once proven.
-  updater-smoke-windows:
-    name: Updater Smoke Windows (advisory)
-    needs: changes
-    if: needs.changes.outputs.desktop == 'true'
-    uses: ./.github/workflows/_e2e-updater-windows.yml
-    with:
-      mode: positive
-
-  # Teeth check: a TAMPERED .nsis.zip (genuine sig) must be REJECTED (no update).
-  updater-smoke-windows-negative:
-    name: Updater Smoke Windows (negative, advisory)
-    needs: changes
-    if: needs.changes.outputs.desktop == 'true'
-    uses: ./.github/workflows/_e2e-updater-windows.yml
-    with:
-      mode: negative
+  # NOTE: the Windows updater-smoke (positive + negative) is PROVEN green and now lives in
+  # the release pipeline (release-accelerator.yml), not per-PR — it builds 4 app versions,
+  # far too heavy for every PR. The reusable _e2e-updater-windows.yml can still be run
+  # manually via workflow_dispatch.
 
   accelerator-status:
     name: Accelerator Status

--- a/.github/workflows/release-accelerator.yml
+++ b/.github/workflows/release-accelerator.yml
@@ -496,6 +496,27 @@ jobs:
     with:
       n-version: ${{ needs.validate.outputs.version }}
 
+  # Windows/NSIS updater smoke — ADVISORY (synthetic-N-1 bootstrap: no prior Windows release
+  # to update from, so it builds its OWN N-1 + N with an ephemeral key). Proves the click-free
+  # N-1→N update (positive) + tampered-artifact rejection (negative). Self-contained — needs
+  # only `validate`. NOT in tag/release `needs` yet; flip to blocking after a green Windows rc
+  # dry-run, then switch to download-real-N-1 once a Windows stable exists.
+  update-smoke-windows:
+    name: Updater Smoke (windows-x86_64 / positive)
+    needs: [validate]
+    if: ${{ !cancelled() && needs.validate.result == 'success' }}
+    uses: ./.github/workflows/_e2e-updater-windows.yml
+    with:
+      mode: positive
+
+  update-smoke-windows-negative:
+    name: Updater Smoke (windows-x86_64 / negative)
+    needs: [validate]
+    if: ${{ !cancelled() && needs.validate.result == 'success' }}
+    uses: ./.github/workflows/_e2e-updater-windows.yml
+    with:
+      mode: negative
+
   tag:
     name: Create Git Tag
     needs: [validate, build, build-headless, smoke, smoke-intel, update-smoke, update-smoke-linux, e2e-webdriver]

--- a/implementations-plan/windows-release-2026-06-02/lessons/phase-4.md
+++ b/implementations-plan/windows-release-2026-06-02/lessons/phase-4.md
@@ -81,3 +81,33 @@ Each is its own PR, windows-latest-validated, codex-reviewed. Expect P2-style mu
 Designed during the AFK window while the 1Password/SSH agent was flaking (blocked reliable CI
 iteration). Execute when SSH is stable. P0–P3 are banked (P3 committed locally `c161015`,
 auto-pushes on SSH recovery via watcher b7y1txmfx).
+
+## P4 updater-smoke — PROVEN + merged (#273)
+Both legs GREEN on windows-latest, reproducibly:
+- **positive**: install synthetic N-1 (0.0.1) → click-free auto-update to N (9.9.9) via local
+  minisign-signed feed → quiet-install → relaunch → /health == 9.9.9.
+- **negative**: tampered `.nsis.zip` (genuine sig) REJECTED — never reaches 9.9.9.
+Harness: `scripts/updater-smoke-windows.ps1` + reusable `_e2e-updater-windows.yml`
+(ephemeral minisign keypair, builds N-1 + N in-job, synthetic-N-1 bootstrap).
+Key fixes that got it green (from app-log evidence over 4 rounds):
+- CA must go to `LocalMachine\Root` (CurrentUser\Root pops a Trusted-Root GUI dialog → freezes
+  the headless runner — regardless of certutil/Import-Certificate/X509Store).
+- `rm -rf target/release/bundle/nsis` after copying N-1's artifact, else N reuses N-1's stale zip.
+- `plugins.updater.windows.installMode: "quiet"` — the only fully click-free mode (default
+  `passive` shows a progress window that freezes the runner). Also = parity with silent mac/linux.
+
+### Codex review (session 019e8e71, ship-with-changes)
+- **FIXED now**: Defender exclusion was added but never removed — added `Remove-MpPreference`
+  for the same scoped paths ($InstallRoot, $ServeDir) to the `finally` Cleanup. No impact on
+  ephemeral GH runners but never leave an AV hole in a committed harness.
+- **Deferred to P5 blocking-flip (#93)**: (1) HIGH — single-slot release concurrency means a
+  hung advisory Windows leg holds the run `in_progress`, delaying a later dispatch; (2) MED — a
+  failed advisory leg makes the overall run conclude `failure` (harmless in-repo; resolved by
+  the blocking flip). Did NOT touch the proven-green timeout to chase a low-probability hang.
+- **Accepted**: `quiet` UX (no native progress/error UI) is a deliberate tray-app choice +
+  parity with mac/linux silent auto-update.
+
+### P5 partial (in #273)
+Per-PR smoke scaffolding removed from accelerator.yml; the proven jobs now live in
+release-accelerator.yml as ADVISORY (needs:[validate], absent from tag/release needs).
+Flip to blocking after a green Windows rc dry-run (#93/P6).

--- a/packages/accelerator/scripts/updater-smoke-windows.ps1
+++ b/packages/accelerator/scripts/updater-smoke-windows.ps1
@@ -9,12 +9,14 @@
 
   Trust model (no signing key needed): we serve an ALREADY-signed N .nsis.zip; N-1
   (unmodified) verifies the .sig against its embedded pubkey. reqwest on Windows uses
-  schannel, which reads the Windows cert store — so a local CA trusted in CurrentUser\Root
+  schannel, which reads the Windows cert store — so a local CA trusted in LocalMachine\Root
   is honored.
 
   Windows vs Linux swaps:
-    CA trust : Import-Certificate -> CurrentUser\Root (vs update-ca-certificates; NOT certutil
-               -addstore Root, which pops a GUI confirmation that hangs a non-interactive runner)
+    CA trust : Import-Certificate -> LocalMachine\Root (vs update-ca-certificates). MUST be the
+               MACHINE store, not per-user: adding a CA to the per-user Trusted Root pops a GUI
+               confirmation that hangs a headless runner; the machine store is admin-authorized
+               (runner is admin) so it adds silently. schannel validates against both.
     hosts    : %SystemRoot%\System32\drivers\etc\hosts
     install  : <setup>.exe /S  (silent NSIS, %LOCALAPPDATA%)   (vs cp + chmod AppImage)
     AV       : scoped Add-MpPreference exclusion (unsigned exe) (no Linux analogue)
@@ -56,8 +58,8 @@ function Cleanup {
   if ($AppProc) { Stop-Process -Id $AppProc.Id -Force -ErrorAction SilentlyContinue }
   Get-Process -Name "aztec-accelerator" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
   if ($FeedProc) { Stop-Process -Id $FeedProc.Id -Force -ErrorAction SilentlyContinue }
-  # Drop the test CA from CurrentUser\Root (ephemeral runner is torn down anyway).
-  if ($CaThumb) { Get-ChildItem "Cert:\CurrentUser\Root\$CaThumb" -ErrorAction SilentlyContinue | Remove-Item -Force -ErrorAction SilentlyContinue }
+  # Drop the test CA from LocalMachine\Root (ephemeral runner is torn down anyway).
+  if ($CaThumb) { Get-ChildItem "Cert:\LocalMachine\Root\$CaThumb" -ErrorAction SilentlyContinue | Remove-Item -Force -ErrorAction SilentlyContinue }
   # Drop the hosts line we added (anchored, exact).
   if (Test-Path $HostsFile) {
     (Get-Content $HostsFile) | Where-Object { $_ -notmatch "^127\.0\.0\.1\s+$([regex]::Escape($FeedHost))$" } | Set-Content $HostsFile -ErrorAction SilentlyContinue
@@ -99,12 +101,14 @@ try {
   "subjectAltName=DNS:$FeedHost`nextendedKeyUsage=serverAuth" | Set-Content "$Work\leaf.ext"
   & openssl x509 -req -in "$Work\leaf.csr" -CA "$Work\ca.pem" -CAkey "$Work\ca.key" -CAcreateserial -out "$Work\leaf.pem" -days 2 -extfile "$Work\leaf.ext" 2>$null
 
-  # ── Trust the CA (CurrentUser\Root — schannel reads it for reqwest) + impersonate host ──
-  # Import-Certificate adds to the store PROGRAMMATICALLY. Do NOT use `certutil -addstore Root`:
-  # adding to the Root store that way pops a GUI "install this certificate?" confirmation that
-  # HANGS a non-interactive CI runner (observed: the smoke stalled here on iteration 1).
-  Log "trusting CA (Import-Certificate -> CurrentUser\Root) + hosts entry"
-  $CaThumb = (Import-Certificate -FilePath "$Work\ca.pem" -CertStoreLocation Cert:\CurrentUser\Root).Thumbprint
+  # ── Trust the CA (LocalMachine\Root — schannel validates against it for reqwest) + host ──
+  # MUST be LocalMachine\Root, NOT CurrentUser\Root: adding a CA to the PER-USER Trusted Root
+  # store pops a GUI security-confirmation dialog ("install this certificate?") that hangs a
+  # headless runner — regardless of certutil vs Import-Certificate vs X509Store.Add. The MACHINE
+  # store is admin-authorized (the GH runner is admin) so it adds with NO prompt; schannel
+  # validates against both stores. (Observed freeze on iterations 1-3.)
+  Log "trusting CA (Import-Certificate -> LocalMachine\Root) + hosts entry"
+  $CaThumb = (Import-Certificate -FilePath "$Work\ca.pem" -CertStoreLocation Cert:\LocalMachine\Root).Thumbprint
   Write-Host "CA trusted (thumbprint $CaThumb)"
   Add-Content -Path $HostsFile -Value "127.0.0.1 $FeedHost"
   Write-Host "hosts entry added"

--- a/packages/accelerator/scripts/updater-smoke-windows.ps1
+++ b/packages/accelerator/scripts/updater-smoke-windows.ps1
@@ -58,6 +58,9 @@ function Cleanup {
   if ($AppProc) { Stop-Process -Id $AppProc.Id -Force -ErrorAction SilentlyContinue }
   Get-Process -Name "aztec-accelerator" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
   if ($FeedProc) { Stop-Process -Id $FeedProc.Id -Force -ErrorAction SilentlyContinue }
+  # Drop the scoped Defender exclusions we added (self-hosted-runner hygiene; no-op on
+  # ephemeral GH-hosted runners, which are torn down — but never leave an AV hole behind).
+  Remove-MpPreference -ExclusionPath $InstallRoot, $ServeDir -ErrorAction SilentlyContinue
   # Drop the test CA from LocalMachine\Root (ephemeral runner is torn down anyway).
   if ($CaThumb) { Get-ChildItem "Cert:\LocalMachine\Root\$CaThumb" -ErrorAction SilentlyContinue | Remove-Item -Force -ErrorAction SilentlyContinue }
   # Drop the hosts line we added (anchored, exact).

--- a/packages/accelerator/scripts/updater-smoke-windows.ps1
+++ b/packages/accelerator/scripts/updater-smoke-windows.ps1
@@ -13,7 +13,8 @@
   is honored.
 
   Windows vs Linux swaps:
-    CA trust : certutil -addstore -user Root        (vs update-ca-certificates)
+    CA trust : Import-Certificate -> CurrentUser\Root (vs update-ca-certificates; NOT certutil
+               -addstore Root, which pops a GUI confirmation that hangs a non-interactive runner)
     hosts    : %SystemRoot%\System32\drivers\etc\hosts
     install  : <setup>.exe /S  (silent NSIS, %LOCALAPPDATA%)   (vs cp + chmod AppImage)
     AV       : scoped Add-MpPreference exclusion (unsigned exe) (no Linux analogue)
@@ -96,10 +97,14 @@ try {
   & openssl x509 -req -in "$Work\leaf.csr" -CA "$Work\ca.pem" -CAkey "$Work\ca.key" -CAcreateserial -out "$Work\leaf.pem" -days 2 -extfile "$Work\leaf.ext" 2>$null
 
   # ── Trust the CA (CurrentUser\Root — schannel reads it for reqwest) + impersonate host ──
-  Log "trusting CA (certutil -addstore -user Root) + hosts entry"
-  & certutil -addstore -f -user Root "$Work\ca.pem" | Out-Null
+  # Import-Certificate adds to the store PROGRAMMATICALLY. Do NOT use `certutil -addstore Root`:
+  # adding to the Root store that way pops a GUI "install this certificate?" confirmation that
+  # HANGS a non-interactive CI runner (observed: the smoke stalled here on iteration 1).
+  Log "trusting CA (Import-Certificate -> CurrentUser\Root) + hosts entry"
   $CaThumb = (Import-Certificate -FilePath "$Work\ca.pem" -CertStoreLocation Cert:\CurrentUser\Root).Thumbprint
+  Write-Host "CA trusted (thumbprint $CaThumb)"
   Add-Content -Path $HostsFile -Value "127.0.0.1 $FeedHost"
+  Write-Host "hosts entry added"
 
   # ── Scoped Defender exclusion (the UNSIGNED installer/exe) ──
   Add-MpPreference -ExclusionPath $InstallRoot, $ServeDir -ErrorAction SilentlyContinue

--- a/packages/accelerator/scripts/updater-smoke-windows.ps1
+++ b/packages/accelerator/scripts/updater-smoke-windows.ps1
@@ -1,0 +1,176 @@
+<#
+  Release-time updater smoke test (Windows / NSIS) — ADVISORY first.
+
+  Windows sibling of updater-smoke-linux.sh. Proves a user on N-1 auto-updates to
+  the just-built+signed build (N) via a local feed impersonating aztec-accelerator.dev,
+  and relaunches reporting version N. Answers the open `v1Compatible` question on
+  Windows: does the updater download the .nsis.zip, minisign-verify it, run the NSIS
+  installer SILENTLY (currentUser, no UAC), and relaunch?
+
+  Trust model (no signing key needed): we serve an ALREADY-signed N .nsis.zip; N-1
+  (unmodified) verifies the .sig against its embedded pubkey. reqwest on Windows uses
+  schannel, which reads the Windows cert store — so a local CA trusted in CurrentUser\Root
+  is honored.
+
+  Windows vs Linux swaps:
+    CA trust : certutil -addstore -user Root        (vs update-ca-certificates)
+    hosts    : %SystemRoot%\System32\drivers\etc\hosts
+    install  : <setup>.exe /S  (silent NSIS, %LOCALAPPDATA%)   (vs cp + chmod AppImage)
+    AV       : scoped Add-MpPreference exclusion (unsigned exe) (no Linux analogue)
+    feed     : same bun server, no sudo (Windows binds :443 as user)
+
+  Usage:
+    updater-smoke-windows.ps1 -NVersion 9.9.9 -NArtifactsDir <dir> -N1Installer <setup.exe> -RepoRoot <root>
+    -NArtifactsDir : dir with N's *-setup.nsis.zip + *-setup.nsis.zip.sig
+    -N1Installer   : path to N-1's *-setup.exe
+  UPDATER_SMOKE_MODE = positive (default) | negative (tamper the served zip, expect rejection)
+#>
+param(
+  [Parameter(Mandatory)][string]$NVersion,
+  [string]$PlatformKey = "windows-x86_64",
+  [Parameter(Mandatory)][string]$NArtifactsDir,
+  [Parameter(Mandatory)][string]$N1Installer,
+  [Parameter(Mandatory)][string]$RepoRoot
+)
+
+$ErrorActionPreference = "Stop"
+$Mode = if ($env:UPDATER_SMOKE_MODE) { $env:UPDATER_SMOKE_MODE } else { "positive" }
+$FeedHost = "aztec-accelerator.dev"
+$HealthUrl = "http://127.0.0.1:59833/health"
+$HostsFile = "$env:SystemRoot\System32\drivers\etc\hosts"
+$ConfigDir = Join-Path $env:USERPROFILE ".aztec-accelerator"
+$InstallRoot = "$env:LOCALAPPDATA\Aztec Accelerator"
+# Run-unique CA name so cleanup removes only THIS run's anchor (self-hosted safety).
+$CaCn = "updater-smoke-CA-$($env:GITHUB_RUN_ID)-$($env:GITHUB_RUN_ATTEMPT)"
+$Work = Join-Path $env:RUNNER_TEMP ("updater-smoke-" + [guid]::NewGuid().ToString('N'))
+$ServeDir = Join-Path $Work "serve"
+New-Item -ItemType Directory -Force -Path $ServeDir | Out-Null
+$AppProc = $null
+$FeedProc = $null
+$CaThumb = $null
+
+function Log($m) { Write-Host "── $m ──" }
+
+function Cleanup {
+  if ($AppProc) { Stop-Process -Id $AppProc.Id -Force -ErrorAction SilentlyContinue }
+  Get-Process -Name "aztec-accelerator" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+  if ($FeedProc) { Stop-Process -Id $FeedProc.Id -Force -ErrorAction SilentlyContinue }
+  # Drop the test CA from CurrentUser\Root (ephemeral runner is torn down anyway).
+  if ($CaThumb) { Get-ChildItem "Cert:\CurrentUser\Root\$CaThumb" -ErrorAction SilentlyContinue | Remove-Item -Force -ErrorAction SilentlyContinue }
+  # Drop the hosts line we added (anchored, exact).
+  if (Test-Path $HostsFile) {
+    (Get-Content $HostsFile) | Where-Object { $_ -notmatch "^127\.0\.0\.1\s+$([regex]::Escape($FeedHost))$" } | Set-Content $HostsFile -ErrorAction SilentlyContinue
+  }
+}
+
+function Dump-Logs {
+  Write-Host "── feed log ──"; Get-Content (Join-Path $Work "feed.log") -ErrorAction SilentlyContinue
+  Write-Host "── feed err ──"; Get-Content (Join-Path $Work "feed.err") -ErrorAction SilentlyContinue
+  Write-Host "── last /health ──"; try { Invoke-RestMethod -Uri $HealthUrl -TimeoutSec 3 | ConvertTo-Json -Compress } catch { "unreachable" }
+}
+
+try {
+  # ── Locate N's signed updater artifact ──
+  $NZip = Get-ChildItem -Path $NArtifactsDir -Recurse -Filter "*-setup.nsis.zip" | Select-Object -First 1
+  $NSig = Get-ChildItem -Path $NArtifactsDir -Recurse -Filter "*-setup.nsis.zip.sig" | Select-Object -First 1
+  if (-not $NZip) { Write-Error "no *-setup.nsis.zip in $NArtifactsDir"; exit 1 }
+  if (-not $NSig) { Write-Error "no *-setup.nsis.zip.sig in $NArtifactsDir"; exit 1 }
+  $NName = $NZip.Name
+  $Served = Join-Path $ServeDir $NName
+  Copy-Item $NZip.FullName $Served
+  $NSigText = (Get-Content $NSig.FullName -Raw).Trim()
+  Log "N artifact: $NName"
+
+  # Negative control: tamper the served zip (append a byte) but keep the GENUINE sig,
+  # so the minisign check over the tampered bytes MUST fail against the embedded pubkey.
+  if ($Mode -eq "negative") {
+    Add-Content -Path $Served -Value ([byte]0x78) -AsByteStream
+    Log "NEGATIVE mode: serving a TAMPERED .nsis.zip with the genuine signature — expecting REJECTION"
+  }
+
+  # ── Local CA + leaf (SAN = the prod host) via openssl (Git ships it on the runner) ──
+  Log "generating local CA + leaf (SAN=$FeedHost)"
+  & openssl req -x509 -newkey rsa:2048 -nodes -keyout "$Work\ca.key" -out "$Work\ca.pem" -days 2 -subj "/CN=$CaCn" 2>$null
+  & openssl req -newkey rsa:2048 -nodes -keyout "$Work\leaf.key" -out "$Work\leaf.csr" -subj "/CN=$FeedHost" 2>$null
+  "subjectAltName=DNS:$FeedHost`nextendedKeyUsage=serverAuth" | Set-Content "$Work\leaf.ext"
+  & openssl x509 -req -in "$Work\leaf.csr" -CA "$Work\ca.pem" -CAkey "$Work\ca.key" -CAcreateserial -out "$Work\leaf.pem" -days 2 -extfile "$Work\leaf.ext" 2>$null
+
+  # ── Trust the CA (CurrentUser\Root — schannel reads it for reqwest) + impersonate host ──
+  Log "trusting CA (certutil -addstore -user Root) + hosts entry"
+  & certutil -addstore -f -user Root "$Work\ca.pem" | Out-Null
+  $CaThumb = (Import-Certificate -FilePath "$Work\ca.pem" -CertStoreLocation Cert:\CurrentUser\Root).Thumbprint
+  Add-Content -Path $HostsFile -Value "127.0.0.1 $FeedHost"
+
+  # ── Scoped Defender exclusion (the UNSIGNED installer/exe) ──
+  Add-MpPreference -ExclusionPath $InstallRoot, $ServeDir -ErrorAction SilentlyContinue
+
+  # ── Synthesize latest.json for N ──
+  $latest = [ordered]@{
+    version  = $NVersion
+    notes    = "updater smoke $NVersion"
+    pub_date = "2026-01-01T00:00:00Z"
+    platforms = [ordered]@{ $PlatformKey = [ordered]@{ signature = $NSigText; url = "https://$FeedHost/releases/download/$NName" } }
+  } | ConvertTo-Json -Depth 6
+  Set-Content -Path (Join-Path $Work "latest.json") -Value $latest
+  Log "latest.json:"; Write-Host $latest
+
+  # ── Start the local HTTPS feed on :443 (no sudo on Windows) ──
+  Log "starting feed server on :443"
+  $FeedProc = Start-Process -FilePath "bun" -PassThru `
+    -ArgumentList "$RepoRoot\packages\accelerator\scripts\updater-feed-server.ts","--cert","$Work\leaf.pem","--key","$Work\leaf.key","--latest-json","$Work\latest.json","--serve-dir","$ServeDir" `
+    -RedirectStandardOutput (Join-Path $Work "feed.log") -RedirectStandardError (Join-Path $Work "feed.err")
+  $feedUp = $false
+  for ($i = 0; $i -lt 20; $i++) {
+    try { Invoke-RestMethod -Uri "https://$FeedHost/releases/latest.json" -TimeoutSec 3 | Out-Null; $feedUp = $true; break } catch { }
+    Start-Sleep -Milliseconds 500
+  }
+  if (-not $feedUp) { Write-Error "feed server not reachable"; Dump-Logs; exit 1 }
+
+  # ── Install N-1 silently (currentUser → %LOCALAPPDATA%, no UAC) ──
+  Log "installing N-1 silently: $N1Installer /S"
+  Start-Process -FilePath $N1Installer -ArgumentList "/S" -Wait
+  $Exe = Get-ChildItem -Path $InstallRoot -Recurse -Filter "aztec-accelerator.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+  if (-not $Exe) { Write-Error "installed exe not found under $InstallRoot"; exit 1 }
+
+  # ── Pre-seed auto-update so N-1 updates without UI ──
+  New-Item -ItemType Directory -Force -Path $ConfigDir | Out-Null
+  '{"config_version":1,"safari_support":false,"approved_origins":[],"speed":"full","auto_update":true}' | Set-Content (Join-Path $ConfigDir "config.json")
+
+  # ── Launch N-1; it should auto-update to N and relaunch ──
+  Log "launching N-1 (expecting auto-update → $NVersion)"
+  $AppProc = Start-Process -FilePath $Exe.FullName -PassThru
+
+  if ($Mode -eq "negative") {
+    Log "NEGATIVE: asserting /health never reports $NVersion (tampered artifact rejected), 120s"
+    for ($i = 0; $i -lt 60; $i++) {
+      try { $got = (Invoke-RestMethod -Uri $HealthUrl -TimeoutSec 3).version } catch { $got = $null }
+      if ($got -eq $NVersion) { Write-Error "NEGATIVE FAILED — a TAMPERED artifact was ACCEPTED (updated to $NVersion). The updater is not verifying signatures."; Dump-Logs; exit 1 }
+      Start-Sleep -Seconds 2
+    }
+    if (-not (Select-String -Path (Join-Path $Work "feed.log") -Pattern "/releases/download/" -Quiet)) {
+      Write-Error "NEGATIVE inconclusive — the updater never downloaded the artifact, so signature rejection wasn't exercised."; Dump-Logs; exit 1
+    }
+    Log "SUCCESS (negative) — updater downloaded the tampered artifact and refused to update"
+    Dump-Logs; exit 0
+  }
+
+  # ── Positive: poll /health until version == N ──
+  Log "polling $HealthUrl for version == $NVersion (up to 300s)"
+  for ($i = 0; $i -lt 150; $i++) {
+    try { $got = (Invoke-RestMethod -Uri $HealthUrl -TimeoutSec 3).version } catch { $got = $null }
+    if ($got -eq $NVersion) {
+      if (-not (Select-String -Path (Join-Path $Work "feed.log") -Pattern "/releases/download/" -Quiet)) {
+        Write-Error "/health reports $NVersion but the feed log has no download hit — the update didn't flow through our feed."; Dump-Logs; exit 1
+      }
+      Log "SUCCESS — updated to $got via the local feed (artifact downloaded + relaunched)"
+      exit 0
+    }
+    Start-Sleep -Seconds 2
+  }
+  Write-Error "updater smoke failed — /health never reported $NVersion (does Tauri's Windows updater apply the .nsis.zip? see feed/app logs)"
+  Dump-Logs
+  exit 1
+}
+finally {
+  Cleanup
+}

--- a/packages/accelerator/scripts/updater-smoke-windows.ps1
+++ b/packages/accelerator/scripts/updater-smoke-windows.ps1
@@ -67,6 +67,9 @@ function Cleanup {
 function Dump-Logs {
   Write-Host "── feed log ──"; Get-Content (Join-Path $Work "feed.log") -ErrorAction SilentlyContinue
   Write-Host "── feed err ──"; Get-Content (Join-Path $Work "feed.err") -ErrorAction SilentlyContinue
+  Write-Host "── app log (what the updater actually did) ──"
+  Get-ChildItem "$env:LOCALAPPDATA\aztec-accelerator\logs" -ErrorAction SilentlyContinue |
+    ForEach-Object { Write-Host "-- $($_.Name) --"; Get-Content $_.FullName -Tail 80 -ErrorAction SilentlyContinue }
   Write-Host "── last /health ──"; try { Invoke-RestMethod -Uri $HealthUrl -TimeoutSec 3 | ConvertTo-Json -Compress } catch { "unreachable" }
 }
 
@@ -132,8 +135,15 @@ try {
   if (-not $feedUp) { Write-Error "feed server not reachable"; Dump-Logs; exit 1 }
 
   # ── Install N-1 silently (currentUser → %LOCALAPPDATA%, no UAC) ──
+  # Timed (not -Wait): a non-silent NSIS prompt would hang the runner forever, so fail fast.
   Log "installing N-1 silently: $N1Installer /S"
-  Start-Process -FilePath $N1Installer -ArgumentList "/S" -Wait
+  $inst = Start-Process -FilePath $N1Installer -ArgumentList "/S" -PassThru
+  if (-not $inst.WaitForExit(120000)) {
+    try { $inst.Kill() } catch { }
+    Write-Error "N-1 silent install did NOT finish in 120s — a non-silent NSIS prompt? (runner can't click)"
+    exit 1
+  }
+  Write-Host "N-1 installed (exit $($inst.ExitCode))"
   $Exe = Get-ChildItem -Path $InstallRoot -Recurse -Filter "aztec-accelerator.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
   if (-not $Exe) { Write-Error "installed exe not found under $InstallRoot"; exit 1 }
 

--- a/packages/accelerator/src-tauri/tauri.conf.json
+++ b/packages/accelerator/src-tauri/tauri.conf.json
@@ -15,7 +15,10 @@
       "endpoints": [
         "https://aztec-accelerator.dev/releases/latest.json"
       ],
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEIzNzEzODFFMEEzMzU2QTgKUldTb1ZqTUtIamh4czNrcWR3QVZiUmIwdyttSzg5OUhtZXJobURnY05KL2pCZWMydDFPcWkvWFAK"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEIzNzEzODFFMEEzMzU2QTgKUldTb1ZqTUtIamh4czNrcWR3QVZiUmIwdyttSzg5OUhtZXJobURnY05KL2pCZWMydDFPcWkvWFAK",
+      "windows": {
+        "installMode": "quiet"
+      }
     }
   },
   "bundle": {


### PR DESCRIPTION
The make-or-break P4 gate. Builds a synthetic N-1 + N (one ephemeral key) and proves N-1 auto-updates to N on windows-latest via a local feed (the de-risk already proved the app runs). Advisory while iterating — expect P2-style rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)