### PR TITLE
ci(accelerator): flip Windows updater-smoke to blocking

### DIFF
--- a/.github/workflows/release-accelerator.yml
+++ b/.github/workflows/release-accelerator.yml
@@ -502,13 +502,12 @@ jobs:
     with:
       n-version: ${{ needs.validate.outputs.version }}
 
-  # Windows/NSIS updater smoke — ADVISORY. Tests the REAL prod-signed Windows artifact (this run's
+  # Windows/NSIS updater smoke — BLOCKING (in tag.needs + release.needs), proven green on the
+  # 1.0.4-rc.3 dry-run (positive + negative). Tests the REAL prod-signed Windows artifact (this run's
   # `build` output) installing as an auto-update FROM a synthetic N-1 that embeds the prod pubkey —
   # parity with the mac/linux smokes (they download a real N-1 stable; Windows has no stable yet, so
-  # it bootstraps N-1 in-job). Proves the click-free update (positive) + tampered-artifact rejection
-  # (negative). NOT in tag/release `needs` yet — STAGED: prove this real-artifact path on a green
-  # Windows rc dry-run, THEN flip to blocking (add both to tag.needs + release.needs).
-  # REVERT: to demote back to advisory, drop both from tag.needs/release.needs (this is the state).
+  # it bootstraps N-1 in-job). Once a Windows STABLE exists, switch N-1 to the linux download-real-N-1.
+  # REVERT (if it flakes): drop both jobs from tag.needs/release.needs to demote back to advisory.
   update-smoke-windows:
     name: Updater Smoke (windows-x86_64 / positive)
     needs: [validate, build]
@@ -535,7 +534,7 @@ jobs:
 
   tag:
     name: Create Git Tag
-    needs: [validate, build, build-headless, smoke, smoke-intel, update-smoke, update-smoke-linux, e2e-webdriver]
+    needs: [validate, build, build-headless, smoke, smoke-intel, update-smoke, update-smoke-linux, update-smoke-windows, update-smoke-windows-negative, e2e-webdriver]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -558,7 +557,7 @@ jobs:
 
   release:
     name: Create GitHub Release
-    needs: [validate, build, build-headless, smoke, smoke-intel, update-smoke, update-smoke-linux, tag, e2e-webdriver]
+    needs: [validate, build, build-headless, smoke, smoke-intel, update-smoke, update-smoke-linux, update-smoke-windows, update-smoke-windows-negative, tag, e2e-webdriver]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
## What

Promote the Windows NSIS updater-smoke from **advisory** to **blocking**: add
`update-smoke-windows` + `update-smoke-windows-negative` to `tag.needs` and
`release.needs` in `release-accelerator.yml`. A failed Windows auto-update smoke
now blocks the tag and GitHub release — **full parity with the mac/Linux updater
gates**, which already gate there with the identical pattern.

## Why now

Proven green on the **1.0.4-rc.3** dry-run (the staged plan: validate the
real-artifact rework on a green advisory rc, *then* flip):

- **positive** — the real prod-signed Windows `-setup.nsis.zip` installs as a
  click-free minisign-verified auto-update from a synthetic N-1 that embeds the
  committed prod pubkey;
- **negative** — a tampered artifact is rejected against the prod pubkey;
- the run **tagged + released** (not wedged).

This is the final step of the `windows-ci-parity-2026-06-03` plan (#93 / P5):
Windows reaches the same release-pipeline assurance as Linux/macOS.

## Wedge analysis

`tag` is pure needs-gated (no `if:`). The two Windows jobs carry the same
`if: !cancelled() && needs.validate.result == 'success'` as the mac/Linux smokes,
so a `validate` failure skips them — but `validate` is already a shared need, so
no new wedge path is introduced. The green path is mechanically identical to the
already-working mac/Linux gates.

**Revert (if it flakes):** drop both jobs from `tag.needs`/`release.needs` to
demote back to advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)