### PR TITLE
fix(accelerator): recursively find N's nsis artifacts in the windows smoke (rc.2 caught)

### DIFF
--- a/.github/workflows/_e2e-updater-windows.yml
+++ b/.github/workflows/_e2e-updater-windows.yml
@@ -66,9 +66,17 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/n"
-          # Only the updater artifacts (.nsis.zip + .sig) are needed to serve the update.
-          cp "$RUNNER_TEMP"/n-dl/*-setup.nsis.zip "$RUNNER_TEMP/n/"
-          cp "$RUNNER_TEMP"/n-dl/*-setup.nsis.zip.sig "$RUNNER_TEMP/n/"
+          # upload-artifact preserves the bundle/ subdir (the build's path globs span dmg/deb/
+          # appimage/macos/nsis, so the common ancestor is bundle/) — the nsis files land under
+          # n-dl/nsis/, not flat. Find recursively (mirrors the linux smoke's `find`), not a glob.
+          nzip=$(find "$RUNNER_TEMP/n-dl" -name '*-setup.nsis.zip' | head -1)
+          nsig=$(find "$RUNNER_TEMP/n-dl" -name '*-setup.nsis.zip.sig' | head -1)
+          if [ -z "$nzip" ] || [ -z "$nsig" ]; then
+            echo "::error::N updater artifacts (-setup.nsis.zip/.sig) not found in the build artifact"
+            find "$RUNNER_TEMP/n-dl" -type f
+            exit 1
+          fi
+          cp "$nzip" "$nsig" "$RUNNER_TEMP/n/"
           ls -la "$RUNNER_TEMP/n"
 
       # Throwaway key ONLY so tauri will emit N-1's updater artifacts; N-1's .sig is never used.

--- a/implementations-plan/windows-ci-parity-2026-06-03/lessons/phase-3.md
+++ b/implementations-plan/windows-ci-parity-2026-06-03/lessons/phase-3.md
@@ -30,3 +30,10 @@ OWNER-DISPATCHED rc dry-run is the validation. Iterations are expensive (rc-gate
   update-smoke-linux (gate on validate only) so an unrelated mac/linux leg failure doesn't skip the
   Windows validation; the download-artifact step fails cleanly if the windows artifact is missing.
 - Trust chain, artifact flow, version/feed (no live 9.9.9), negative leg: all confirmed fine.
+
+## rc.2 caught a flat-glob bug (fixed)
+rc.2's Windows smoke failed at "Stage N updater artifacts": `cp n-dl/*-setup.nsis.zip` → No such
+file. upload-artifact NESTS the nsis files in `n-dl/nsis/` (the build's path globs span dmg/deb/
+appimage/macos/nsis → common ancestor is `bundle/`, so the subdir is preserved). Fixed with a
+recursive `find` (mirrors the linux smoke's `find n1 -name '*.AppImage'`) + a clear error that lists
+the artifact tree. The trust chain / update logic wasn't reached — re-validate on the next rc.


### PR DESCRIPTION
rc.2 caught a flat-glob bug in the P5 rework: `cp n-dl/*-setup.nsis.zip` failed because `upload-artifact` nests the nsis files under `n-dl/nsis/` (the build's path globs span dmg/deb/appimage/macos/nsis → common ancestor is `bundle/`). Fixed with a recursive `find` (mirrors the linux smoke) + a clear error that lists the artifact tree. Trust-chain/update logic wasn't reached on rc.2 — re-validate on the next rc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)