### PR TITLE
ci(accelerator): fix windows version-patch steps in release pipeline (rc dry-run caught)

### DIFF
--- a/.github/workflows/release-accelerator.yml
+++ b/.github/workflows/release-accelerator.yml
@@ -114,6 +114,9 @@ jobs:
       - name: Patch version in Cargo.toml
         env:
           RELEASE_VERSION: ${{ needs.validate.outputs.version }}
+        # bash on every platform — the windows-x86_64 matrix leg would otherwise run this in
+        # pwsh, where `sed` + `$RELEASE_VERSION` (a bash var) don't resolve (rc dry-run caught it).
+        shell: bash
         run: |
           cd packages/accelerator/src-tauri
           sed -i.bak "s/^version = \".*\"/version = \"$RELEASE_VERSION\"/" Cargo.toml
@@ -122,6 +125,9 @@ jobs:
       - name: Patch version in tauri.conf.json
         env:
           RELEASE_VERSION: ${{ needs.validate.outputs.version }}
+        # bash on every platform — the multi-line `bun -e` quoting would otherwise be at the
+        # mercy of pwsh on the windows-x86_64 leg.
+        shell: bash
         run: |
           cd packages/accelerator/src-tauri
           bun -e "


### PR DESCRIPTION
The 1.0.4-rc.1 Windows rc dry-run failed at **Patch version in Cargo.toml** (3m53s in, before the build). That step had no `shell:` override, so on the `windows-x86_64` matrix leg it ran in **pwsh**, where `sed` + `$RELEASE_VERSION` (a bash var) don't resolve. The PR-gate windows-build-smoke never patches the version, so this only surfaced in the release pipeline — exactly what the dry-run is for.

Fix: `shell: bash` on both version-patch steps (Cargo.toml + the tauri.conf `bun -e`, whose multi-line quoting was the likely next pwsh casualty). The Build Tauri bundle step already uses `shell: bash` + a Windows NSIS branch, and upload uses an action — so this unblocks the Windows release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)