### PR TITLE
chore: ignore .claude session lock + drop stray empty file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ infra/tofu/.snapshot/
 .pnp.*
 .yarn/
 yarn.lock
+
+# Claude Code local runtime state (settings.local.json is already ignored globally)
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
Small repo hygiene.

- **`.gitignore`**: ignore `.claude/scheduled_tasks.lock` — Claude Code's per-session
  task lock (local runtime state holding the session's PID/start-time so concurrent
  sessions don't clobber scheduled tasks). It was the reason `.claude/` showed up as an
  untracked commit candidate. (`.claude/settings.local.json` is already ignored globally.)
- Removed a stray empty root file `amp` (0 bytes, untracked, never committed — an accidental
  `> amp`/`touch`); local-only deletion, nothing to commit for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)