### PR TITLE
fix(accelerator): windows crash-recovery via repeating trigger (RestartOnFailure was broken)

### DIFF
--- a/.github/workflows/_e2e-crash-recovery-windows.yml
+++ b/.github/workflows/_e2e-crash-recovery-windows.yml
@@ -1,9 +1,10 @@
 name: _E2E Crash Recovery (Windows)
 
-# Diagnostic spike (codex session 019e8e9e): does Task Scheduler <RestartOnFailure>
-# actually relaunch the app on a crash? Pinned to windows-2025 (not windows-latest —
-# that label drifts). Path-scoped push trigger so it runs when the spike files change;
-# workflow_dispatch for re-runs once this is on the default branch.
+# Gates the Windows crash-recovery MECHANISM: a repeating Task Scheduler TimeTrigger
+# (PT1M) + IgnoreNew must relaunch a dead app and never duplicate a live one. (The
+# original RestartOnFailure was proven BROKEN here — see lessons/phase-4.md.) Pinned to
+# windows-2025 (windows-latest drifts — codex 019e8e9e). Runs when the test/workflow
+# changes; workflow_dispatch for re-runs.
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/_e2e-crash-recovery-windows.yml
+++ b/.github/workflows/_e2e-crash-recovery-windows.yml
@@ -1,0 +1,26 @@
+name: _E2E Crash Recovery (Windows)
+
+# Diagnostic spike (codex session 019e8e9e): does Task Scheduler <RestartOnFailure>
+# actually relaunch the app on a crash? Pinned to windows-2025 (not windows-latest —
+# that label drifts). Path-scoped push trigger so it runs when the spike files change;
+# workflow_dispatch for re-runs once this is on the default branch.
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "packages/accelerator/scripts/crash-recovery-smoke-windows.ps1"
+      - ".github/workflows/_e2e-crash-recovery-windows.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  crash-recovery-smoke:
+    name: Crash-recovery crux (Task Scheduler)
+    runs-on: windows-2025
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run crash-recovery crux spike
+        shell: pwsh
+        run: ./packages/accelerator/scripts/crash-recovery-smoke-windows.ps1

--- a/implementations-plan/windows-release-2026-06-02/lessons/phase-4.md
+++ b/implementations-plan/windows-release-2026-06-02/lessons/phase-4.md
@@ -111,3 +111,32 @@ Key fixes that got it green (from app-log evidence over 4 rounds):
 Per-PR smoke scaffolding removed from accelerator.yml; the proven jobs now live in
 release-accelerator.yml as ADVISORY (needs:[validate], absent from tag/release needs).
 Flip to blocking after a green Windows rc dry-run (#93/P6).
+
+## P4c crash-recovery — RestartOnFailure is BROKEN (codex 019e8e9e + empirical proof)
+Codex flagged that Task Scheduler `<RestartOnFailure>` may not relaunch on a non-zero/crash
+exit. Spiked it on a real windows-2025 runner (SYSTEM principal to isolate the mechanism):
+```
+exit0 runs=1  (stays down — fine)
+exit1 runs=1  (graceful non-zero does NOT relaunch)
+kill  runs=1  (abnormal kill = real crash does NOT relaunch)  -> crash->relaunch BROKEN
+```
+RestartOnFailure is for "the engine couldn't start the action", NOT "the action ran then died".
+mac (launchd KeepAlive{SuccessfulExit:false}) + linux (systemd Restart=on-failure) genuinely
+work and key on the exit code; Windows had no working equivalent. Merged-but-never-released, so
+zero users affected — exactly what this test push exists to catch pre-release.
+
+### Fix (user chose: repeating-trigger task)
+Two parts:
+1. **task_xml**: replace `LogonTrigger + RestartOnFailure` with a REPEATING `TimeTrigger` (PT1M,
+   no Duration) + keep `MultipleInstancesPolicy=IgnoreNew`. Every minute TS tries to start the
+   action; IgnoreNew = no-op if alive, RELAUNCH if dead. ~<=1min recovery latency.
+2. **disable-on-quit** (app code): a repeating trigger relaunches ANYTHING not running, incl.
+   after an intentional quit — which would break quit->stays-down. So the Quit path
+   (main.rs `"quit" => app.exit(0)`) must call `disable_crash_recovery()` (delete the task)
+   BEFORE exit. A crash skips that path -> task remains -> relaunched. Clean quit deletes it
+   first -> stays down. (Updater handoff: restart() launches the NEW build at the same exe path;
+   task either way points there.)
+
+Round-2 spike (crash-recovery-smoke-windows.ps1) confirms the two OS behaviors the fix needs:
+relaunch-on-death (runs grows) + no-dup-when-alive (IgnoreNew, runs stays 1). Spike FIRST,
+then implement — same discipline that caught the round-1 bug.

--- a/packages/accelerator/scripts/crash-recovery-smoke-windows.ps1
+++ b/packages/accelerator/scripts/crash-recovery-smoke-windows.ps1
@@ -1,51 +1,50 @@
 #!/usr/bin/env pwsh
-# ── Task Scheduler crash-recovery CRUX spike ───────────────────────────────────
-# The shipped Windows crash-recovery relies on <RestartOnFailure> (Interval PT1M,
-# Count 3) relaunching the app when it dies. Codex (session 019e8e9e) flagged that
-# Microsoft's docs DON'T define "failure" in action-exit-code terms — a graceful
-# non-zero exit may NOT trigger a restart, which would make the feature broken.
+# ── Task Scheduler crash-recovery mechanism spike ──────────────────────────────
+# Round 1 (RestartOnFailure) was proven BROKEN — it does not relaunch a dead/crashed
+# action (exit1=1, kill=1). Codex (019e8e9e) predicted it; a real runner confirmed it.
 #
-# This isolates the RestartOnFailure mechanism and answers, empirically, on a real
-# runner:
-#   exit0 → must STAY DOWN (clean quit / updater handoff = no relaunch)
-#   exit1 → does a graceful non-zero exit trigger a restart?
-#   kill  → does an ABNORMAL termination (a real crash) trigger a restart?
+# Round 2 (this): the chosen fix is a REPEATING TimeTrigger (PT1M) + IgnoreNew —
+# every minute Task Scheduler tries to start the action; IgnoreNew makes that a no-op
+# if it's already running, and a RELAUNCH if it died. This spike confirms the two OS
+# behaviors the fix depends on:
+#   relaunch → a dead action is restarted by the next tick (runs grows past 1)
+#   nodup    → a live action is NOT duplicated by later ticks (runs stays 1)
 #
-# Uses a SYSTEM principal (S-1-5-18) so the task runs headless on a CI runner,
-# deliberately sidestepping the separate InteractiveToken/desktop question (that's
-# about whether the REAL app's task launches at logon on a user's machine — true by
-# design there; only the CI runner lacks a guaranteed interactive desktop). The
-# RestartOnFailure SETTING behaves independently of the principal, so the crux
-# answer transfers.
+# (quit→stays-down is handled in app code — the quit path calls disable_crash_recovery()
+# to delete the task before exit — NOT by the trigger, so it's not spiked here.)
+#
+# SYSTEM principal so the task runs headless on CI (isolates the trigger/IgnoreNew
+# mechanism from the InteractiveToken/desktop question).
 $ErrorActionPreference = 'Stop'
-$Work = Join-Path $env:RUNNER_TEMP ("crsmoke-" + [guid]::NewGuid().ToString('N'))
+$Work = Join-Path $env:RUNNER_TEMP ("crsmoke2-" + [guid]::NewGuid().ToString('N'))
 New-Item -ItemType Directory -Force -Path $Work | Out-Null
 
 function New-Stub($path, $counter, $mode) {
   $lines = @('@echo off', ">>`"$counter`" echo run")
   switch ($mode) {
-    'exit0' { $lines += 'exit /b 0' }
-    'exit1' { $lines += 'exit /b 1' }
-    'hang'  { $lines += ':loop', 'ping -n 3 127.0.0.1 >nul', 'goto loop' }
+    'exit'  { $lines += 'exit /b 0' }                                   # dies between ticks
+    'hang'  { $lines += ':loop', 'ping -n 3 127.0.0.1 >nul', 'goto loop' }  # stays alive
   }
   Set-Content -Path $path -Value ($lines -join "`r`n") -Encoding Ascii
 }
 
-function Invoke-Case($name, $mode, [bool]$kill) {
-  $counter = Join-Path $Work "$name.count"
-  New-Item -ItemType File -Force -Path $counter | Out-Null
-  $stub = Join-Path $Work "$name.cmd"
-  New-Stub $stub $counter $mode
-  $task = "CrSmoke-$name-$PID"
-  $xmlPath = Join-Path $Work "$name.xml"
-  # Mirrors the real task_xml restart contract (RestartOnFailure PT1M / Count 3).
+function Register-RepeatingTask($task, $stub) {
+  $xmlPath = Join-Path $Work "$task.xml"
+  # Repeating TimeTrigger (past StartBoundary + PT1M, no Duration = forever) + IgnoreNew.
   $xml = @"
 <?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <Triggers>
+    <TimeTrigger>
+      <StartBoundary>2024-01-01T00:00:00</StartBoundary>
+      <Enabled>true</Enabled>
+      <Repetition><Interval>PT1M</Interval><StopAtDurationEnd>false</StopAtDurationEnd></Repetition>
+    </TimeTrigger>
+  </Triggers>
   <Settings>
     <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <StartWhenAvailable>true</StartWhenAvailable>
     <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
-    <RestartOnFailure><Interval>PT1M</Interval><Count>3</Count></RestartOnFailure>
   </Settings>
   <Principals><Principal id="Author"><UserId>S-1-5-18</UserId><RunLevel>HighestAvailable</RunLevel></Principal></Principals>
   <Actions Context="Author"><Exec><Command>cmd.exe</Command><Arguments>/c "$stub"</Arguments></Exec></Actions>
@@ -53,42 +52,38 @@ function Invoke-Case($name, $mode, [bool]$kill) {
 "@
   [System.IO.File]::WriteAllText($xmlPath, $xml, [System.Text.Encoding]::Unicode)
   & schtasks /Create /F /TN $task /XML $xmlPath | Out-Null
-  & schtasks /Run /TN $task | Out-Null
-
-  if ($kill) {
-    Start-Sleep -Seconds 6   # let the action start looping, then crash it
-    $procs = Get-CimInstance Win32_Process -Filter "Name='cmd.exe'" |
-             Where-Object { $_.CommandLine -like "*$stub*" }
-    foreach ($p in $procs) { & taskkill /F /T /PID $p.ProcessId 2>$null | Out-Null }
-    Write-Host "[$name] force-killed $($procs.Count) action process(es)"
-  }
-
-  # Restart (if any) fires after the PT1M interval, so poll past 60s with a deadline.
-  $deadline = (Get-Date).AddSeconds(115)
-  $runs = 0
-  while ((Get-Date) -lt $deadline) {
-    $runs = (Get-Content $counter -ErrorAction SilentlyContinue | Measure-Object -Line).Lines
-    if ($runs -ge 2) { break }
-    Start-Sleep -Seconds 5
-  }
-  & schtasks /End /F /TN $task 2>$null | Out-Null
-  & schtasks /Delete /F /TN $task 2>$null | Out-Null
-  return [int]$runs
 }
 
-Write-Host "== running crux cases (each waits past the PT1M restart floor) =="
-$r0 = Invoke-Case 'exit0' 'exit0' $false
-$r1 = Invoke-Case 'exit1' 'exit1' $false
-$rk = Invoke-Case 'kill'  'hang'  $true
+function Runs($counter) { (Get-Content $counter -ErrorAction SilentlyContinue | Measure-Object -Line).Lines }
+
+# ── relaunch: stub dies each tick → repetition must restart it (runs grows) ──
+$cR = Join-Path $Work 'relaunch.count'; New-Item -ItemType File -Force -Path $cR | Out-Null
+$sR = Join-Path $Work 'relaunch.cmd'; New-Stub $sR $cR 'exit'
+Register-RepeatingTask 'CrSmoke2-relaunch' $sR
+& schtasks /Run /TN 'CrSmoke2-relaunch' | Out-Null     # seed run 1; ticks drive the rest
+$deadline = (Get-Date).AddSeconds(185); $rRelaunch = 0
+while ((Get-Date) -lt $deadline) { $rRelaunch = Runs $cR; if ($rRelaunch -ge 2) { break }; Start-Sleep 5 }
+& schtasks /Delete /F /TN 'CrSmoke2-relaunch' 2>$null | Out-Null
+
+# ── nodup: stub stays alive → IgnoreNew must skip later ticks (runs stays 1) ──
+$cN = Join-Path $Work 'nodup.count'; New-Item -ItemType File -Force -Path $cN | Out-Null
+$sN = Join-Path $Work 'nodup.cmd'; New-Stub $sN $cN 'hang'
+Register-RepeatingTask 'CrSmoke2-nodup' $sN
+& schtasks /Run /TN 'CrSmoke2-nodup' | Out-Null
+Start-Sleep -Seconds 150                                # span >=2 ticks while it's alive
+$rNodup = Runs $cN
+& schtasks /End /F /TN 'CrSmoke2-nodup' 2>$null | Out-Null
+& schtasks /Delete /F /TN 'CrSmoke2-nodup' 2>$null | Out-Null
+Get-CimInstance Win32_Process -Filter "Name='cmd.exe'" |
+  Where-Object { $_.CommandLine -like "*$sN*" } |
+  ForEach-Object { & taskkill /F /T /PID $_.ProcessId 2>$null | Out-Null }
 
 Write-Host ""
-Write-Host "===== RESULTS ====="
-Write-Host "exit0 runs=$r0   (expect 1 = stays down on clean quit/updater handoff)"
-Write-Host "exit1 runs=$r1   (>=2 => RestartOnFailure fires on a graceful non-zero exit)"
-Write-Host "kill  runs=$rk   (>=2 => RestartOnFailure fires on an abnormal kill = real crash)"
-$crash = if ($rk -ge 2) { 'WORKS' } else { 'BROKEN' }
-$quit  = if ($r0 -lt 2) { 'OK' } else { 'UNEXPECTED' }
-Write-Host "VERDICT crash->relaunch:  $crash"
-Write-Host "VERDICT quit->stays-down: $quit"
-# Diagnostic only for now — never fail the job; we're learning the mechanism.
-Write-Host "::notice::crash=$crash quit=$quit (exit0=$r0 exit1=$r1 kill=$rk)"
+Write-Host "===== RESULTS (repeating-trigger mechanism) ====="
+Write-Host "relaunch runs=$rRelaunch   (>=2 => dead action IS relaunched by the repetition)"
+Write-Host "nodup    runs=$rNodup   (==1 => live action is NOT duplicated; IgnoreNew works)"
+$relOk = if ($rRelaunch -ge 2) { 'WORKS' } else { 'BROKEN' }
+$dupOk = if ($rNodup -eq 1) { 'OK' } else { 'DUPLICATED' }
+Write-Host "VERDICT relaunch-on-death: $relOk"
+Write-Host "VERDICT no-dup-when-alive: $dupOk"
+Write-Host "::notice::relaunch=$relOk nodup=$dupOk (relaunch_runs=$rRelaunch nodup_runs=$rNodup)"

--- a/packages/accelerator/scripts/crash-recovery-smoke-windows.ps1
+++ b/packages/accelerator/scripts/crash-recovery-smoke-windows.ps1
@@ -87,3 +87,11 @@ $dupOk = if ($rNodup -eq 1) { 'OK' } else { 'DUPLICATED' }
 Write-Host "VERDICT relaunch-on-death: $relOk"
 Write-Host "VERDICT no-dup-when-alive: $dupOk"
 Write-Host "::notice::relaunch=$relOk nodup=$dupOk (relaunch_runs=$rRelaunch nodup_runs=$rNodup)"
+
+# Standing gate: fail if the mechanism the Windows crash-recovery relies on regresses.
+if ($rRelaunch -ge 2 -and $rNodup -eq 1) {
+  Write-Host "PASS — repeating-trigger crash-recovery mechanism verified"
+} else {
+  Write-Error "FAIL — crash-recovery mechanism regressed (relaunch=$rRelaunch want>=2; nodup=$rNodup want=1)"
+  exit 1
+}

--- a/packages/accelerator/scripts/crash-recovery-smoke-windows.ps1
+++ b/packages/accelerator/scripts/crash-recovery-smoke-windows.ps1
@@ -1,0 +1,94 @@
+#!/usr/bin/env pwsh
+# ── Task Scheduler crash-recovery CRUX spike ───────────────────────────────────
+# The shipped Windows crash-recovery relies on <RestartOnFailure> (Interval PT1M,
+# Count 3) relaunching the app when it dies. Codex (session 019e8e9e) flagged that
+# Microsoft's docs DON'T define "failure" in action-exit-code terms — a graceful
+# non-zero exit may NOT trigger a restart, which would make the feature broken.
+#
+# This isolates the RestartOnFailure mechanism and answers, empirically, on a real
+# runner:
+#   exit0 → must STAY DOWN (clean quit / updater handoff = no relaunch)
+#   exit1 → does a graceful non-zero exit trigger a restart?
+#   kill  → does an ABNORMAL termination (a real crash) trigger a restart?
+#
+# Uses a SYSTEM principal (S-1-5-18) so the task runs headless on a CI runner,
+# deliberately sidestepping the separate InteractiveToken/desktop question (that's
+# about whether the REAL app's task launches at logon on a user's machine — true by
+# design there; only the CI runner lacks a guaranteed interactive desktop). The
+# RestartOnFailure SETTING behaves independently of the principal, so the crux
+# answer transfers.
+$ErrorActionPreference = 'Stop'
+$Work = Join-Path $env:RUNNER_TEMP ("crsmoke-" + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force -Path $Work | Out-Null
+
+function New-Stub($path, $counter, $mode) {
+  $lines = @('@echo off', ">>`"$counter`" echo run")
+  switch ($mode) {
+    'exit0' { $lines += 'exit /b 0' }
+    'exit1' { $lines += 'exit /b 1' }
+    'hang'  { $lines += ':loop', 'ping -n 3 127.0.0.1 >nul', 'goto loop' }
+  }
+  Set-Content -Path $path -Value ($lines -join "`r`n") -Encoding Ascii
+}
+
+function Invoke-Case($name, $mode, [bool]$kill) {
+  $counter = Join-Path $Work "$name.count"
+  New-Item -ItemType File -Force -Path $counter | Out-Null
+  $stub = Join-Path $Work "$name.cmd"
+  New-Stub $stub $counter $mode
+  $task = "CrSmoke-$name-$PID"
+  $xmlPath = Join-Path $Work "$name.xml"
+  # Mirrors the real task_xml restart contract (RestartOnFailure PT1M / Count 3).
+  $xml = @"
+<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
+    <RestartOnFailure><Interval>PT1M</Interval><Count>3</Count></RestartOnFailure>
+  </Settings>
+  <Principals><Principal id="Author"><UserId>S-1-5-18</UserId><RunLevel>HighestAvailable</RunLevel></Principal></Principals>
+  <Actions Context="Author"><Exec><Command>cmd.exe</Command><Arguments>/c "$stub"</Arguments></Exec></Actions>
+</Task>
+"@
+  [System.IO.File]::WriteAllText($xmlPath, $xml, [System.Text.Encoding]::Unicode)
+  & schtasks /Create /F /TN $task /XML $xmlPath | Out-Null
+  & schtasks /Run /TN $task | Out-Null
+
+  if ($kill) {
+    Start-Sleep -Seconds 6   # let the action start looping, then crash it
+    $procs = Get-CimInstance Win32_Process -Filter "Name='cmd.exe'" |
+             Where-Object { $_.CommandLine -like "*$stub*" }
+    foreach ($p in $procs) { & taskkill /F /T /PID $p.ProcessId 2>$null | Out-Null }
+    Write-Host "[$name] force-killed $($procs.Count) action process(es)"
+  }
+
+  # Restart (if any) fires after the PT1M interval, so poll past 60s with a deadline.
+  $deadline = (Get-Date).AddSeconds(115)
+  $runs = 0
+  while ((Get-Date) -lt $deadline) {
+    $runs = (Get-Content $counter -ErrorAction SilentlyContinue | Measure-Object -Line).Lines
+    if ($runs -ge 2) { break }
+    Start-Sleep -Seconds 5
+  }
+  & schtasks /End /F /TN $task 2>$null | Out-Null
+  & schtasks /Delete /F /TN $task 2>$null | Out-Null
+  return [int]$runs
+}
+
+Write-Host "== running crux cases (each waits past the PT1M restart floor) =="
+$r0 = Invoke-Case 'exit0' 'exit0' $false
+$r1 = Invoke-Case 'exit1' 'exit1' $false
+$rk = Invoke-Case 'kill'  'hang'  $true
+
+Write-Host ""
+Write-Host "===== RESULTS ====="
+Write-Host "exit0 runs=$r0   (expect 1 = stays down on clean quit/updater handoff)"
+Write-Host "exit1 runs=$r1   (>=2 => RestartOnFailure fires on a graceful non-zero exit)"
+Write-Host "kill  runs=$rk   (>=2 => RestartOnFailure fires on an abnormal kill = real crash)"
+$crash = if ($rk -ge 2) { 'WORKS' } else { 'BROKEN' }
+$quit  = if ($r0 -lt 2) { 'OK' } else { 'UNEXPECTED' }
+Write-Host "VERDICT crash->relaunch:  $crash"
+Write-Host "VERDICT quit->stays-down: $quit"
+# Diagnostic only for now — never fail the job; we're learning the mechanism.
+Write-Host "::notice::crash=$crash quit=$quit (exit0=$r0 exit1=$r1 kill=$rk)"

--- a/packages/accelerator/src-tauri/src/crash_recovery.rs
+++ b/packages/accelerator/src-tauri/src/crash_recovery.rs
@@ -289,7 +289,9 @@ pub fn disable_crash_recovery() {
             .args(["/Query", "/TN", TASK_NAME])
             .output()
             .map(|o| o.status.success())
-            .unwrap_or(false);
+            // If /Query itself can't run, don't claim the task is gone — assume it may persist
+            // so we keep retrying and ultimately log the error rather than a false success.
+            .unwrap_or(true);
         if !still_present {
             tracing::info!("Task Scheduler crash-recovery task removed (or absent)");
             return;

--- a/packages/accelerator/src-tauri/src/crash_recovery.rs
+++ b/packages/accelerator/src-tauri/src/crash_recovery.rs
@@ -340,6 +340,14 @@ mod tests {
         // Crash → relaunch is the whole point.
         assert!(xml.contains("<RestartOnFailure>"));
         assert!(xml.contains("<LogonTrigger>"));
+        // The restart must be BOUNDED — a finite count + a real interval — else a
+        // crash-looping app would be relaunched forever. PT1M is the documented minimum.
+        assert!(xml.contains("<Interval>PT1M</Interval>"));
+        assert!(xml.contains("<Count>3</Count>"));
+        // The Run key (autostart) AND this task's LogonTrigger both fire at logon;
+        // IgnoreNew tells Task Scheduler not to spawn a second instance if one is up
+        // (the exit-0-if-healthy guard in main.rs handles the Run-key-vs-task race).
+        assert!(xml.contains("<MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>"));
         // The raw ampersand must be escaped or the XML is invalid.
         assert!(xml.contains("A &amp; B"));
         assert!(!xml.contains("A & B"));

--- a/packages/accelerator/src-tauri/src/crash_recovery.rs
+++ b/packages/accelerator/src-tauri/src/crash_recovery.rs
@@ -277,16 +277,29 @@ pub fn enable_crash_recovery() {
 /// Remove the Task Scheduler crash-recovery task. Call after `manager.disable()`.
 #[cfg(target_os = "windows")]
 pub fn disable_crash_recovery() {
-    let result = std::process::Command::new(schtasks_exe())
-        .args(["/Delete", "/F", "/TN", TASK_NAME])
-        .output();
-    match result {
-        Ok(o) if o.status.success() => {
-            tracing::info!("Task Scheduler crash-recovery task removed");
+    // Deletion is correctness-critical now: the repeating-trigger task relaunches the app a
+    // minute after an intentional quit if it survives. So retry, and verify via /Query
+    // (locale-independent — it exits non-zero when the task is absent) rather than trusting
+    // a single best-effort /Delete whose stderr wording varies by Windows language.
+    for attempt in 1..=3 {
+        let _ = std::process::Command::new(schtasks_exe())
+            .args(["/Delete", "/F", "/TN", TASK_NAME])
+            .output();
+        let still_present = std::process::Command::new(schtasks_exe())
+            .args(["/Query", "/TN", TASK_NAME])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if !still_present {
+            tracing::info!("Task Scheduler crash-recovery task removed (or absent)");
+            return;
         }
-        Ok(_) => tracing::debug!("Task Scheduler task not present (already removed)"),
-        Err(e) => tracing::warn!("Failed to run schtasks /Delete: {e}"),
+        tracing::warn!("crash-recovery task still present after /Delete (attempt {attempt})");
+        std::thread::sleep(std::time::Duration::from_millis(200));
     }
+    tracing::error!(
+        "crash-recovery task could NOT be removed after retries — the app may relaunch after an intentional quit"
+    );
 }
 
 /// Build the Task Scheduler task definition. The exe path is XML-escaped.

--- a/packages/accelerator/src-tauri/src/crash_recovery.rs
+++ b/packages/accelerator/src-tauri/src/crash_recovery.rs
@@ -274,9 +274,11 @@ pub fn enable_crash_recovery() {
     }
 }
 
-/// Remove the Task Scheduler crash-recovery task. Call after `manager.disable()`.
+/// Remove the Task Scheduler crash-recovery task. Returns `true` if the task is confirmed gone
+/// (removed or already absent), `false` if removal could not be verified — callers that rely on
+/// the task being gone (the updater, before NSIS mutates files) MUST check this and not proceed.
 #[cfg(target_os = "windows")]
-pub fn disable_crash_recovery() {
+pub fn disable_crash_recovery() -> bool {
     // Deletion is correctness-critical now: the repeating-trigger task relaunches the app a
     // minute after an intentional quit if it survives. So retry, and verify via /Query
     // (locale-independent — it exits non-zero when the task is absent) rather than trusting
@@ -290,11 +292,11 @@ pub fn disable_crash_recovery() {
             .output()
             .map(|o| o.status.success())
             // If /Query itself can't run, don't claim the task is gone — assume it may persist
-            // so we keep retrying and ultimately log the error rather than a false success.
+            // so we keep retrying and ultimately report failure rather than a false success.
             .unwrap_or(true);
         if !still_present {
             tracing::info!("Task Scheduler crash-recovery task removed (or absent)");
-            return;
+            return true;
         }
         tracing::warn!("crash-recovery task still present after /Delete (attempt {attempt})");
         std::thread::sleep(std::time::Duration::from_millis(200));
@@ -302,6 +304,7 @@ pub fn disable_crash_recovery() {
     tracing::error!(
         "crash-recovery task could NOT be removed after retries — the app may relaunch after an intentional quit"
     );
+    false
 }
 
 /// Build the Task Scheduler task definition. The exe path is XML-escaped.

--- a/packages/accelerator/src-tauri/src/crash_recovery.rs
+++ b/packages/accelerator/src-tauri/src/crash_recovery.rs
@@ -178,15 +178,23 @@ pub fn disable_crash_recovery() {
 
 // ── Windows ──────────────────────────────────────────────────────────────────
 //
-// PROVISIONAL mechanism (windows-release-2026-06-02 plan, owner decision):
-// a Task Scheduler task with `RestartOnFailure` — a non-zero exit (crash) relaunches
-// the app; a clean exit 0 (intentional quit) completes the task and is NOT restarted.
-// Mirrors the Linux systemd approach: a separate recovery mechanism alongside the
-// autostart entry created by tauri-plugin-autostart (a Run key on Windows).
+// A Task Scheduler task with a REPEATING TimeTrigger (every PT1M) + IgnoreNew. Every
+// minute Task Scheduler tries to start the app; IgnoreNew makes that a no-op if it's
+// already running and a RELAUNCH if it died — so a crash recovers within <=1 min.
 //
-// Known caveat the P4 gating tests must resolve: the Run key AND the task's logon
-// trigger both fire at logon (potential double-launch). If the crash-vs-quit or
-// updater-handoff tests fail, the sibling-crate watchdog is the documented fallback.
+// Why not `RestartOnFailure`: it was the original design, but it's BROKEN for this —
+// it does NOT relaunch on a non-zero/abnormal process exit (proven empirically on a
+// windows-2025 runner; see lessons/phase-4.md). It only restarts when the task ENGINE
+// fails to start the action, not when the action runs then dies. mac launchd
+// (KeepAlive{SuccessfulExit:false}) and linux systemd (Restart=on-failure) genuinely
+// key on the exit code; the repeating trigger is the working Windows equivalent.
+//
+// The repeating trigger relaunches ANYTHING not running, so it can't distinguish an
+// intentional quit from a crash. The Quit menu therefore calls disable_crash_recovery()
+// (delete this task) BEFORE exiting — see the `"quit"` handler in main.rs. A crash skips
+// that path → the task survives → relaunch; a clean quit deletes it first → stays down.
+// Logon start is handled by the autostart Run key (tauri-plugin-autostart), not this
+// task; the Run-key-vs-tick race is absorbed by the exit-0-if-healthy guard in main.rs.
 
 #[cfg(target_os = "windows")]
 const TASK_NAME: &str = "Aztec Accelerator Crash Recovery";
@@ -292,9 +300,14 @@ fn task_xml(exe_path: &str) -> String {
     <Description>Aztec Accelerator crash recovery</Description>
   </RegistrationInfo>
   <Triggers>
-    <LogonTrigger>
+    <TimeTrigger>
+      <StartBoundary>2024-01-01T00:00:00</StartBoundary>
       <Enabled>true</Enabled>
-    </LogonTrigger>
+      <Repetition>
+        <Interval>PT1M</Interval>
+        <StopAtDurationEnd>false</StopAtDurationEnd>
+      </Repetition>
+    </TimeTrigger>
   </Triggers>
   <Principals>
     <Principal id="Author">
@@ -308,10 +321,6 @@ fn task_xml(exe_path: &str) -> String {
     <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
     <StartWhenAvailable>true</StartWhenAvailable>
     <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
-    <RestartOnFailure>
-      <Interval>PT1M</Interval>
-      <Count>3</Count>
-    </RestartOnFailure>
   </Settings>
   <Actions Context="Author">
     <Exec>
@@ -335,18 +344,26 @@ fn xml_escape(s: &str) -> String {
 mod tests {
     #[test]
     #[cfg(target_os = "windows")]
-    fn task_xml_has_restart_and_escapes_exe() {
+    fn task_xml_uses_repeating_trigger_and_escapes_exe() {
         let xml = super::task_xml(r"C:\Program Files\A & B\aztec-accelerator.exe");
-        // Crash → relaunch is the whole point.
-        assert!(xml.contains("<RestartOnFailure>"));
-        assert!(xml.contains("<LogonTrigger>"));
-        // The restart must be BOUNDED — a finite count + a real interval — else a
-        // crash-looping app would be relaunched forever. PT1M is the documented minimum.
+        // Crash → relaunch is a REPEATING TimeTrigger (every PT1M) + IgnoreNew, proven
+        // on a real runner. NOT RestartOnFailure, which does NOT relaunch a dead/crashed
+        // process (see the module comment + lessons/phase-4.md).
+        assert!(xml.contains("<TimeTrigger>"));
+        assert!(xml.contains("<Repetition>"));
         assert!(xml.contains("<Interval>PT1M</Interval>"));
-        assert!(xml.contains("<Count>3</Count>"));
-        // The Run key (autostart) AND this task's LogonTrigger both fire at logon;
-        // IgnoreNew tells Task Scheduler not to spawn a second instance if one is up
-        // (the exit-0-if-healthy guard in main.rs handles the Run-key-vs-task race).
+        // Regression guards: the broken mechanism must not come back, and logon-start is
+        // the autostart Run key's job (not a LogonTrigger here).
+        assert!(
+            !xml.contains("<RestartOnFailure>"),
+            "RestartOnFailure does not relaunch a crash — regression"
+        );
+        assert!(
+            !xml.contains("<LogonTrigger>"),
+            "logon start is the autostart Run key's job, not this task"
+        );
+        // IgnoreNew = the every-minute tick is a no-op if the app is alive, a relaunch if
+        // it died (the exit-0-if-healthy guard in main.rs absorbs the Run-key-vs-tick race).
         assert!(xml.contains("<MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>"));
         // The raw ampersand must be escaped or the XML is invalid.
         assert!(xml.contains("A &amp; B"));

--- a/packages/accelerator/src-tauri/src/main.rs
+++ b/packages/accelerator/src-tauri/src/main.rs
@@ -270,7 +270,17 @@ fn main() {
 
             let tray =
                 tray::build_tray_icon(app, &menu, move |app, event| match event.id().as_ref() {
-                    "quit" => app.exit(0),
+                    "quit" => {
+                        // The repeating-trigger crash-recovery task relaunches anything not
+                        // running, so an intentional quit must delete it first or the app
+                        // returns within ~1 min. A crash skips this path → the task survives
+                        // → relaunch. Windows-only: mac/linux key on exit code (launchd
+                        // SuccessfulExit:false / systemd on-failure), so a clean quit is a
+                        // no-op there and the recovery entry must persist across quit.
+                        #[cfg(target_os = "windows")]
+                        aztec_accelerator::crash_recovery::disable_crash_recovery();
+                        app.exit(0);
+                    }
                     "show_logs" => open_in_browser(&log_dir()),
                     "open_github" => {
                         open_in_browser(&"https://github.com/alejoamiras/aztec-accelerator");

--- a/packages/accelerator/src-tauri/src/updater.rs
+++ b/packages/accelerator/src-tauri/src/updater.rs
@@ -61,15 +61,6 @@ pub async fn check_for_update(
 pub async fn perform_update(app: &AppHandle, update: tauri_plugin_updater::Update) {
     tracing::info!(version = %update.version, "Downloading update");
 
-    // Windows guard: the crash-recovery task is an always-armed repeating launcher (every
-    // PT1M). If a tick fires while NSIS is mutating the install tree, it could spawn the exe
-    // mid-update — locking the file being replaced or launching a half-written binary.
-    // Disarm it for the install window. On success the relaunched build re-arms on startup
-    // (per autostart); on failure the app keeps running, so we re-arm below. No-op if the
-    // task was never armed (autostart off).
-    #[cfg(target_os = "windows")]
-    crate::crash_recovery::disable_crash_recovery();
-
     match update
         .download_and_install(
             |chunk_length, content_length| {
@@ -81,25 +72,42 @@ pub async fn perform_update(app: &AppHandle, update: tauri_plugin_updater::Updat
             },
             || {
                 tracing::info!("Download complete, installing");
+                // Windows: disarm the always-armed repeating crash-recovery task ONLY now —
+                // right before NSIS mutates the install tree. A tick during that window could
+                // spawn the exe mid-update (lock the file being replaced / launch a half-written
+                // binary). Disarming here (not before the download) keeps a mid-download crash
+                // recoverable. No-op if the task was never armed (autostart off).
+                #[cfg(target_os = "windows")]
+                crate::crash_recovery::disable_crash_recovery();
             },
         )
         .await
     {
         Ok(()) => {
+            // Re-arm BEFORE restarting: a failed relaunch must not leave recovery off while
+            // autostart is on. IgnoreNew + the exit-0-if-healthy guard absorb any brief
+            // double-launch with the restarted build.
+            #[cfg(target_os = "windows")]
+            rearm_crash_recovery_if_enabled(app);
             tracing::info!("Update installed, restarting");
             app.restart();
         }
         Err(e) => {
             tracing::error!("Update failed: {e}");
-            // The app keeps running, so crash-recovery must resume — but only if it should
-            // be armed (autostart on), mirroring the enable condition at startup.
+            // The app keeps running, so crash-recovery must resume (only if it should be
+            // armed — autostart on). Idempotent if it was never disarmed (crash mid-download).
             #[cfg(target_os = "windows")]
-            {
-                use tauri_plugin_autostart::ManagerExt;
-                if app.autolaunch().is_enabled().unwrap_or(false) {
-                    crate::crash_recovery::enable_crash_recovery();
-                }
-            }
+            rearm_crash_recovery_if_enabled(app);
         }
+    }
+}
+
+/// Re-arm the Windows crash-recovery task iff it should be armed (autostart on). Idempotent —
+/// `enable_crash_recovery` overwrites any existing task.
+#[cfg(target_os = "windows")]
+fn rearm_crash_recovery_if_enabled(app: &AppHandle) {
+    use tauri_plugin_autostart::ManagerExt;
+    if app.autolaunch().is_enabled().unwrap_or(false) {
+        crate::crash_recovery::enable_crash_recovery();
     }
 }

--- a/packages/accelerator/src-tauri/src/updater.rs
+++ b/packages/accelerator/src-tauri/src/updater.rs
@@ -61,8 +61,10 @@ pub async fn check_for_update(
 pub async fn perform_update(app: &AppHandle, update: tauri_plugin_updater::Update) {
     tracing::info!(version = %update.version, "Downloading update");
 
-    match update
-        .download_and_install(
+    // Download first (separate from install) so crash-recovery stays armed through the whole
+    // download/verify span — a mid-download crash is still recovered.
+    let bytes = match update
+        .download(
             |chunk_length, content_length| {
                 tracing::info!(
                     chunk_length,
@@ -70,19 +72,31 @@ pub async fn perform_update(app: &AppHandle, update: tauri_plugin_updater::Updat
                     "Download progress"
                 );
             },
-            || {
-                tracing::info!("Download complete, installing");
-                // Windows: disarm the always-armed repeating crash-recovery task ONLY now —
-                // right before NSIS mutates the install tree. A tick during that window could
-                // spawn the exe mid-update (lock the file being replaced / launch a half-written
-                // binary). Disarming here (not before the download) keeps a mid-download crash
-                // recoverable. No-op if the task was never armed (autostart off).
-                #[cfg(target_os = "windows")]
-                crate::crash_recovery::disable_crash_recovery();
-            },
+            || tracing::info!("Download complete"),
         )
         .await
     {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            tracing::error!("Update download failed: {e}");
+            return;
+        }
+    };
+
+    // Windows: disarm the always-armed repeating crash-recovery task right before install. A
+    // tick during NSIS file mutation could spawn the exe mid-update (lock the file being
+    // replaced / launch a half-written binary). If we CANNOT verify the task is gone, do NOT
+    // install — the race would be live; skip this attempt (the app keeps running on the current
+    // version, and the next check retries). disable returns true if never armed (autostart off).
+    #[cfg(target_os = "windows")]
+    if !crate::crash_recovery::disable_crash_recovery() {
+        tracing::error!(
+            "Aborting update install: could not disarm crash-recovery task (race risk)"
+        );
+        return;
+    }
+
+    match update.install(bytes) {
         Ok(()) => {
             // Re-arm BEFORE restarting: a failed relaunch must not leave recovery off while
             // autostart is on. IgnoreNew + the exit-0-if-healthy guard absorb any brief
@@ -93,9 +107,8 @@ pub async fn perform_update(app: &AppHandle, update: tauri_plugin_updater::Updat
             app.restart();
         }
         Err(e) => {
-            tracing::error!("Update failed: {e}");
-            // The app keeps running, so crash-recovery must resume (only if it should be
-            // armed — autostart on). Idempotent if it was never disarmed (crash mid-download).
+            tracing::error!("Update install failed: {e}");
+            // The app keeps running, so crash-recovery must resume (only if it should be armed).
             #[cfg(target_os = "windows")]
             rearm_crash_recovery_if_enabled(app);
         }

--- a/packages/accelerator/src-tauri/src/updater.rs
+++ b/packages/accelerator/src-tauri/src/updater.rs
@@ -93,6 +93,10 @@ pub async fn perform_update(app: &AppHandle, update: tauri_plugin_updater::Updat
         tracing::error!(
             "Aborting update install: could not disarm crash-recovery task (race risk)"
         );
+        // The app keeps running on the current version, and disarm may have PARTIALLY succeeded
+        // (/Delete worked but /Query couldn't confirm), so recovery could now be off. Restore it
+        // before bailing out — every path that leaves the app running must end armed.
+        rearm_crash_recovery_if_enabled(app);
         return;
     }
 

--- a/packages/accelerator/src-tauri/src/updater.rs
+++ b/packages/accelerator/src-tauri/src/updater.rs
@@ -61,6 +61,15 @@ pub async fn check_for_update(
 pub async fn perform_update(app: &AppHandle, update: tauri_plugin_updater::Update) {
     tracing::info!(version = %update.version, "Downloading update");
 
+    // Windows guard: the crash-recovery task is an always-armed repeating launcher (every
+    // PT1M). If a tick fires while NSIS is mutating the install tree, it could spawn the exe
+    // mid-update — locking the file being replaced or launching a half-written binary.
+    // Disarm it for the install window. On success the relaunched build re-arms on startup
+    // (per autostart); on failure the app keeps running, so we re-arm below. No-op if the
+    // task was never armed (autostart off).
+    #[cfg(target_os = "windows")]
+    crate::crash_recovery::disable_crash_recovery();
+
     match update
         .download_and_install(
             |chunk_length, content_length| {
@@ -82,6 +91,15 @@ pub async fn perform_update(app: &AppHandle, update: tauri_plugin_updater::Updat
         }
         Err(e) => {
             tracing::error!("Update failed: {e}");
+            // The app keeps running, so crash-recovery must resume — but only if it should
+            // be armed (autostart on), mirroring the enable condition at startup.
+            #[cfg(target_os = "windows")]
+            {
+                use tauri_plugin_autostart::ManagerExt;
+                if app.autolaunch().is_enabled().unwrap_or(false) {
+                    crate::crash_recovery::enable_crash_recovery();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## The bug (caught pre-release)
Windows crash-recovery shipped on Task Scheduler `RestartOnFailure` — which a real windows-2025 runner proves **does not relaunch a dead/crashed process** (`exit1=1`, `kill=1`). It only restarts when the task ENGINE fails to launch the action, not when the action runs then dies. mac (launchd `KeepAlive{SuccessfulExit:false}`) + linux (systemd `Restart=on-failure`) genuinely work; Windows had no working equivalent. **No users affected — no Windows release exists yet.** Found by a codex consult (019e8e9e) + an empirical spike.

## The fix (owner chose: repeating-trigger)
- **task_xml**: replace `LogonTrigger + RestartOnFailure` with a repeating `TimeTrigger` (PT1M) + keep `IgnoreNew`. Spike-confirmed: relaunches a dead action (`runs=2`), never duplicates a live one (`runs=1`). ≤1-min recovery.
- **disable-on-quit**: a repeating trigger relaunches anything not running, so the tray **Quit** handler now calls `disable_crash_recovery()` before exit — Windows-only, *only* in the explicit quit path (NOT the redundant-instance bow-out or the updater `restart()`, which must keep the task). A crash skips that path → task survives → relaunch.
- **gate**: the smoke is now a standing gate (fails on regression); the unit test asserts the repeating-trigger XML + guards against reintroducing `RestartOnFailure`.

mac/linux behavior is unchanged (all new logic is `#[cfg(target_os = "windows")]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)