### PR TITLE
test(accelerator): prove the Windows disarm-before-install actually ran (#97)

### DIFF
--- a/implementations-plan/windows-disarm-proof-2026-06-04/audit-codex.md
+++ b/implementations-plan/windows-disarm-proof-2026-06-04/audit-codex.md
@@ -1,0 +1,44 @@
+# Codex audit (xhigh, session 019e93b2) — #97 plan — verdict: needs-rework
+
+## The reframe (most important)
+Codex argues for **state-proof over log-proof**, which dissolves most of the plan's complexity:
+
+> "If you want state-proof rather than log-proof, a background `schtasks /Query` poller that records
+> 'task absent at least once during install' is stronger and removes the prod-log dependency."
+
+This is **better** and I'm adopting it (pending owner re-confirm of decision #3):
+- The disarm removes the task, THEN the NSIS install runs (seconds), THEN re-arm (updater.rs:86-110).
+  So the task is **absent for the whole multi-second install window** — NOT "too brief" (my original
+  dismissal was wrong). A ~200-300ms background `/Query` poller reliably samples that absence.
+- Observing the task **actually absent** proves the disarm's *effect* directly — no trust in an
+  instrumentation string, and it catches the regression log-proof misses (codex Medium: a stub that
+  returns `true` + emits the exact log line without deleting would pass log-proof).
+- **No prod-code change** → the correctness-critical `disable_crash_recovery()` stays untouched
+  (eliminates codex's Critical + the whole stdout-vs-file fight).
+- The 5s initial update delay (main.rs:432) guarantees the poller is up + has confirmed the task
+  PRESENT before the disarm fires → clean present→absent→present ordering, no race.
+
+## Findings (all dissolved by going state-proof)
+- **Critical — up-front /Query must not short-circuit deletion.** My draft's "cleanly absent → return
+  true without /Delete" is a NEW false-success path: a lying pre-/Query → skip delete → updater installs
+  with the task still armed. Today the loop ALWAYS deletes. (Moot under state-proof: no Rust change.)
+- **High — "read newest log file" is brittle for a blocking gate.** Daily UTC rotation (main.rs:185,
+  lib.rs:18): a run crossing UTC midnight splits arm/disarm/re-arm across files → false-red. (Moot: no
+  log read.)
+- **Medium — "only residual is a lying /Query" overstated** for log-proof: trusts an instrumentation
+  string; a regression emitting the line without deleting passes. (State-proof removes this.)
+- **Low — rc-only validation:** the Windows unit test IS reachable in PR CI — `windows-build` runs
+  `cargo test` on windows-latest (accelerator.yml:295). But end-to-end the smoke needs the rc.
+
+## Codex vs opus on stdout-vs-file (now moot)
+- Opus: assert on **stdout** (LineWriter, flushed per line; non-blocking file loses the tail on
+  `app.restart()`→`std::process::exit`).
+- Codex: the persisted **file** is better than stdout — the script doesn't capture app stdout today
+  (ps1:177), and `app.restart()` (new process) makes single-process stdout capture "the wrong primitive."
+- **Resolution:** state-proof reads NEITHER — it polls task state. Both concerns evaporate.
+
+## What's fine (per codex)
+- "A permanent `false` from `disable_crash_recovery()` already fails the smoke" is **correct** — the
+  updater aborts before install (updater.rs:92) and the background updater only retries after 12h
+  following the initial 5s check (main.rs:432). So the only gap is "returns true without removing,"
+  which state-proof catches by observing real absence.

--- a/implementations-plan/windows-disarm-proof-2026-06-04/audit-opus.md
+++ b/implementations-plan/windows-disarm-proof-2026-06-04/audit-opus.md
@@ -1,0 +1,43 @@
+# Opus subagent audit (Plan, model opus) — #97 plan
+
+**Verdict: approve-with-changes.** Core insight confirmed sound: a `false`-returning disarm already
+fails the smoke (updater.rs:92 aborts → `/health` stays N-1 → positive leg dies at ps1:222), so the
+only uncaught regression is a disarm that returns `true` WITHOUT removing — and a "removed (was armed)"
+log assertion is the right tool. Prod-guard integrity preserved.
+
+## Ranked concerns
+
+**1. (WEDGE RISK — load-bearing) Flush across `app.restart()` is NOT covered by "read the file."**
+The disarm line is written by N-1's `non_blocking` appender (main.rs:192, background-thread flush).
+`app.restart()` resolves to `std::process::exit` (code=Some(i32::MAX), main.rs:475 path), which does
+NOT run the `_guard` destructor → N-1's tail buffer (which may include the `removed` line if written
+late) can be lost, and N never re-writes it. The NSIS install gives time but there's no flush barrier.
+A bounded poll can't recover a never-flushed line → a hard assertion on the FILE can **false-RED a
+blocking gate**. → ADOPTED FIX: assert on N-1's **stdout** (captured via `Start-Process
+-RedirectStandardOutput`), not the non-blocking file. The stdout layer (main.rs:198) is RAW
+`std::io::stdout()` = Rust `LineWriter`, flushed per newline → the `removed` line is on disk before the
+NSIS install even starts. Sidesteps the flush-race without a prod flush change.
+
+**2. (FACTUAL) Wrong line for the load-bearing log.** Disarm-success `info!` is **crash_recovery.rs:298**
+(verified), not :303 (that's the `sleep`). Listed under "Facts (verified)" but wasn't. → ADOPTED: fix
+the cite to :298.
+
+**3. (FALSE-GREEN gap) "registered after removed" ordering for re-arm is unreliable.** Re-arm is
+conditional on `app.autolaunch().is_enabled()` (updater.rs:127 — true here, Run key set ps1:171), and
+the post-restart N `registered` may not be captured / the pre-restart one may be the lost line. →
+ADOPTED: the HARD re-arm assertion stays the durable post-update `schtasks /Query` PRESENT check; the
+log ordering is SOFT corroboration (warn, never `Write-Error`). With the stdout-capture fix, N-1's
+pre-restart re-arm `registered` is also reliably captured.
+
+**4. (CONFIRMED FINE) `.unwrap_or(true)` for the new up-front `/Query` is the correct safe default** —
+unreadable Query → treat as present → go through delete loop → never short-circuit `return true`.
+Verified against the existing `still_present` default (crash_recovery.rs:296). No new
+`true`-while-present path. Skipping the no-op `/Delete` in the genuinely-absent case is safe.
+
+## What's fine (per opus)
+- Refactor preserves the `bool` contract + 3-attempt retry; updater abort path (updater.rs:92-101) untouched.
+- `workflow_dispatch` genuinely absent from `_e2e-updater-windows.yml` → rc-only validation claim holds.
+- Security/least-privilege: no new secrets/net/deps; `permissions: contents: read` unchanged; fixed-string log.
+- Residual "lying /Query" correctly identified as the only escape and correctly scoped out.
+- `Dump-Logs` reads the exact dir (ps1:80); TASK_NAME (:200), arm log (:267), test block (:361) accurate.
+- `mid` tier is right.

--- a/implementations-plan/windows-disarm-proof-2026-06-04/lessons/phase-1.md
+++ b/implementations-plan/windows-disarm-proof-2026-06-04/lessons/phase-1.md
@@ -73,3 +73,14 @@ Conscious residual (NOT a defect): the `maxAbsentStreak >= 3` threshold isn't ai
 consecutive transient schtasks failure, but raising it risks false-RED on a fast install. For a
 BLOCKING gate, not-wedging is the priority + a 3-failure burst (while the app's own schtasks calls
 succeed) is implausible. The rc reveals the real streak (expected 10-40) → tune the floor up then.
+
+## Codex final confirm (minor — no new defects) + last touch
+Fix 2 (Receive-Job) confirmed clean. Fixes 1+3 "improve but not fully airtight":
+- #1 (poller-before-launch): added a best-effort BARRIER — after Start-Job, peek `Receive-Job -Keep`
+  until the poller has emitted ≥1 sample (i.e. is actually sampling) before launching. -Keep is
+  non-destructive so the final read still sees every sample. (The 5s disarm margin already covered it;
+  this makes "before launch" meaningful rather than racy.)
+- #3 (pre-clean verify treats any non-zero /Query as gone): ACCEPTED as-is — ephemeral CI runners have
+  no stale task, and a false-green needs BOTH a silently-failed /Delete AND a /Query error at once;
+  the exit-0-only-fails-closed pattern matches the Rust convention (crash_recovery.rs). Documented, not
+  closed. Verdict was minor → shipping; the rc is the real integration proof.

--- a/implementations-plan/windows-disarm-proof-2026-06-04/lessons/phase-1.md
+++ b/implementations-plan/windows-disarm-proof-2026-06-04/lessons/phase-1.md
@@ -58,3 +58,18 @@ Mechanics: poller writes "`<sawPresent> <maxStreak>`" to `$Work/task-state.txt` 
 parent Stop-Job → reads it → asserts sawPresent==1 AND maxStreak>=3, then the durable re-arm /Query.
 Job is stopped in the success path and in Cleanup (`finally`) so it can't leak. The `>=3` threshold is
 the one rc-tunable knob if a future install is unusually fast (the window is install-bound, seconds).
+
+## Codex re-review (still-High) → 3 more fixes
+1. **Poller started AFTER launch** → Start-Job latency could miss first-present + the absent window
+   (false-RED). FIX: start the poller BEFORE Start-Process (in the positive arming block). The
+   pre-registration absence isn't miscounted — the `sawPresent` gate only counts the streak after the
+   task was first seen present.
+2. **Stop-Job→Get-Content torn read** (fail-closed "0 0" flake). FIX: dropped file IPC; the job emits
+   "<sawPresent> <maxStreak>" to its output stream; parent reads the LAST line via Receive-Job.
+3. **Pre-clean delete unverified** (a surviving stale task could satisfy arming). FIX: /Query after
+   /Delete; fail closed if the task survived. Combined with the verified-gone state + poller-before-
+   launch, `sawPresent==1` now provably means THIS run's N-1 registered the task.
+Conscious residual (NOT a defect): the `maxAbsentStreak >= 3` threshold isn't airtight against a 3+
+consecutive transient schtasks failure, but raising it risks false-RED on a fast install. For a
+BLOCKING gate, not-wedging is the priority + a 3-failure burst (while the app's own schtasks calls
+succeed) is implausible. The rc reveals the real streak (expected 10-40) → tune the floor up then.

--- a/implementations-plan/windows-disarm-proof-2026-06-04/lessons/phase-1.md
+++ b/implementations-plan/windows-disarm-proof-2026-06-04/lessons/phase-1.md
@@ -37,3 +37,24 @@ NON-disarming guard) and wouldn't prevent the race anyway. Out of scope.
   review + the rc are the gates.
 - Phase 2 = owner-dispatched rc dry-run (the smoke runs only in the release pipeline since P5 dropped
   workflow_dispatch). SURFACE + STOP for that.
+
+## Codex post-impl (High) → reworked to a decoupled poller
+The first cut coupled /Query sampling into the /health loop. Codex post-impl (verdict High, would not
+trust as a blocking gate) flagged three real issues; all fixed:
+1. **Cadence not really 500ms** — Invoke-RestMethod (≤2-3s) blocked each tick, so a /health stall
+   spread samples and a fast install could be missed (false-RED/wedge); the "300s" comment was wrong
+   (worst case ~25min). → FIX: a **decoupled `Start-Job` background poller** samples /Query every
+   ~200ms independently; the /health wait loop (150×2s=300s) no longer gates sampling.
+2. **False-GREEN on a transient schtasks error** — `$sawAbsent` flipped on ANY non-zero exit. → FIX:
+   the poller tracks the longest run of CONSECUTIVE absent samples after first-present; assert
+   `maxAbsentStreak >= 3` (~≥600ms) — a one-off blip is streak 1 (filtered); the real install-window
+   absence is seconds (streak 10-40+).
+3. **Hollow arming proof** — no pre-run cleanup, so a stale task could satisfy it. → FIX: delete any
+   stale task before launch (the arming block); the poller's `sawPresent` only counts a real
+   registration by THIS run's N-1, and the absent-streak is only counted AFTER first-present (so the
+   post-cleanup pre-registration gap isn't miscounted as the disarm).
+
+Mechanics: poller writes "`<sawPresent> <maxStreak>`" to `$Work/task-state.txt` each tick (file IPC);
+parent Stop-Job → reads it → asserts sawPresent==1 AND maxStreak>=3, then the durable re-arm /Query.
+Job is stopped in the success path and in Cleanup (`finally`) so it can't leak. The `>=3` threshold is
+the one rc-tunable knob if a future install is unusually fast (the window is install-bound, seconds).

--- a/implementations-plan/windows-disarm-proof-2026-06-04/lessons/phase-1.md
+++ b/implementations-plan/windows-disarm-proof-2026-06-04/lessons/phase-1.md
@@ -1,0 +1,39 @@
+# Phase 1 — state-proof full-cycle assertion (updater-smoke-windows.ps1)
+
+## Design pivot (dual audit → owner)
+Drafted as log-proof (tighten disable_crash_recovery's log + grep it). Both audits killed it:
+- Codex (needs-rework): proposed STATE-proof — a background schtasks /Query poller asserting "task
+  absent at least once during install". Stronger (observes the disarm's real effect, not a log string)
+  + removes the prod-log dependency. My "absence too brief to observe" premise was WRONG: the task is
+  gone for the ENTIRE NSIS install (disable → install → re-arm, updater.rs:86-110) = seconds.
+- Opus (approve-with-changes): the log-proof file read could false-RED a blocking gate (non-blocking
+  appender loses N-1's tail on app.restart()→std::process::exit). Moot under state-proof (no log read).
+- Owner chose "A" (the watcher) after an ELI5.
+
+## What shipped
+Positive leg now proves the full cycle from OBSERVED TASK STATE (no Rust change, no log parsing):
+1. ARMED: poll schtasks /Query until PRESENT before the update (bounded ~20s) — proves N-1 registered
+   the task. Safe to run pre-disarm: first update check is 5s post-launch (main.rs:436).
+2. DISARMED: tightened the /health poll to 500ms; each tick samples schtasks /Query FIRST (cheap, never
+   blocks) and sets $sawAbsent on absence. On /health==N, assert $sawAbsent — the task was physically
+   removed during the install. A non-disarming regression → never absent → FAIL (the end-state re-arm
+   check alone would hide it — the exact #96 gap).
+3. RE-ARMED: kept the #96 durable end-state check (task PRESENT after the update).
+Negative leg untouched (tampered artifact rejected before install → no disarm → no absence assertion).
+
+## Why 500ms sampling is reliable (not flaky)
+Absence window = the NSIS install = seconds, and N-1's /health server stays up DURING the install
+(separate axum task), so the loop keeps a tight cadence exactly when it matters. The slow /health
+timeout only bites later (during the restart), after absence is already recorded. Sampling /Query
+before /health each tick guarantees the sample isn't lost to a /health stall.
+
+## Residual (documented, accepted)
+A watcher can't prove ordering beyond present→absent→present; a pathological remove-then-instantly-
+re-arm-before-install would read as a valid cycle — but that's not the regression class in scope (a
+NON-disarming guard) and wouldn't prevent the race anyway. Out of scope.
+
+## Validation
+- bun run lint:actions exit 0 (workflow untouched). pwsh not installed locally → no PS lint; careful
+  review + the rc are the gates.
+- Phase 2 = owner-dispatched rc dry-run (the smoke runs only in the release pipeline since P5 dropped
+  workflow_dispatch). SURFACE + STOP for that.

--- a/implementations-plan/windows-disarm-proof-2026-06-04/plan.md
+++ b/implementations-plan/windows-disarm-proof-2026-06-04/plan.md
@@ -35,20 +35,19 @@ in favour of **state-proof**, and the owner chose it ("A — the watcher"):
 ## Phase 1 — PowerShell: state-proof full-cycle assertion (positive leg)
 **File:** `packages/accelerator/scripts/updater-smoke-windows.ps1` (positive leg, L193-221). No Rust.
 
-Replace the end-state-only check with a three-part observed-state proof:
-1. **Armed (pre-update):** after launching N-1, poll `schtasks /Query /TN "Aztec Accelerator Crash
-   Recovery"` until PRESENT (bounded ~20s). Fail if never present → N-1's autostart Run key / startup
-   `enable_crash_recovery()` regressed. (Run before the disarm can fire — safe because the first update
-   check is 5s post-launch, main.rs:436.)
-2. **Disarmed-during-install (the new teeth):** tighten the `/health` poll loop to ~500ms and, each
-   tick, sample `schtasks /Query` *first* (cheap, never blocks); set `$sawAbsent` if it reports absent.
-   On `/health == N`, assert `$sawAbsent` — the task was physically removed during the update. If it
-   was armed the whole time, `disable_crash_recovery()` never ran → fail loudly. (~500ms sampling
-   reliably catches a seconds-long, install-bound absence; N-1's `/health` server stays up *during* the
-   install, so the cadence is tight when it matters; the slow `/health` timeout only bites later, during
-   the restart, after absence is already recorded.)
-3. **Re-armed (post-update, durable):** keep the existing #96 check — task PRESENT again after the
-   update (the re-arm end-state).
+Replace the end-state-only check with an observed-state proof via a **decoupled background poller**
+(reworked per codex post-impl — see lessons/phase-1.md):
+0. **Pre-run cleanup:** before launching N-1 (positive leg), delete any stale crash-recovery task, so
+   the "armed" observation below provably reflects THIS run's registration (not a leftover).
+1. **Decoupled poller:** after launch, a `Start-Job` poller samples `schtasks /Query` every ~200ms —
+   *independent of `/health` latency* — recording whether the task was ever PRESENT (armed) and the
+   longest run of **consecutive** ABSENT samples after first-present (the disarm). Writes
+   `<sawPresent> <maxStreak>` to a state file each tick.
+2. **Assert the cycle** once `/health == N` (a separate 150×2s=300s wait loop): stop the job, read the
+   state, require **armed** (`sawPresent==1`) + **disarmed** (`maxStreak >= 3` ≈ ≥600ms sustained —
+   filters a one-off `schtasks` error; the real install-window absence is seconds) + **re-armed** (the
+   durable #96 `/Query` PRESENT check). The job is stopped in the success path and in `Cleanup`
+   (`finally`) so it can't leak.
 
 Each failure `Write-Error`s a specific cause + `Dump-Logs` + `exit 1`. **Negative leg unchanged** (the
 tampered artifact is rejected *before* install → no disarm → must NOT assert absence). The
@@ -84,12 +83,12 @@ No STABLE release. rc dry-run only, owner-dispatched.
   surfaces the app log dir for debugging (`:80`).
 
 ### Inferences (attack these)
-- The absence window (disarm → re-arm) spans the entire NSIS install (seconds) → ~500ms sampling
-  reliably observes it. *If wrong* (sub-500ms install): tighten the interval; the window is install-
-  bound so this is conservative.
-- N-1's `/health` server stays responsive during `update.install()` (separate axum task), so the
-  combined loop keeps a tight `/Query` cadence during the absence. *If wrong:* sampling `/Query` first
-  each tick still records absence before any `/health` stall.
+- The absence window (disarm → re-arm) spans the entire NSIS install (seconds) → ~200ms decoupled
+  sampling yields a consecutive-absent streak ≫3. *If wrong* (sub-600ms install): lower the `maxStreak`
+  threshold; the window is install-bound so 3 is conservative. (The one rc-tunable knob.)
+- `Start-Job` runs reliably on windows-latest and the file-IPC state is readable after `Stop-Job` (the
+  job's last `Set-Content` completed before the parent reads). *If wrong:* the parent defaults to
+  "0 0" → ARMING proof fails closed (a broken poller fails the gate, not a false-green).
 - No prod-code change ⇒ zero risk to the disarm guard itself (only the test gets stricter).
 
 ### Asks (resolved)

--- a/implementations-plan/windows-disarm-proof-2026-06-04/plan.md
+++ b/implementations-plan/windows-disarm-proof-2026-06-04/plan.md
@@ -1,0 +1,140 @@
+# Windows updater-smoke: prove the disarm-before-install actually ran (#97)
+
+**Tier:** `/plan mid` (codex + opus dual audit — both done; verdicts + the design pivot below).
+**Status:** ✅ approach locked (**state-proof**, owner chose "A") → implement → owner rc dry-run.
+
+## North star
+The Windows updater-smoke is a BLOCKING release gate. Today its crash-recovery check is
+**end-state-only** (asserts the Task Scheduler task is PRESENT after the update) — so a regression that
+never disarms would still pass green, shipping the half-written-binary install race. Make the smoke
+**prove the disarm actually happened** by observing the task **physically absent during the install**,
+so the guard can't silently rot.
+
+## The design pivot (what the dual audit changed)
+The draft was *log-proof* (tighten `disable_crash_recovery()`'s log + grep it). Both audits killed it
+in favour of **state-proof**, and the owner chose it ("A — the watcher"):
+- **Codex (needs-rework → proposed state-proof):** a background `schtasks /Query` poller that records
+  "task absent at least once during install" is stronger and removes the prod-log dependency. My
+  "absence is too brief to observe" premise was **wrong** — the task is gone for the **whole NSIS
+  install (seconds)**: `disable_crash_recovery()` → `update.install()` → re-arm (updater.rs:86-110).
+- **Opus (approve-with-changes):** the log-proof file read could false-RED a blocking gate (the
+  non-blocking appender can lose N-1's tail on `app.restart()`→`std::process::exit`). State-proof reads
+  no log, so this evaporates.
+- **Net:** observe real task state, not a log string a regression could fake; **no change to the
+  correctness-critical `disable_crash_recovery()`**; no log flush/rotation/capture fragility.
+
+## Decisions (owner)
+1. **Validation:** one owner-dispatched **rc dry-run** after merge (the smoke runs only in the release
+   pipeline — P5 removed its `workflow_dispatch` trigger).
+2. **Assertion strength:** prove the **full armed → disarm → re-arm cycle**.
+3. **Mechanism:** **state-proof** (watch the task go absent), **not** the prod-log change. The prod fn
+   is left untouched.
+
+---
+
+## Phase 1 — PowerShell: state-proof full-cycle assertion (positive leg)
+**File:** `packages/accelerator/scripts/updater-smoke-windows.ps1` (positive leg, L193-221). No Rust.
+
+Replace the end-state-only check with a three-part observed-state proof:
+1. **Armed (pre-update):** after launching N-1, poll `schtasks /Query /TN "Aztec Accelerator Crash
+   Recovery"` until PRESENT (bounded ~20s). Fail if never present → N-1's autostart Run key / startup
+   `enable_crash_recovery()` regressed. (Run before the disarm can fire — safe because the first update
+   check is 5s post-launch, main.rs:436.)
+2. **Disarmed-during-install (the new teeth):** tighten the `/health` poll loop to ~500ms and, each
+   tick, sample `schtasks /Query` *first* (cheap, never blocks); set `$sawAbsent` if it reports absent.
+   On `/health == N`, assert `$sawAbsent` — the task was physically removed during the update. If it
+   was armed the whole time, `disable_crash_recovery()` never ran → fail loudly. (~500ms sampling
+   reliably catches a seconds-long, install-bound absence; N-1's `/health` server stays up *during* the
+   install, so the cadence is tight when it matters; the slow `/health` timeout only bites later, during
+   the restart, after absence is already recorded.)
+3. **Re-armed (post-update, durable):** keep the existing #96 check — task PRESENT again after the
+   update (the re-arm end-state).
+
+Each failure `Write-Error`s a specific cause + `Dump-Logs` + `exit 1`. **Negative leg unchanged** (the
+tampered artifact is rejected *before* install → no disarm → must NOT assert absence). The
+`$Mode -eq "positive"` arming guard stays symmetric.
+
+**Validation:** `bun run lint:actions` (workflow untouched but reachable); careful PS authoring (no repo
+PowerShell linter); end-to-end only via the rc (Phase 2).
+
+---
+
+## Phase 2 — rc dry-run validation (owner-gated)
+After Phase 1 merges, **surface + stop** for the owner to dispatch `1.0.4-rc.N`. Verify:
+- `Updater Smoke (windows-x86_64 / positive)` **green** with the three signals exercised (the step log
+  shows "arming confirmed" / "disarm confirmed — task observed absent" / "re-arm confirmed").
+- `Updater Smoke (windows-x86_64 / negative)` still green (no absence assertion on that leg).
+- tag + release still produced (the blocking gate didn't wedge).
+
+No STABLE release. rc dry-run only, owner-dispatched.
+
+---
+
+## Assumptions
+
+### Facts (verified against files)
+- Disarm → install → re-arm order, install aborts on `!disable_crash_recovery()`: `updater.rs:86-110`.
+- First update check is **5s** after launch, then every 12h: `main.rs:432-439`. → the watcher confirms
+  PRESENT before any disarm can fire.
+- `TASK_NAME = "Aztec Accelerator Crash Recovery"` (`crash_recovery.rs:200`); `schtasks /Query` exits
+  non-zero when the task is absent (locale-independent — already relied on at `crash_recovery.rs:291`).
+- The smoke runs only in the release pipeline (`workflow_dispatch` removed from
+  `_e2e-updater-windows.yml` in P5) → integration validation needs an rc.
+- Current positive leg is end-state-only (`updater-smoke-windows.ps1:193-221`); `Dump-Logs` already
+  surfaces the app log dir for debugging (`:80`).
+
+### Inferences (attack these)
+- The absence window (disarm → re-arm) spans the entire NSIS install (seconds) → ~500ms sampling
+  reliably observes it. *If wrong* (sub-500ms install): tighten the interval; the window is install-
+  bound so this is conservative.
+- N-1's `/health` server stays responsive during `update.install()` (separate axum task), so the
+  combined loop keeps a tight `/Query` cadence during the absence. *If wrong:* sampling `/Query` first
+  each tick still records absence before any `/health` stall.
+- No prod-code change ⇒ zero risk to the disarm guard itself (only the test gets stricter).
+
+### Asks (resolved)
+- Owner chose state-proof ("A"), full cycle, one rc validation. No open asks.
+- Residual (documented, accepted): a watcher can't prove *ordering* beyond present→absent→present; a
+  pathological disarm that removes-then-instantly-re-arms before install would still read as a valid
+  cycle — but that is not the regression class in scope (a *non-disarming* guard), and it would not
+  actually prevent the race anyway, so it's out of scope.
+
+---
+
+## Security & Adversarial Considerations
+- **Threat model.** Test-only change (one PowerShell file). No prod code, no secrets, no network, no
+  deps, no crypto. The updater trust chain (minisign, pubkey, feed) is untouched.
+- **Wedge / false-RED (the only real risk).** The new assertions run **only** in the positive leg,
+  **only** after a successful update. The single flake vector is "didn't observe absence" → mitigated
+  by tight install-window sampling + the 5s pre-disarm margin + sampling `/Query` before the blocking
+  `/health` call. The negative leg is untouched.
+- **False-GREEN closed.** Observing the task physically absent proves the disarm's *effect*, not a log
+  claim a regression could emit without acting (the log-proof gap codex flagged).
+- **Least privilege.** `permissions: contents: read` on the smoke job unchanged. `schtasks /Query` is a
+  read-only local call. No attacker-influenced inputs.
+
+---
+
+## Audit verdicts
+- **Opus subagent (Plan, opus):** approve-with-changes — caught the file-flush wedge risk (→ moot under
+  state-proof). Full transcript: `audit-opus.md`.
+- **Codex (xhigh, 019e93b2):** needs-rework — proposed the state-proof pivot now adopted; confirmed a
+  permanent `false` disarm already fails the smoke, so the only gap was "returns true without removing,"
+  which state-proof catches. Full transcript: `audit-codex.md`.
+- **Final fresh-context codex pass:** waived — the design was *converged on by the audits themselves*
+  (codex proposed state-proof; opus's concerns are moot under it) and the owner chose it; a fresh pass
+  would re-audit a design both auditors already endorsed. Post-impl codex audit still runs on the diff.
+
+---
+
+## Seeds
+
+### /goal
+```
+/goal Phase 1 (state-proof full-cycle assertion in updater-smoke-windows.ps1) ✓ in implementations-plan/windows-disarm-proof-2026-06-04/plan.md with `LESSONS_FILE=…/lessons/phase-1.md` printed; the positive leg asserts armed (present pre-update) + disarmed (task observed ABSENT during install) + re-armed (present after), negative leg untouched; `/code-review max --fix` applied + committed; codex post-impl audit clean (or high/critical addressed); `bun run test` + `bun run lint:actions` exit 0 in transcript; then SURFACE+STOP for the owner-dispatched rc dry-run (Phase 2) — no autonomous release.
+```
+
+### /loop
+```
+/loop Each turn: (1) read implementations-plan/windows-disarm-proof-2026-06-04/plan.md + lessons/; git status; open PR? gh pr view --json statusCheckRollup. (2) CI on HEAD? gh run watch ≤10min. (3) Failed? triage+fix, /codex xhigh if non-trivial, commit+push; stop after 5 fails on one step. (4) Phase green? mark ✓, file lessons/phase-1.md, print LESSONS_FILE=…, advance. (5) Nothing in flight? next pending step (edit → bun run lint:actions → commit → push). (6) Phase 1 ✓? /code-review max --fix → commit → codex post-impl audit (/codex xhigh, adversarial+security) → address high/critical → SURFACE+STOP for the owner rc dispatch (Phase 2). NEVER merge to main or cut a release autonomously.
+```

--- a/packages/accelerator/scripts/updater-smoke-windows.ps1
+++ b/packages/accelerator/scripts/updater-smoke-windows.ps1
@@ -51,6 +51,8 @@ New-Item -ItemType Directory -Force -Path $ServeDir | Out-Null
 $AppProc = $null
 $FeedProc = $null
 $CaThumb = $null
+$PollJob = $null
+$TaskName = "Aztec Accelerator Crash Recovery"
 
 function Log($m) { Write-Host "── $m ──" }
 
@@ -70,7 +72,9 @@ function Cleanup {
   # (#96) Disarm: drop the autostart Run key + the crash-recovery task we may have armed, and
   # verify the task is gone — an armed task must not leak even on an ephemeral runner.
   Remove-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run" -Name "Aztec Accelerator" -ErrorAction SilentlyContinue
-  & schtasks /Delete /F /TN "Aztec Accelerator Crash Recovery" *> $null
+  & schtasks /Delete /F /TN $TaskName *> $null
+  # (#97) Stop the background task-state poller if it's still running (don't leak a job).
+  if ($PollJob) { Stop-Job $PollJob -ErrorAction SilentlyContinue; Remove-Job $PollJob -Force -ErrorAction SilentlyContinue }
 }
 
 function Dump-Logs {
@@ -168,8 +172,11 @@ try {
   #    productName "Aztec Accelerator" — a missing StartupApproved entry counts as enabled
   #    (auto-launch `unwrap_or(true)`). Positive leg only (the negative leg rejects before install).
   if ($Mode -eq "positive") {
+    # (#97) Clear any stale crash-recovery task FIRST, so the poller's "seen present" below provably
+    #   reflects THIS run's registration by N-1 (Cleanup's delete only runs in `finally`, after).
+    & schtasks /Delete /F /TN $TaskName *> $null
     Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run" -Name "Aztec Accelerator" -Value "`"$($Exe.FullName)`""
-    Log "armed crash-recovery (autostart Run key set for 'Aztec Accelerator')"
+    Log "armed crash-recovery (stale task cleared; autostart Run key set for 'Aztec Accelerator')"
   }
 
   # ── Launch N-1; it should auto-update to N and relaunch ──
@@ -190,68 +197,77 @@ try {
     Dump-Logs; exit 0
   }
 
-  # ── Positive: prove the full armed → disarm(absent during install) → re-arm cycle ──
-  $taskName = "Aztec Accelerator Crash Recovery"
-
-  # (#97) ARMED: N-1 must register the crash-recovery task on startup (autostart Run key set above).
-  #   Confirm it is PRESENT *before* the disarm can fire — safe because the first update check is 5s
-  #   after launch (main.rs:436) and task registration happens during early startup. This makes the
-  #   absence we watch for below a real disarm, not a pre-registration gap.
-  $armed = $false
-  for ($a = 0; $a -lt 40; $a++) {        # up to ~20s
-    & schtasks /Query /TN $taskName *> $null
-    if ($LASTEXITCODE -eq 0) { $armed = $true; break }
-    Start-Sleep -Milliseconds 500
-  }
-  if (-not $armed) {
-    Write-Error "(#97) ARMING proof FAILED — N-1 never registered the '$taskName' task (autostart Run key or startup enable_crash_recovery regressed); the update-while-armed scenario was never set up."; Dump-Logs; exit 1
-  }
-  Log "(#97) armed — crash-recovery task present before the update"
-
-  # ── Poll /health until == N, sampling the task each tick to catch the disarm DURING the install ──
-  Log "polling $HealthUrl for version == $NVersion (up to 300s), watching '$taskName'"
-  $sawAbsent = $false
-  for ($i = 0; $i -lt 600; $i++) {       # 600 * 500ms = 300s
-    # (#97) DISARM proof (state, not log): sample the task FIRST (cheap, never blocks). The updater
-    #   removes it for the ENTIRE NSIS install window (disable_crash_recovery → install → re-arm,
-    #   updater.rs:86-110) while N-1's /health stays up, so 500ms sampling reliably observes the gap.
-    & schtasks /Query /TN $taskName *> $null
-    if ($LASTEXITCODE -ne 0) { $sawAbsent = $true }
-
-    try { $got = (Invoke-RestMethod -Uri $HealthUrl -TimeoutSec 2).version } catch { $got = $null }
-    if ($got -eq $NVersion) {
-      if (-not (Select-String -Path (Join-Path $Work "feed.log") -Pattern "/releases/download/" -Quiet)) {
-        Write-Error "/health reports $NVersion but the feed log has no download hit — the update didn't flow through our feed."; Dump-Logs; exit 1
-      }
-      Log "SUCCESS — updated to $got via the local feed (artifact downloaded + relaunched)"
-
-      # (#97) DISARM: the task must have been observed ABSENT at least once during the update. If it
-      #   stayed armed throughout, disable_crash_recovery() never ran before install — the
-      #   half-written-binary race is LIVE. The end-state re-arm check below would still pass and hide
-      #   this; observing the real absence is the teeth #96 lacked.
-      if (-not $sawAbsent) {
-        Write-Error "(#97) DISARM proof FAILED — '$taskName' was NEVER observed absent during the update; the disarm-before-install guard (disable_crash_recovery) did not run. The crash-recovery race is live."; Dump-Logs; exit 1
-      }
-      Log "(#97) disarmed — task observed absent during the install window"
-
-      # (#96) RE-ARM (durable end-state): the task must be present again after the update.
-      $rearmed = $false
-      for ($r = 0; $r -lt 10; $r++) {
-        & schtasks /Query /TN $taskName *> $null
-        if ($LASTEXITCODE -eq 0) { $rearmed = $true; break }
-        Start-Sleep -Seconds 2
-      }
-      if (-not $rearmed) {
-        Write-Error "update succeeded but '$taskName' is ABSENT — the guard did not re-arm (updater.rs rearm path or N-startup enable_crash_recovery failed)."; Dump-Logs; exit 1
-      }
-      Log "(#97) re-armed — full armed→disarm→re-arm cycle proven"
-      exit 0
+  # ── Positive: prove the full armed → disarm(sustained-absent during install) → re-arm cycle, via a
+  #    DECOUPLED background poller. (codex post-impl: don't couple /Query sampling to /health latency,
+  #    and require SUSTAINED absence so a one-off schtasks error can't read as a disarm.)
+  $PollState = Join-Path $Work "task-state.txt"
+  Set-Content -Path $PollState -Value "0 0"
+  $PollJob = Start-Job -ScriptBlock {
+    param($tn, $outFile)
+    # Sample the task ~every 200ms, independent of /health. Track whether it was ever PRESENT (armed)
+    # and the longest run of consecutive ABSENT samples AFTER that (the disarm). A seconds-long
+    # install-window absence → a long streak; a single transient schtasks blip → streak 1 (filtered).
+    $sawPresent = 0; $streak = 0; $maxStreak = 0
+    while ($true) {
+      & schtasks /Query /TN $tn *> $null
+      if ($LASTEXITCODE -eq 0) { $sawPresent = 1; $streak = 0 }
+      elseif ($sawPresent -eq 1) { $streak++; if ($streak -gt $maxStreak) { $maxStreak = $streak } }
+      Set-Content -Path $outFile -Value "$sawPresent $maxStreak"
+      Start-Sleep -Milliseconds 200
     }
-    Start-Sleep -Milliseconds 500
+  } -ArgumentList $TaskName, $PollState
+
+  # ── Wait for the update (/health == N). The poller runs independently, so a slow /health never
+  #    starves task sampling. 150 * 2s = 300s budget.
+  Log "polling $HealthUrl for version == $NVersion (up to 300s); background poller watching '$TaskName'"
+  $updated = $false
+  for ($i = 0; $i -lt 150; $i++) {
+    try { $got = (Invoke-RestMethod -Uri $HealthUrl -TimeoutSec 3).version } catch { $got = $null }
+    if ($got -eq $NVersion) { $updated = $true; break }
+    Start-Sleep -Seconds 2
   }
-  Write-Error "updater smoke failed — /health never reported $NVersion (does Tauri's Windows updater apply the .nsis.zip? see feed/app logs)"
-  Dump-Logs
-  exit 1
+  if (-not $updated) {
+    Write-Error "updater smoke failed — /health never reported $NVersion (does Tauri's Windows updater apply the .nsis.zip? see feed/app logs)"; Dump-Logs; exit 1
+  }
+  if (-not (Select-String -Path (Join-Path $Work "feed.log") -Pattern "/releases/download/" -Quiet)) {
+    Write-Error "/health reports $NVersion but the feed log has no download hit — the update didn't flow through our feed."; Dump-Logs; exit 1
+  }
+  Log "SUCCESS — updated to $NVersion via the local feed (artifact downloaded + relaunched)"
+
+  # ── Read what the poller observed, then stop it. ──
+  Stop-Job $PollJob -ErrorAction SilentlyContinue
+  $raw = (Get-Content $PollState -Raw -ErrorAction SilentlyContinue); if (-not $raw) { $raw = "0 0" }
+  $parts = $raw.Trim() -split '\s+'
+  $sawPresent = [int]$parts[0]; $maxAbsentStreak = [int]$parts[1]
+  Remove-Job $PollJob -Force -ErrorAction SilentlyContinue; $PollJob = $null
+
+  # (#97) ARMED: the poller must have seen the task PRESENT (N-1 registered it; the stale task was
+  #   cleared pre-run, so this is genuinely this run's registration — not a leftover).
+  if ($sawPresent -ne 1) {
+    Write-Error "(#97) ARMING proof FAILED — '$TaskName' was never observed present; N-1 did not register the crash-recovery task (autostart Run key or startup enable_crash_recovery regressed). The update-while-armed scenario was never set up."; Dump-Logs; exit 1
+  }
+  # (#97) DISARM: after being present, the task must have been SUSTAINED-absent (>=3 consecutive ~200ms
+  #   samples ≈ >=600ms) during the update. The real disarm-before-install window is the whole NSIS
+  #   install (seconds); requiring a streak rejects a one-off schtasks error AND proves the guard ran.
+  #   If it stayed armed throughout, disable_crash_recovery() never disarmed — the race is live (and the
+  #   end-state re-arm check below would still pass, hiding it: the exact #96 gap).
+  if ($maxAbsentStreak -lt 3) {
+    Write-Error "(#97) DISARM proof FAILED — '$TaskName' was never observed sustained-absent during the update (longest consecutive-absent run: $maxAbsentStreak samples). disable_crash_recovery() did not disarm before install; the half-written-binary race is live."; Dump-Logs; exit 1
+  }
+  Log "(#97) armed + disarmed — task seen present, then sustained-absent ($maxAbsentStreak samples) across the install"
+
+  # (#96) RE-ARM (durable end-state): the task must be present again after the update.
+  $rearmed = $false
+  for ($r = 0; $r -lt 10; $r++) {
+    & schtasks /Query /TN $TaskName *> $null
+    if ($LASTEXITCODE -eq 0) { $rearmed = $true; break }
+    Start-Sleep -Seconds 2
+  }
+  if (-not $rearmed) {
+    Write-Error "update succeeded but '$TaskName' is ABSENT — the guard did not re-arm (updater.rs rearm path or N-startup enable_crash_recovery failed)."; Dump-Logs; exit 1
+  }
+  Log "(#97) re-armed — full armed→disarm→re-arm cycle proven"
+  exit 0
 }
 finally {
   Cleanup

--- a/packages/accelerator/scripts/updater-smoke-windows.ps1
+++ b/packages/accelerator/scripts/updater-smoke-windows.ps1
@@ -190,21 +190,51 @@ try {
     Dump-Logs; exit 0
   }
 
-  # ── Positive: poll /health until version == N ──
-  Log "polling $HealthUrl for version == $NVersion (up to 300s)"
-  for ($i = 0; $i -lt 150; $i++) {
-    try { $got = (Invoke-RestMethod -Uri $HealthUrl -TimeoutSec 3).version } catch { $got = $null }
+  # ── Positive: prove the full armed → disarm(absent during install) → re-arm cycle ──
+  $taskName = "Aztec Accelerator Crash Recovery"
+
+  # (#97) ARMED: N-1 must register the crash-recovery task on startup (autostart Run key set above).
+  #   Confirm it is PRESENT *before* the disarm can fire — safe because the first update check is 5s
+  #   after launch (main.rs:436) and task registration happens during early startup. This makes the
+  #   absence we watch for below a real disarm, not a pre-registration gap.
+  $armed = $false
+  for ($a = 0; $a -lt 40; $a++) {        # up to ~20s
+    & schtasks /Query /TN $taskName *> $null
+    if ($LASTEXITCODE -eq 0) { $armed = $true; break }
+    Start-Sleep -Milliseconds 500
+  }
+  if (-not $armed) {
+    Write-Error "(#97) ARMING proof FAILED — N-1 never registered the '$taskName' task (autostart Run key or startup enable_crash_recovery regressed); the update-while-armed scenario was never set up."; Dump-Logs; exit 1
+  }
+  Log "(#97) armed — crash-recovery task present before the update"
+
+  # ── Poll /health until == N, sampling the task each tick to catch the disarm DURING the install ──
+  Log "polling $HealthUrl for version == $NVersion (up to 300s), watching '$taskName'"
+  $sawAbsent = $false
+  for ($i = 0; $i -lt 600; $i++) {       # 600 * 500ms = 300s
+    # (#97) DISARM proof (state, not log): sample the task FIRST (cheap, never blocks). The updater
+    #   removes it for the ENTIRE NSIS install window (disable_crash_recovery → install → re-arm,
+    #   updater.rs:86-110) while N-1's /health stays up, so 500ms sampling reliably observes the gap.
+    & schtasks /Query /TN $taskName *> $null
+    if ($LASTEXITCODE -ne 0) { $sawAbsent = $true }
+
+    try { $got = (Invoke-RestMethod -Uri $HealthUrl -TimeoutSec 2).version } catch { $got = $null }
     if ($got -eq $NVersion) {
       if (-not (Select-String -Path (Join-Path $Work "feed.log") -Pattern "/releases/download/" -Quiet)) {
         Write-Error "/health reports $NVersion but the feed log has no download hit — the update didn't flow through our feed."; Dump-Logs; exit 1
       }
       Log "SUCCESS — updated to $got via the local feed (artifact downloaded + relaunched)"
-      # ── (#96) The update ran with crash-recovery ARMED. The updater disarms the repeating task
-      #    right before NSIS mutates files, then re-arms (before restart + on N's startup). Assert
-      #    the task is PRESENT again — proves the guard disarmed-then-rearmed rather than leaking
-      #    the task or leaving recovery off. (The in-install-window absence is too brief to observe
-      #    reliably; the re-armed end-state is the durable signal.)
-      $taskName = "Aztec Accelerator Crash Recovery"
+
+      # (#97) DISARM: the task must have been observed ABSENT at least once during the update. If it
+      #   stayed armed throughout, disable_crash_recovery() never ran before install — the
+      #   half-written-binary race is LIVE. The end-state re-arm check below would still pass and hide
+      #   this; observing the real absence is the teeth #96 lacked.
+      if (-not $sawAbsent) {
+        Write-Error "(#97) DISARM proof FAILED — '$taskName' was NEVER observed absent during the update; the disarm-before-install guard (disable_crash_recovery) did not run. The crash-recovery race is live."; Dump-Logs; exit 1
+      }
+      Log "(#97) disarmed — task observed absent during the install window"
+
+      # (#96) RE-ARM (durable end-state): the task must be present again after the update.
       $rearmed = $false
       for ($r = 0; $r -lt 10; $r++) {
         & schtasks /Query /TN $taskName *> $null
@@ -212,12 +242,12 @@ try {
         Start-Sleep -Seconds 2
       }
       if (-not $rearmed) {
-        Write-Error "update succeeded but the crash-recovery task is ABSENT — the disarm-before-install guard did not re-arm (updater.rs rearm path or N-startup enable_crash_recovery failed)."; Dump-Logs; exit 1
+        Write-Error "update succeeded but '$taskName' is ABSENT — the guard did not re-arm (updater.rs rearm path or N-startup enable_crash_recovery failed)."; Dump-Logs; exit 1
       }
-      Log "crash-recovery re-armed after the update (disarm-before-install guard verified)"
+      Log "(#97) re-armed — full armed→disarm→re-arm cycle proven"
       exit 0
     }
-    Start-Sleep -Seconds 2
+    Start-Sleep -Milliseconds 500
   }
   Write-Error "updater smoke failed — /health never reported $NVersion (does Tauri's Windows updater apply the .nsis.zip? see feed/app logs)"
   Dump-Logs

--- a/packages/accelerator/scripts/updater-smoke-windows.ps1
+++ b/packages/accelerator/scripts/updater-smoke-windows.ps1
@@ -172,11 +172,32 @@ try {
   #    productName "Aztec Accelerator" — a missing StartupApproved entry counts as enabled
   #    (auto-launch `unwrap_or(true)`). Positive leg only (the negative leg rejects before install).
   if ($Mode -eq "positive") {
-    # (#97) Clear any stale crash-recovery task FIRST, so the poller's "seen present" below provably
-    #   reflects THIS run's registration by N-1 (Cleanup's delete only runs in `finally`, after).
+    # (#97) Clear any stale crash-recovery task FIRST and VERIFY it's gone, so the poller's "seen
+    #   present" below provably reflects THIS run's registration by N-1 (not a leftover). Cleanup's
+    #   delete only runs in `finally`, after.
     & schtasks /Delete /F /TN $TaskName *> $null
+    & schtasks /Query /TN $TaskName *> $null
+    if ($LASTEXITCODE -eq 0) {
+      Write-Error "(#97) pre-run cleanup FAILED — a stale '$TaskName' task survived /Delete; cannot prove this run armed it."; Dump-Logs; exit 1
+    }
     Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run" -Name "Aztec Accelerator" -Value "`"$($Exe.FullName)`""
-    Log "armed crash-recovery (stale task cleared; autostart Run key set for 'Aztec Accelerator')"
+    Log "armed crash-recovery (stale task cleared + verified gone; autostart Run key set)"
+
+    # (#97) Start the task-state poller BEFORE launching N-1, so Start-Job's startup latency can't miss
+    #   the first-present observation or the disarm window (first update check is 5s post-launch,
+    #   main.rs:436). It emits "<sawPresent> <maxConsecutiveAbsentAfterPresent>" each ~200ms; the parent
+    #   reads the last value via Receive-Job (no file/torn-read race).
+    $PollJob = Start-Job -ScriptBlock {
+      param($tn)
+      $sawPresent = 0; $streak = 0; $maxStreak = 0
+      while ($true) {
+        & schtasks /Query /TN $tn *> $null
+        if ($LASTEXITCODE -eq 0) { $sawPresent = 1; $streak = 0 }
+        elseif ($sawPresent -eq 1) { $streak++; if ($streak -gt $maxStreak) { $maxStreak = $streak } }
+        "$sawPresent $maxStreak"
+        Start-Sleep -Milliseconds 200
+      }
+    } -ArgumentList $TaskName
   }
 
   # ── Launch N-1; it should auto-update to N and relaunch ──
@@ -197,28 +218,8 @@ try {
     Dump-Logs; exit 0
   }
 
-  # ── Positive: prove the full armed → disarm(sustained-absent during install) → re-arm cycle, via a
-  #    DECOUPLED background poller. (codex post-impl: don't couple /Query sampling to /health latency,
-  #    and require SUSTAINED absence so a one-off schtasks error can't read as a disarm.)
-  $PollState = Join-Path $Work "task-state.txt"
-  Set-Content -Path $PollState -Value "0 0"
-  $PollJob = Start-Job -ScriptBlock {
-    param($tn, $outFile)
-    # Sample the task ~every 200ms, independent of /health. Track whether it was ever PRESENT (armed)
-    # and the longest run of consecutive ABSENT samples AFTER that (the disarm). A seconds-long
-    # install-window absence → a long streak; a single transient schtasks blip → streak 1 (filtered).
-    $sawPresent = 0; $streak = 0; $maxStreak = 0
-    while ($true) {
-      & schtasks /Query /TN $tn *> $null
-      if ($LASTEXITCODE -eq 0) { $sawPresent = 1; $streak = 0 }
-      elseif ($sawPresent -eq 1) { $streak++; if ($streak -gt $maxStreak) { $maxStreak = $streak } }
-      Set-Content -Path $outFile -Value "$sawPresent $maxStreak"
-      Start-Sleep -Milliseconds 200
-    }
-  } -ArgumentList $TaskName, $PollState
-
-  # ── Wait for the update (/health == N). The poller runs independently, so a slow /health never
-  #    starves task sampling. 150 * 2s = 300s budget.
+  # ── Positive: the task-state poller is already running (started BEFORE launch, above). Wait for the
+  #    update, then read what the poller observed. ──
   Log "polling $HealthUrl for version == $NVersion (up to 300s); background poller watching '$TaskName'"
   $updated = $false
   for ($i = 0; $i -lt 150; $i++) {
@@ -234,12 +235,14 @@ try {
   }
   Log "SUCCESS — updated to $NVersion via the local feed (artifact downloaded + relaunched)"
 
-  # ── Read what the poller observed, then stop it. ──
+  # ── Read what the poller observed: Receive-Job returns every emitted "<sawPresent> <maxStreak>" line;
+  #    the LAST is the final state (no file/torn-read race). Default closed to "0 0" → ARMING fails. ──
   Stop-Job $PollJob -ErrorAction SilentlyContinue
-  $raw = (Get-Content $PollState -Raw -ErrorAction SilentlyContinue); if (-not $raw) { $raw = "0 0" }
-  $parts = $raw.Trim() -split '\s+'
-  $sawPresent = [int]$parts[0]; $maxAbsentStreak = [int]$parts[1]
+  $samples = @(Receive-Job $PollJob -ErrorAction SilentlyContinue)
   Remove-Job $PollJob -Force -ErrorAction SilentlyContinue; $PollJob = $null
+  $last = if ($samples.Count -gt 0) { [string]$samples[-1] } else { "0 0" }
+  $parts = $last.Trim() -split '\s+'
+  $sawPresent = [int]$parts[0]; $maxAbsentStreak = [int]$parts[1]
 
   # (#97) ARMED: the poller must have seen the task PRESENT (N-1 registered it; the stale task was
   #   cleared pre-run, so this is genuinely this run's registration — not a leftover).

--- a/packages/accelerator/scripts/updater-smoke-windows.ps1
+++ b/packages/accelerator/scripts/updater-smoke-windows.ps1
@@ -198,6 +198,15 @@ try {
         Start-Sleep -Milliseconds 200
       }
     } -ArgumentList $TaskName
+
+    # Barrier: Start-Job is async — wait until the poller has actually emitted a sample (i.e. is
+    #   sampling) before launching, so it can't miss the early task lifecycle. `-Keep` peeks without
+    #   consuming (the final Receive-Job still sees every sample). Best-effort + bounded (~5s); the
+    #   disarm is 5s out, so even a slow start has margin.
+    for ($w = 0; $w -lt 50; $w++) {
+      if (@(Receive-Job $PollJob -Keep -ErrorAction SilentlyContinue).Count -gt 0) { break }
+      Start-Sleep -Milliseconds 100
+    }
   }
 
   # ── Launch N-1; it should auto-update to N and relaunch ──


### PR DESCRIPTION
Closes the codex post-impl **Medium** from windows-ci-parity: the Windows updater-smoke's
crash-recovery check was **end-state-only** (asserts the task is present *after* the update), so a
regression that never disarms would still pass green — shipping the half-written-binary install race.

## What
The positive leg now proves the full **armed → disarm → re-arm** cycle from **observed task state**
(state-proof, not log-proof) — **no production code touched**, only the test got stricter:
- **Pre-run cleanup (verified):** delete any stale crash-recovery task + `/Query`-confirm it's gone, so
  the "armed" observation reflects *this* run's registration.
- **Decoupled background poller:** a `Start-Job` poller samples `schtasks /Query` every ~200ms,
  *independent of `/health` latency*, started **before** launch (with a sampling barrier) so it can't
  miss the early task lifecycle. Reports `<sawPresent> <maxConsecutiveAbsentStreak>` via `Receive-Job`.
- **Assert the cycle:** **armed** (`sawPresent==1`) + **disarmed** (`maxStreak ≥ 3` ≈ ≥600ms sustained —
  the real install-window absence is seconds; a one-off `schtasks` blip is filtered) + **re-armed**
  (the durable `/Query` end-state). Negative leg untouched.

## Why state-proof (dual-audit-driven)
Codex (plan audit) proposed it; opus flagged the log-read wedge risk. State-proof observes the disarm's
*real effect* — not a log string a regression could fake — and needs no change to the correctness-
critical `disable_crash_recovery()`. Three codex post-impl rounds hardened the poller (cadence
decoupling, sustained-streak transient-error filter, pre-launch start, `Receive-Job`, verified
pre-clean); final verdict **minor, no new defects**. Full trail: `implementations-plan/windows-disarm-proof-2026-06-04/`.

## Validation
- `bun run test` exit 0 · `bun run lint:actions` exit 0.
- The smoke runs **only** in the release pipeline (no `workflow_dispatch` since P5), so end-to-end
  proof is an **owner-dispatched rc dry-run** (next step). The `≥3` floor is rc-tunable once the real
  streak is known (expected 10-40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)