### PR TITLE
docs(audit): quality harden report for sdk + accelerator

### DIFF
--- a/audit/quality/2026-06-05-sdk-accel/findings/verified.md
+++ b/audit/quality/2026-06-05-sdk-accel/findings/verified.md
@@ -1,0 +1,23 @@
+# Verified findings (Phase 3 reduce + Phase 4 verify) — quality / sdk+accelerator
+
+Dedup by root-cause+location. `both` = Claude AND Codex converged independently (strongest signal). Anchor lines spot-verified against source.
+
+| ID | Impact | Found by | Smell | Root cause |
+|---|---|---|---|---|
+| Q1 | architectural | both | Temporary Field / Data Clump | `AppState` conflates headless + GUI (7 `Option` fields, server.rs:34-42) |
+| Q2 | architectural | both | Long Method / Large Class | `/prove` (server.rs:487-577) + `authorize_origin` (288-406) workflow sprawl |
+| Q3 | architectural | both | Primitive Obsession | Aztec version as raw `&str` (from_version:38, sort_key:133, sigs across versions/bb/server) |
+| Q4 | architectural | both | Divergent Change / Parallel Impls | crash_recovery platform semantics leak to callers; divergent disable signatures |
+| Q5 | architectural | both | Long Method + Temporal Coupling | SDK `checkAcceleratorStatus` (202-319) + scattered phase emission |
+| Q6 | architectural | codex | Temporal Coupling / Shotgun Surgery | update flow spread across main/updater/commands/windows |
+| Q7 | architectural | both | Shotgun Surgery | Safari/HTTPS split between startup (main.rs) + settings commands |
+| Q8 | structural | both | Primitive Obsession (stringly-typed protocol) | `ProveError=(StatusCode,String)`; 19 `json!` errors; magic header literals |
+| Q9 | structural | both | Duplicate Code | config lock-mutate-save ×6 (commands.rs); respond_update_prompt SWALLOWS save err (219-220) vs `?` elsewhere |
+| Q10 | structural | both | Primitive Obsession (UI state in strings) | tray animation `text.contains("Proving")` (main.rs:356) coupled to display copy |
+| Q11 | structural | both | Long Method | `download_bb` (versions.rs:272-421) — guard/stream/digest/extract+codesign |
+| Q12 | structural | both | Primitive Obsession | SDK `AcceleratorStatus` flat-optionals + string phase events |
+| Q13 | structural | both | Repeated Switches | copy-bb.ts platform/arch matrix in 3 places (31-46,152-170,172-178) |
+| Q14 | structural | claude | Duplicate Code | `is_auto_approved` (authorization.rs:126-147) re-parses vs `canonicalize_origin` |
+| Q15 | local | both | Duplicate Code | 60s auth-timeout literal: server.rs:361 + windows.rs:72 (no shared const) |
+
+Minor bucket (local/cosmetic, single-model unless noted): SDK WASM-fallback dup (sdk:336/384); home-dir fallback inconsistency `"."`vs`"~"` (certs.rs:14, crash_recovery.rs:84 — both-ish); 3 window-open helpers (windows.rs:20/41/88); AppState clone stutter (main.rs:347/377/397); MAX_BODY_SIZE literal vs const (server.rs:213/485); versions_to_evict re-parses from_version (168-170); bb_asset_name clump (versions.rs:121/331); write_pem_file double 0o600 (certs.rs:177/193); certs test dup w/ stale consts 3650/825 (certs.rs:414/448); VerifiedSite 3 dead fields (verified_sites.rs:24-34); default_config_version serde indirection (config.rs:69); frontend popup scaffolding dup + global-bridge coupling (authorize/update-prompt.html).

--- a/audit/quality/2026-06-05-sdk-accel/raw/claude-findings.md
+++ b/audit/quality/2026-06-05-sdk-accel/raw/claude-findings.md
@@ -1,0 +1,50 @@
+# Phase 2 raw findings — Claude (Sonnet) finders, 6 clusters
+
+## Cluster: sdk (accelerator-prover.ts)
+1. **Long Method / Divergent Change** — `checkAcceleratorStatus()` L202-319 (118 LOC: cache + dual-protocol probe+retry + multi-version vs legacy parse). Extract `#probeHealth` + `#parseHealthResponse`. *structural*
+2. **Temporal Coupling / boilerplate state-machine** — ~17 ad-hoc `#onPhase?.()` emissions across `createChonkProof` (L331-404) + `#proveLocally` (L417,422); legal orderings enforced nowhere. *architectural*
+3. **Duplicate Code** — WASM-fallback sequence twice: not-available L336-339 vs 403-denial L384-390. Extract `#fallbackToWasm(steps, preamblePhase?)`. *structural*
+4. **Primitive Obsession** — `AcceleratorStatus` (L46-59) flat iface w/ 6 optionals = implicit discriminated union; consumers re-derive. Replace w/ discriminated union. *structural*
+5. **Feature Envy** — port/host resolution in constructor L145-167; extract `resolveAcceleratorConfig()`. *local*
+
+## Cluster: server.rs
+1. **Primitive Obsession** — `ProveError = (StatusCode, String)`; 7/10 error sites bypass `json_error` w/ inline `serde_json::to_string(&json!{}).unwrap()` (L315-319,338-343,351,368-376,398-404,504-509,516-519,565-567,421-424,456-460). Typed `ProveErrorBody: Serialize+IntoResponse`. *structural*
+2. **Duplicate Code** — 60s auth-timeout split: server.rs:361 + windows.rs:72. Shared const. *structural* [CONVERGES w/ app-shell #3]
+3. **Duplicate Code** — `MAX_BODY_SIZE` literal `50*1024*1024` inline at L213 vs const at L485. *local*
+4. **Large Class / Divergent Change** — server.rs 578 prod-LOC, 6 unrelated clusters (bind-retry / TLS loop / CORS / auth-glue / version-resolve / prove). Extract submodules. *architectural*
+5. **Long Method + Temporal Coupling** — `authorize_origin` L288-406 (118 LOC, 6 ordered phases). Extract phase fns. *structural*
+6. **Data Clump** — `AppState` L33-43 merges GUI callbacks + headless fields → Option-guard everywhere (4 guards in authorize_origin). Split GuiCallbacks. *structural*
+7. (cosmetic) misleading test names + tautology assert L1259,1291,1314. *local*
+
+## Cluster: versions-bb
+1. **Primitive Obsession** — version strings raw through API: `from_version` L38-52 + `version_sort_key` L133-140 + signatures (versions.rs:84,148,272; bb.rs:18,79). `ParsedVersion`/`BbVersion` value object w/ tier+suffix computed once. *architectural*
+2. **Temporal Coupling (doc)** — `is_valid_version` "single source of truth" prose attached to `download_bb`'s rustdoc block, not the fn. *structural (weak)*
+3. **Long Method** — `download_bb` L272-421 (149 LOC: guard / stream / digest / extract+macOS-codesign). Extract `install_bb_binary`. *structural*
+4. **Data Clump** — `barretenberg-{}.tar.gz` format in download_url L121-127 + download_bb L331. Extract `bb_asset_name()`. *local*
+5. **Duplicate Code** — `versions_to_evict` re-invokes `from_version` L168-170 on already-classified strings; compute `bundled_tier` once. *local* [consequence of #1]
+6. **Feature Envy** — `dirs_next`/`home_dir_fallback` wrappers bb.rs:66-72 (trivial delegators; inconsistent w/ versions.rs:68 direct call). *cosmetic/local* [CONVERGES w/ certs-recovery #2]
+
+## Cluster: certs-recovery
+1. **Parallel Platform Impls / Shotgun Surgery** — `enable/disable_crash_recovery` 6 disjoint `#[cfg]` blocks (crash_recovery.rs:23-51,76-80,93-158,163-177,216-275,281-308); **divergent signatures** (Win disable→bool, mac/linux→()). Extract `trait CrashRecovery`. *architectural*
+2. **Duplicate Code** — home-dir boilerplate inconsistent fallback: certs.rs:14-15 `"."` vs crash_recovery.rs:84-85 `"~"` vs certs.rs:303-305 `"."`. Shared `home_dir()`. *structural* [CONVERGES w/ versions-bb #6]
+3. **Long Method** — `enable_crash_recovery` Linux L93-158 + Windows L216-275 mix orchestration+I/O+subprocess. Extract install helpers. *structural*
+4. **Temporal Coupling** — `write_pem_file` sets 0o600 twice (open L177-186 + post-rename set_permissions L193-197); 2nd redundant. *local*
+5. **Duplicate Code (test)** — 2 tests rebuild CA+leaf verbatim (certs.rs:414-445,448-490) w/ stale consts (3650 not CA_VALIDITY_DAYS; 825 not 824). *local*
+
+## Cluster: app-shell (main/tray/updater/windows/commands)
+1. **Stringly-Typed / Primitive Obsession** — animation trigger `text.contains("Proving")||text.contains("Downloading")` main.rs:356, coupled to display strings server.rs:437,465,531. Typed `ServerStatus` enum in StatusCallback. *structural*
+2. **Duplicate Code** — HTTPS-spawn pattern main.rs:83-89 (`try_start_https`) vs commands.rs:153-162 (enable_safari_support); one has recovery path, other doesn't. Extract `spawn_https_server`. *structural*
+3. **Duplicate Code / Config Sprawl** — 60s timeout windows.rs:72 + server.rs:361. *local* [CONVERGES w/ server #2 — SAME finding]
+4. **Duplicate Code** — 3 window-open helpers windows.rs:20-35,41-81,88-107 (builder chain copy-paste). Extract `open_or_focus_window(WindowConfig)`. *local*
+5. **Duplicate Code** — lock-write-save boilerplate 6 sites commands.rs:49-52,60-63,147-149,171-173,195-197,217-219; respond_update_prompt SWALLOWS save error (divergence). Extract `mutate_config(f)`. *local*
+6. **Temporal Coupling** — main.rs AppState clone stutter: https_port patched on 2 clones L347-366,376-378,396-397. *local*
+   - REJECTED by finder: safari_support `#[cfg]` stubs (genuinely different impls, correct pattern).
+
+## Cluster: config-auth-ui
+1. **Duplicate Code / Shotgun Surgery** — `is_auto_approved` (authorization.rs:126-147) bespoke strip_prefix/split parser duplicates `canonicalize_origin` (L21-57 url::Url). Reuse canonical host. *structural*
+2. **Data Clump / Speculative Generality** — `VerifiedSite` (verified_sites.rs:24-34) 3 `#[allow(dead_code)]` pub fields + parallel `VerifiedSitesEntry` (43-51) + `VerifiedSiteDto` (commands.rs:84-87) = 3-place edits. Collapse. *structural*
+3. **Duplicate Code** — `fetchWindowsBb` twin size guards copy-bb.ts:99-104,106-110. *local*
+4. **Long Method asymmetry** — copy-bb.ts main(): Windows extracted (L159-160) vs Unix inlined (L161-178). Extract `copyUnixBb`. *local*
+5. **Config Sprawl** — `default_config_version` free fn config.rs:44,69-71 (serde-default indirection). *cosmetic/local*
+6. **Duplicate Code** — popup scaffolding authorize.html:11-30 ≈ update-prompt.html:11-30. *local*
+   - REJECTED: tauri-bridge.js helpers NOT duplicated (all pages use them); style.css well-factored; AuthorizationManager methods clean.

--- a/audit/quality/2026-06-05-sdk-accel/raw/codex-findings.md
+++ b/audit/quality/2026-06-05-sdk-accel/raw/codex-findings.md
@@ -1,0 +1,160 @@
+# Phase 2 raw — Codex (xhigh) cross-model passes
+
+## Rust modules
+
+**Ranked Findings**
+
+1. **`AppState` is carrying two runtimes at once.**  
+Smell: `Temporary Field`.  
+Impact: architectural; 3 production files today and any new router feature; very high frequency because every server capability threads through this context.  
+Evidence: optional fields in [server.rs:33](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:33), [server.rs:37](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:37), [server.rs:38](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:38), [server.rs:39](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:39), [server.rs:40](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:40), [server.rs:42](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:42); partial constructors in [main.rs:347](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/main.rs:347), [main.rs:377](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/main.rs:377), [server main.rs:43](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/server/src/main.rs:43), [server main.rs:62](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/server/src/main.rs:62); `None`/fallback branches in [server.rs:226](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:226), [server.rs:250](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:250), [server.rs:292](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:292), [server.rs:324](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:324), [server.rs:334](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:334), [server.rs:382](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:382), [server.rs:432](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:432), [server.rs:475](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:475), [server.rs:513](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:513).  
+Why: adding a new server concern, like metrics, a second UI callback, or another runtime mode, forces edits in both constructors and in many `Option` branches.  
+Refactor: `Extract Class` plus `Introduce Null Object`, or split `AppState` into invariant server state plus a desktop adapter.  
+What disappears: `Option` checks, `unwrap_or` fallbacks, and headless-vs-desktop branching inside request code.
+
+2. **`/prove` is still one distributed procedural script.**  
+Smell: `Long Method` with helper extraction, but one change unit remains spread across functions.  
+Impact: architectural; `server.rs` plus auth UI wiring; very high frequency because this is the app’s core request path.  
+Evidence: auth flow in [server.rs:288](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:288), duplicated auth timeout in [server.rs:361](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:361) and [windows.rs:72](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/windows.rs:72), version resolution in [server.rs:409](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:409), main handler in [server.rs:487](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:487), popup creation in [windows.rs:41](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/windows.rs:41), response path in [commands.rs:100](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/commands.rs:100).  
+Why: a change like “queue proves per origin”, “show auth countdown”, or “support cancellation/progress” cuts across HTTP parsing, auth, popup lifecycle, status updates, and proving.  
+Refactor: `Extract Class`/workflow object such as `ProveWorkflow` or `AuthorizeAndProve`.  
+What disappears: interleaving of auth, body buffering, semaphore handling, status changes, version download, and response serialization.
+
+3. **The update flow is a temporal state machine spread across four modules.**  
+Smell: `Temporal Coupling` (close to `Shotgun Surgery`: one transition requires synchronized edits in several files).  
+Impact: architectural; `main.rs`, `updater.rs`, `commands.rs`, `windows.rs`, config state; medium/high frequency because updater UX tends to evolve.  
+Evidence: shared mutable state type in [commands.rs:17](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/commands.rs:17), poll/store/show in [main.rs:150](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/main.rs:150), [main.rs:157](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/main.rs:157), [main.rs:168](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/main.rs:168), prompt window in [windows.rs:88](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/windows.rs:88), user response logic in [commands.rs:206](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/commands.rs:206), policy/install logic in [updater.rs:14](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/updater.rs:14) and [updater.rs:61](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/updater.rs:61).  
+Why: adding “skip this version”, retry, or download progress requires coordinated edits to state storage, UI, command handling, and updater policy.  
+Refactor: `Extract Class`/`Introduce State Object` for an `UpdateCoordinator`.  
+What disappears: `PendingUpdate` leaking through Tauri state and the cross-file sequencing knowledge.
+
+4. **Crash-recovery semantics leak out of the platform adapter.**  
+Smell: `Divergent Change`.  
+Impact: architectural; `crash_recovery.rs`, `commands.rs`, `main.rs`, `updater.rs`; medium frequency, high blast radius when autostart or updater behavior changes.  
+Evidence: different platform APIs in [crash_recovery.rs:23](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/crash_recovery.rs:23), [crash_recovery.rs:76](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/crash_recovery.rs:76), [crash_recovery.rs:93](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/crash_recovery.rs:93), [crash_recovery.rs:163](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/crash_recovery.rs:163), [crash_recovery.rs:216](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/crash_recovery.rs:216), [crash_recovery.rs:281](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/crash_recovery.rs:281); caller-side policy in [commands.rs:31](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/commands.rs:31), [main.rs:275](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/main.rs:275), [main.rs:294](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/main.rs:294), [updater.rs:92](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/updater.rs:92), [updater.rs:99](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/updater.rs:99), [updater.rs:109](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/updater.rs:109), [updater.rs:117](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/updater.rs:117), [updater.rs:125](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/updater.rs:125).  
+Why: if Linux/macOS later need verification semantics like Windows, every caller changes instead of only the backend.  
+Refactor: `Introduce Facade`/adapter with uniform operations like `arm_for_autostart`, `disarm_for_quit`, `disarm_for_update`.  
+What disappears: Windows-only recovery rules and re-arm decisions from app-level code.
+
+5. **Safari/HTTPS support is split between startup repair logic and settings commands.**  
+Smell: `Shotgun Surgery`.  
+Impact: architectural; `main.rs`, `commands.rs`, `certs.rs`; medium frequency because cert/trust/startup behavior evolves as one feature.  
+Evidence: startup preflight/start/repair in [main.rs:54](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/main.rs:54), [main.rs:71](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/main.rs:71), [main.rs:83](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/main.rs:83), [main.rs:95](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/main.rs:95), [main.rs:105](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/main.rs:105), [main.rs:373](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/main.rs:373); settings enable/disable in [commands.rs:134](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/commands.rs:134), [commands.rs:141](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/commands.rs:141), [commands.rs:143](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/commands.rs:143), [commands.rs:152](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/commands.rs:152), [commands.rs:157](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/commands.rs:157), [commands.rs:170](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/commands.rs:170).  
+Why: “stop HTTPS immediately”, “retrust CA”, or “rebuild listener after rotation” currently means changing both launch code and command handlers.  
+Refactor: `Extract Class` such as `SafariSupportManager` or `HttpsSupport`.  
+What disappears: duplicated TLS bring-up, config toggling, and repair/reset logic.
+
+6. **Config writes repeat the same lock-mutate-save script.**  
+Smell: `Duplicate Code`, which drives `Shotgun Surgery`.  
+Impact: structural; `commands.rs`, `server.rs`, `main.rs`; high frequency because every new setting or remembered origin repeats it.  
+Evidence: repeated sequences in [commands.rs:45](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/commands.rs:45), [commands.rs:56](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/commands.rs:56), [commands.rs:145](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/commands.rs:145), [commands.rs:171](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/commands.rs:171), [commands.rs:194](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/commands.rs:194), [commands.rs:216](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/commands.rs:216), [server.rs:382](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:382), [main.rs:105](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/main.rs:105).  
+Why: if persistence gets validation, events, telemetry, or batching, each mutator must be updated by hand.  
+Refactor: `Move Function` into a config-store API with named operations.  
+What disappears: repeated `write()`, field mutation, `config::save`, and ad hoc error/logging branches.
+
+7. **The HTTP contract is stringly typed.**  
+Smell: `Primitive Obsession` mapped to a stringly typed protocol.  
+Impact: structural; mostly `server.rs` today, but any client/test change fans out; medium frequency for API evolution.  
+Evidence: raw header names in [server.rs:206](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:206), [server.rs:208](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:208), [server.rs:216](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:216), [server.rs:526](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:526), [server.rs:572](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:572); error payload assembly in [server.rs:283](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:283), [server.rs:315](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:315), [server.rs:338](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:338), [server.rs:351](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:351), [server.rs:368](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:368), [server.rs:374](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:374), [server.rs:398](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:398), [server.rs:421](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:421), [server.rs:457](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:457), [server.rs:505](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:505), [server.rs:517](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:517), [server.rs:565](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:565).  
+Why: adding `request_id`, renaming a header, or changing the error schema becomes a string hunt instead of a type-guided edit.  
+Refactor: `Introduce Data Transfer Object` plus header constants/response builders.  
+What disappears: hand-assembled `json!({...})` errors and repeated header literals.
+
+8. **Aztec versions are plain strings at every seam.**  
+Smell: `Primitive Obsession`.  
+Impact: structural; `versions.rs`, `server.rs`, `bb.rs`; medium/high frequency because cache, retention, and request routing all depend on version semantics.  
+Evidence: tier parsing in [versions.rs:38](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/versions.rs:38), retention logic in [versions.rs:153](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/versions.rs:153), validation in [versions.rs:261](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/versions.rs:261), cache-path derivation in [versions.rs:84](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/versions.rs:84), download entrypoint in [versions.rs:272](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/versions.rs:272), header capture/validation in [server.rs:418](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:418) and [server.rs:524](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:524).  
+Why: another prerelease channel or richer version grammar means updating multiple unrelated string parsers and validators.  
+Refactor: `Introduce Value Object` like `AztecVersion`.  
+What disappears: prefix parsing, ad hoc validation, and raw `String` handoff across modules.
+
+9. **`download_bb` owns too many phases.**  
+Smell: `Long Method`.  
+Impact: structural; 1 file today, but it is the only installer path for non-bundled versions; medium frequency.  
+Evidence: cache check, HTTP, bounded streaming, digest verification, temp install, atomic rename, chmod, and macOS post-processing all live in [versions.rs:272](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/versions.rs:272).  
+Why: adding mirror fallback, retry policy, progress callbacks, or another platform-specific post-step means editing one long control-flow block with many exits.  
+Refactor: `Extract Function` for `download_tarball`, `verify_digest`, `install_version_dir`, `postprocess_downloaded_bb`.  
+What disappears: nested phase transitions and mixed concerns inside `download_bb`.
+
+10. **Tray animation is driven by display copy, not state.**  
+Smell: `Primitive Obsession` mapped to UI state encoded in strings.  
+Impact: local but cross-module; `server.rs` and `main.rs`; medium frequency whenever statuses or UX copy change.  
+Evidence: status emission in [server.rs:275](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:275), [server.rs:437](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:437), [server.rs:465](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:465), [server.rs:531](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/server.rs:531), initial label in [main.rs:268](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/main.rs:268), busy-state parsing in [main.rs:356](/Users/alejoamiras/Projects/aztec-accelerator/packages/accelerator/src-tauri/src/main.rs:356).  
+Why: copy changes like “Downloading Aztec binary” or a new busy phase silently change animation behavior unless the substring parser is updated too.  
+Refactor: `Introduce Enum`/state object with `display_text()` and `is_busy()`.  
+What disappears: `contains("Proving") || contains("Downloading")` and duplicated status literals.
+
+The raw `#[cfg]` splits in `commands.rs`, `certs.rs`, and `crash_recovery.rs` are not separate findings by themselves. The extractable maintenance cost is where platform semantics leak into callers (finding 4) or where one lifecycle is split across startup and commands (finding 5); the remaining per-OS bodies mostly look like legitimate adapters.
+## SDK + frontend
+
+**Findings**
+
+1. `checkAcceleratorStatus()` is a protocol multiplexer stuffed into one method.  
+Smell: `Long Method` (Fowler).  
+Impact: `architectural` | blast radius: every accelerator-detection/status change | change frequency: high.  
+Evidence: `packages/sdk/src/lib/accelerator-prover.ts:202-319` with embedded probe setup at `218-228`, cache write path at `230-233`, and protocol/version branches at `271-314`.  
+Why it harms future change: adding a third transport, a richer offline reason, or removing legacy health support means reopening one 118-line method that also owns retry timing and cache behavior.  
+Smallest safe refactoring: `Extract Method` into `probeHealthEndpoint`, `retryProbe`, `interpretHealthPayload`, `cacheStatus`.  
+What disappears: interleaved transport, compatibility, and caching logic in one control-flow block.
+
+2. `createChonkProof()` is the proof orchestrator, fallback policy, network client, timer, and decoder.  
+Smell: `Long Method` (Fowler).  
+Impact: `architectural` | blast radius: every prove-path change, native/local split, and UI phase change | change frequency: high.  
+Evidence: `packages/sdk/src/lib/accelerator-prover.ts:321-406`; only a small fragment is extracted into `#proveLocally` at `413-423`.  
+Why it harms future change: streamed progress, new denial handling, different request metadata, or alternate fallbacks all accumulate in one method that already sequences detection, serialization, HTTP, timing, and decode.  
+Smallest safe refactoring: `Extract Method` into `proveRemotely`, `proveAfterDenial`, `decodeProofResponse`; keep `createChonkProof` as a short orchestrator.  
+What disappears: one hotspot where unrelated prove-flow concerns keep accreting.
+
+3. Phase sequencing is encoded as scattered callback order, not as a model.  
+Smell: `Temporal Coupling` (close analog: callers must emit phases in the right order, but that order is implicit and branch-local).  
+Impact: `architectural` | blast radius: the SDK/UI contract for all proof progress reporting | change frequency: medium-high.  
+Evidence: phase set at `packages/sdk/src/lib/accelerator-prover.ts:11-20`; emission sites at `331-338`, `344`, `351`, `356-357`, `383-389`, `401-404`, `417-422` (14 manual emissions).  
+Why it harms future change: adding `queued`, renaming `receive`, or changing fallback UX requires editing multiple branches and manually preserving a valid sequence across native, local, and denied paths.  
+Smallest safe refactoring: `Extract Class` for a `PhaseReporter` with `transition(next, data?)` and allowed transitions.  
+What disappears: manual phase-order knowledge scattered across many call sites.
+
+4. Phase events are modeled as strings plus one optional generic payload.  
+Smell: `Primitive Obsession` (string literals plus an optional bag stand in for a richer event type).  
+Impact: `structural` | blast radius: every `onPhase` consumer and every new phase payload | change frequency: medium.  
+Evidence: `packages/sdk/src/lib/accelerator-prover.ts:11-25`, `36-43`, with payload only on `"proved"` at `401` and `422`, while all other emissions at `331-389`, `404`, `417` rely on convention.  
+Why it harms future change: the first new phase-specific payload like denial metadata or download progress forces consumers to infer meaning from `phase` + `data?` instead of an explicit type.  
+Smallest safe refactoring: `Replace Primitive with Object` via a discriminated union event, e.g. `{ type: "proved", durationMs }`.  
+What disappears: ambiguous `data?` rules and string/payload pairing conventions.
+
+5. Accelerator endpoint state is split across loose scalars and repeated URL assembly.  
+Smell: `Data Clumps` / close analog `Config Sprawl` (host, ports, protocol, and invalidation rules travel together but are managed separately).  
+Impact: `structural` | blast radius: all endpoint/config changes | change frequency: medium.  
+Evidence: `packages/sdk/src/lib/accelerator-prover.ts:27-34`, `130-135`, `144-167`, `171-179`, `191-196`, `213-214`.  
+Why it harms future change: adding a path prefix, TLS toggle, or alternate endpoint kind requires coordinated edits in constructor parsing, setter invalidation, base-url generation, and health probing.  
+Smallest safe refactoring: `Introduce Parameter Object` for an `AcceleratorEndpoint` value object with `healthUrls()` and `baseUrl(protocol)`.  
+What disappears: duplicated endpoint construction and multi-field synchronization work.
+
+6. `copy-bb.ts` repeats the target-platform matrix in separate conditionals.  
+Smell: `Repeated Switches` (Fowler; the same platform/arch decision is encoded more than once).  
+Impact: `structural` | blast radius: every new target or sidecar naming rule | change frequency: medium.  
+Evidence: `packages/accelerator/scripts/copy-bb.ts:31-46` (`getTargetTriple`), `152-170` (platform/ext/arch/os routing), `172-178` (darwin-only post-step).  
+Why it harms future change: adding `windows-arm64`, `linux-musl`, or a new packaging rule means editing multiple branch trees that can drift independently.  
+Smallest safe refactoring: `Replace Conditional with Table` by resolving a single `TargetSpec`.  
+What disappears: duplicated `process.platform` / `process.arch` branching across helpers and `main()`.
+
+7. The frontend bridge is a global-script dependency, not a real module boundary.  
+Smell: `Global Data` (Fowler; page controllers depend on globals and script load order).  
+Impact: `structural` | blast radius: all three HTML pages plus the bridge | change frequency: medium.  
+Evidence: `packages/accelerator/src-tauri/frontend/tauri-bridge.js:9`, `16-25`, `37-52`, `65-84`; consumers at `settings.html:8,60,155-170`, `authorize.html:8,53-60`, `update-prompt.html:8,31-42`.  
+Why it harms future change: renaming helpers, switching to module scripts, or testing page logic outside Tauri requires coordinated HTML/script-order changes because the dependency is implicit.  
+Smallest safe refactoring: introduce a module boundary, either one `window.AcceleratorUI` namespace or ES-module page controllers importing a shared helper file.  
+What disappears: hidden load-order coupling and the “used by HTML pages” lint suppressions.
+
+8. Frontend IPC wiring is only partially abstracted; the remaining controller code is duplicated.  
+Smell: `Duplicate Code` (frontend analog: repeated IPC/control wiring across page scripts, with the shared helper covering only part of the surface).  
+Impact: `local` | blast radius: the prompt pages plus the non-toggle settings control | change frequency: medium.  
+Evidence: `packages/accelerator/src-tauri/frontend/authorize.html:33-60` and `update-prompt.html:25-42` both do inline query-param read, DOM hydrate, and paired `wireButton` setup; `settings.html:161-172` reimplements async control/error wiring outside `wireToggle`; the partial abstraction boundary is `tauri-bridge.js:28-84`.  
+Why it harms future change: if you want uniform busy/error behavior, telemetry, or command-shape changes across dialogs, you still touch several inline scripts instead of one controller API.  
+Smallest safe refactoring: `Extract Function` / `Extract Module` for `bindPromptButtons`, `readQueryParamText`, and a generic `wireAsyncControl`.  
+What disappears: near-duplicate dialog bootstraps and one-off async control wiring.
+
+**Rejected / trimmed**
+
+- `checkAcceleratorStatus()` as a `Long Method`: confirmed. The candidate is valid at `packages/sdk/src/lib/accelerator-prover.ts:202-319`.
+- Ad-hoc `#onPhase?.(...)` emissions: confirmed, but the file has 14 emission sites, not ~17.
+- “Shared helper isn’t used everywhere” in the frontend: only partly true. `wireButton`/`wireToggle` are used on all three pages; the real issue is that page bootstrap and the settings speed control still bypass the abstraction, so I would not call the entire frontend pure copy-paste.

--- a/audit/quality/2026-06-05-sdk-accel/raw/repo-map/accelerator.md
+++ b/audit/quality/2026-06-05-sdk-accel/raw/repo-map/accelerator.md
@@ -1,0 +1,46 @@
+# Repo map — accelerator (quality audit)
+
+**Package:** Tauri-2 desktop app. Scope: `packages/accelerator/src-tauri/src` (Rust) + frontend (`src-tauri/frontend`) + `scripts/`.
+
+## Rust inventory (src-tauri/src, 5768 LOC)
+| File | LOC | Purpose |
+|---|---|---|
+| `server.rs` | 1335 | axum HTTP/HTTPS router, `/health`+`/prove`, auth+version resolve, bb invoke, bind-with-retry. **God module; long `prove()` handler ~L487-577.** |
+| `versions.rs` | 964 | bb version cache, tier retention (nightly/devnet/testnet/mainnet), download/extract, digest verify. NetworkTier::from_version prefix-parsing. |
+| `certs.rs` | 561 | TLS cert gen (keyless CA, 824d leaf), macOS trust install, renewal, pem load. Platform `#[cfg]` blocks. |
+| `main.rs` | 495 | Tauri entry, tray, HTTPS startup, 12h update loop, crash recovery, window lifecycle. Status-string parsing for animation (~L356). |
+| `crash_recovery.rs` | 452 | macOS LaunchAgent plist / Linux systemd / Windows Task Scheduler — parallel platform impls. |
+| `config.rs` | 394 | config schema (Speed enum, safari_support, approved_origins, auto_update), JSON load/save, migration. |
+| `authorization.rs` | 383 | origin canonicalization (RFC 6454), pending-request dedup, 60s timeout, decision broadcast. |
+| `bb.rs` | 280 | bb binary search chain (env→cache→sidecar→bbup→PATH), prove invoke w/ timeout+threads. |
+| `commands.rs` | 261 | 14 Tauri commands. `enable/disable_safari_support` duplicated macOS vs !macOS stubs (~L132-190). |
+| `verified_sites.rs` | 211 | embedded JSON registry (recognition badge, NOT security). |
+| `tray.rs` | 172 | tray icon/menu, 24-frame proving animation (static `[&[u8];24]`). |
+| `updater.rs` | 130 | check/perform update, Windows crash-recovery re-arm. |
+| `windows.rs` | 107 | Settings/Auth/Update window lifecycle. 60s timeout const (dup w/ server.rs). |
+| `lib.rs` | 23 | re-exports. |
+
+Headless: `server/src/main.rs` (74) — same router, CLI/env-gated.
+
+## Frontend (src-tauri/frontend)
+`settings.html` (179), `authorize.html` (65), `update-prompt.html` (47), `tauri-bridge.js` (86, shared IPC utils), `style.css` (204).
+
+## Scripts
+`copy-bb.ts` (190, sidecar extract + Windows fetch/SHA-pin), `updater-feed-server.ts` (73).
+
+## Dep graph (use crate::)
+lib→all; main→{auth,commands,server,certs,config,verified_sites,tray,windows,updater}; commands→{auth,config,verified_sites,certs,server}; server→{auth,config,bb,versions}; bb→versions; updater→commands; verified_sites→authorization. No cycles.
+
+## Exclude
+`target/`, `gen/`, `node_modules/`, `dist/`, `icons/`, `binaries/`, `test-results/`, `*.spec.ts` e2e (unless prod-wired).
+
+## First-glance smells (locations only — for finder agents to verify)
+1. **Large Class / Long Method:** server.rs (1335) — `prove()` ~L487-577 mixes auth + version-resolve + bb-invoke + error-serialize.
+2. **Shotgun Surgery / Duplicated platform arms:** safari `#[cfg]` in commands.rs ~L132-190; platform blocks in certs.rs + crash_recovery.rs (plist/systemd/scheduler).
+3. **Duplicated constant:** 60s auth timeout in windows.rs ~L72 + server.rs ~L361 (not a shared const).
+4. **Primitive Obsession:** version strings parsed by prefix (NetworkTier::from_version, versions.rs ~L38-62); raw msgpack `/prove` req + magic header strings ("x-prove-duration-ms") — no DTOs.
+5. **Stringly-typed:** status animation via `text.contains("Proving"|"Downloading")` (main.rs ~L356); hand-assembled `json!({})` errors (server.rs).
+6. Magic numbers: 5min prove timeout, 824d cert, 60s — scattered.
+
+## Clusters (Phase 2)
+1. **sdk** (separate map) 2. **server** = server.rs 3. **versions-bb** = versions.rs+bb.rs 4. **certs-recovery** = certs.rs+crash_recovery.rs 5. **app-shell** = main.rs+tray.rs+updater.rs+windows.rs+commands.rs 6. **config-auth-ui** = config.rs+authorization.rs+verified_sites.rs+frontend+copy-bb.ts

--- a/audit/quality/2026-06-05-sdk-accel/raw/repo-map/sdk.md
+++ b/audit/quality/2026-06-05-sdk-accel/raw/repo-map/sdk.md
@@ -1,0 +1,31 @@
+# Repo map — SDK (quality audit)
+
+**Package:** `@alejoamiras/aztec-accelerator` (published TS lib, AGPL-3.0). Scope: `packages/sdk/src`.
+
+## Inventory
+| File | LOC | Purpose |
+|---|---|---|
+| `src/index.ts` | 8 | public re-exports: AcceleratorProver + 5 types |
+| `src/lib/accelerator-prover.ts` | 434 | core: extends `BBLazyPrivateKernelProver`; HTTP/HTTPS health probe, `/prove` routing, phase callbacks, WASM fallback, status cache |
+| `src/lib/logger.ts` | 3 | LogTape factory |
+| `src/test-setup.ts` | 10 | bun:test shim |
+
+## Public surface
+`new AcceleratorProver(opts?)`, `checkAcceleratorStatus()`, `createChonkProof(steps)`, `setAcceleratorConfig()`, `setOnPhase()`, `setForceLocal()`.
+
+## Patterns
+- `extends BBLazyPrivateKernelProver`; overrides `createChonkProof`, delegates to `super` for WASM.
+- Proxy-based lazy WASMSimulator (`createLazySimulator`, ~L90-103; blocks `then`/symbols).
+- Status cache, 10s TTL. `Promise.any()` dual-protocol HTTP+HTTPS race (Safari mixed-content). Retry-once + 2s timeout.
+- Phase callbacks: detect→serialize→transmit→proving→proved→receive (or fallback/denied).
+
+## Tests
+`src/lib/accelerator-prover.test.ts` (629 LOC, ~29 unit tests) + `e2e/` (real node/wallet, skipIf). Good coverage.
+
+## Exclude
+`dist/`, `*.test.ts`, e2e fixtures.
+
+## First-glance smells (locations only)
+- **Long Method:** `checkAcceleratorStatus()` ~L202-319 (118 LOC — probe + retry + dual-protocol + legacy-vs-multi-version + cache).
+- **Boilerplate:** 17× `#onPhase?.(...)` ad-hoc calls across `createChonkProof` + fallback paths (no phase state-machine).
+- Magic numbers (2000/1000/10_000ms, "10 min") — but already named consts.

--- a/audit/quality/2026-06-05-sdk-accel/report.md
+++ b/audit/quality/2026-06-05-sdk-accel/report.md
@@ -1,0 +1,128 @@
+# Harden Report: quality
+
+**Repo:** aztec-accelerator
+**Date:** 2026-06-05
+**Effort:** high
+**Run ID:** 2026-06-05-sdk-accel
+**Models:** Phase 1 map = Explore (Sonnet); Phase 2 finders = 6× Claude Sonnet (per cluster) + 2× Codex xhigh (cross-model, batched Rust / SDK+frontend); Phase 3 reduce + Phase 4 verify = Opus (this agent), anchors line-verified against source.
+**Scope:** `packages/sdk` (TS) + `packages/accelerator` Rust backend (`src-tauri/src`, `server/src`), frontend (`src-tauri/frontend`), and `scripts/copy-bb.ts`. Excluded: `target/`, `gen/`, `dist/`, `node_modules/`, `icons/`, `binaries/`, and `*.test.ts`/`e2e` (non-finding-eligible unless production-wired).
+
+## Executive summary
+
+The codebase is **healthy** — clear module boundaries, no circular dependencies, strong test coverage (~122 Rust unit tests, ~29 SDK unit tests, Playwright + WebDriver E2E), and recent security/correctness hardening (the #98 audit, the keyless-CA TLS rework, and the #99 download fixes). This is a maintainability pass, not a correctness one: every finding below is about *future change cost*, and nothing here is a bug.
+
+The dominant theme, flagged independently by **both** model families, is that the project's two biggest surfaces — `server.rs` (1335 LOC) and the SDK's `accelerator-prover.ts` (434 LOC) — have grown into **god-objects whose request/proof pipelines are long procedural methods**, and that **three core domain concepts are passed around as primitives**: Aztec *version strings*, the *HTTP error/header protocol*, and *server status* (which drives the tray animation via substring matching). A second theme is **boilerplate duplication** with one latent inconsistency baked in: the config "lock → mutate → save" sequence is copy-pasted across 6 command handlers, and one copy (`respond_update_prompt`) silently *swallows* a save error where the other five propagate it.
+
+Recommended priority: (1) introduce two small value objects — `AztecVersion` and a typed server-status enum — which between them dissolve the largest cluster of findings; (2) extract the `/prove` + `authorize_origin` workflow and split `AppState` into headless-core + GUI-adapter; (3) sweep the cheap local duplications (shared 60s-timeout const, `mutate_config` helper). None of this is urgent; all of it compounds if the surfaces keep growing.
+
+## Methodology
+
+Map-reduce per the harden protocol. Two parallel `Explore` mappers (one per package) built the repo map; the main agent clustered into 6 bounded units (sdk / server.rs / versions+bb / certs+crash_recovery / app-shell / config+auth+ui). Each cluster got a Claude Sonnet finder with the quality rubric + negative list; cross-model Codex coverage ran as 2 xhigh passes (Rust modules; SDK+frontend) — a deliberate adaptation from per-cluster Codex to keep 6 concurrent xhigh sessions tractable, with cross-model coverage of every file preserved. Phase 3 deduped by root-cause+location, weighting impact by blast radius × change frequency, and marked **cross-model convergence** (both families flagging the same root cause independently) as the primary confidence signal — 13 of 15 primary findings converged. Phase 4 spot-verified the top converged anchors against source (guarding shared hallucination); all confirmed, including the `respond_update_prompt` error-swallow divergence. Inter-procedural context was capped per cluster; the update-flow finding (Q6) came from Codex's wider file set crossing the cap via the emit→handler handoff edge.
+
+---
+
+## Findings
+
+### Architectural
+
+#### [architectural] Q1: `AppState` conflates headless-server and desktop-GUI concerns
+**Confidence:** high · **Mapping:** Temporary Field / Data Clump · **Found by:** both
+**Instances:** `server.rs:33-43` (7 `Option` fields: `on_status`, `on_versions_changed`, `https_port`, `config`, `auth_manager`, `show_auth_popup`, `prove_semaphore`); runtime guards `server.rs:226,248,251,292,324,334,356,382,436,444,513`; partial constructors `main.rs:347,377`, `server/src/main.rs:43,62`.
+One struct serves both the desktop app (callbacks present) and the headless CI server (callbacks `None`). Every handler re-derives the headless-vs-GUI distinction at runtime via `Option::is_some`, and every new capability adds another `Option<…>` field + another guard + another `..Default::default()` in tests.
+**Why it matters:** highest change-frequency surface — every server feature threads through `AppState`. **Fix:** Extract Class — `AppState { base: HeadlessState, gui: Option<GuiCallbacks> }`; handlers that don't need GUI take `&HeadlessState`. **Effort:** ~1 day.
+
+#### [architectural] Q2: `/prove` + `authorize_origin` are a distributed procedural script
+**Confidence:** high · **Mapping:** Long Method / Large Class · **Found by:** both
+**Instances:** `prove()` `server.rs:487-577`; `authorize_origin()` `server.rs:288-406` (6 ordered phases); version resolution `server.rs:409-470`. `server.rs` itself is 578 production LOC owning ~6 unrelated responsibility clusters (bind-retry, TLS accept loop, CORS setup, auth glue, version resolve, prove orchestration).
+A single conceptual change ("queue proves per origin", "show an auth countdown", "support cancellation/progress") cuts across HTTP parsing, auth, popup lifecycle, status updates, and proving — all interleaved.
+**Why it matters:** the app's core request path; also unit-untestable at phase granularity (needs full `AppState` + channels). **Fix:** Extract Class `ProveWorkflow` + Extract Method on the auth phases; split `server.rs` into `bind`/`tls`/`handlers` submodules. **Effort:** ~2-3 days.
+
+#### [architectural] Q3: Aztec version is a raw `&str` at every seam (Primitive Obsession)
+**Confidence:** high · **Mapping:** Primitive Obsession · **Found by:** both
+**Instances:** `versions.rs:38` (`from_version` tier parse), `:133` (`version_sort_key`), `:148/:272/:84` (signatures), `:261` (`is_valid_version`), `bb.rs:18/:79`, `server.rs:418/:524`. `versions_to_evict` even re-parses tiers it already computed (`versions.rs:168-170`).
+Tier classification and numeric-suffix sorting are two independent string parsers of the same concept; a new prerelease channel (`-staging`, `-alpha`) means editing multiple unrelated match sites consistently.
+**Why it matters:** version semantics drive cache, retention, routing, validation — high fan-out. **Fix:** Introduce Value Object `AztecVersion { tier, sort_key, raw }` with `is_valid_version` as its constructor guard; raw `&str` survives only at the HTTP/command boundary. Dissolves Q3 + the `versions_to_evict` re-parse + makes the validated-string invariant type-enforced. **Effort:** ~1-1.5 days.
+
+#### [architectural] Q4: Crash-recovery platform semantics leak out of the adapter
+**Confidence:** high · **Mapping:** Divergent Change / Parallel Platform Impls · **Found by:** both
+**Instances:** 6 disjoint `#[cfg]` blocks `crash_recovery.rs:23,76,93,163,216,281` with **divergent signatures** (Windows `disable`→`bool`, macOS/Linux→`()`); caller-side policy in `commands.rs:31`, `main.rs:275,294`, `updater.rs:92,99,109,117,125`.
+Callers must know the platform to know whether `disable` reported success; adding a 4th platform or a uniform "verify-after-enable" contract touches every caller, not just the backend.
+**Why it matters:** updater + autostart both depend on it; the signature divergence is already a real wart. **Fix:** `trait CrashRecovery { fn enable(&self); fn disable(&self) -> bool; }` + a facade with intent-named ops (`arm_for_autostart`, `disarm_for_update`). **Effort:** ~1 day.
+
+#### [architectural] Q5: SDK `checkAcceleratorStatus` is a protocol multiplexer + phases have no model
+**Confidence:** high · **Mapping:** Long Method + Temporal Coupling · **Found by:** both
+**Instances:** `accelerator-prover.ts:202-319` (118 LOC: cache + dual-protocol probe+retry + multi-version-vs-legacy parse); phase emissions scattered across `createChonkProof` (`:331-404`) + `#proveLocally` (`:417,422`) — 14 sites, legal orderings enforced nowhere.
+A third transport, a new denial reason, or a reordered phase means reopening one 118-LOC method and manually preserving a valid sequence across native/local/denied branches.
+**Why it matters:** the SDK's public contract for all proof progress. **Fix:** Extract Method (`#probeHealth`, `#parseHealthResponse`) + a small `PhaseReporter` with declared transitions. **Effort:** ~1 day.
+
+#### [architectural] Q6: Update flow is a temporal state machine spread across 4 modules
+**Confidence:** moderate · **Mapping:** Temporal Coupling / Shotgun Surgery · **Found by:** codex (cross-model disagreement — Claude's app-shell cluster saw the pieces but not the cross-module whole)
+**Instances:** shared `PendingUpdate` state `commands.rs:17`; poll/store/show `main.rs:150,157,168`; prompt window `windows.rs:88`; user response `commands.rs:206`; policy/install `updater.rs:14,61`.
+"Skip this version" / retry / download-progress each require coordinated edits to state storage, UI, command handling, and updater policy. **Fix:** Introduce State Object `UpdateCoordinator` owning the transitions. **Effort:** ~1 day.
+
+#### [architectural] Q7: Safari/HTTPS support is split between startup repair and settings commands
+**Confidence:** moderate · **Mapping:** Shotgun Surgery · **Found by:** both (Codex framed the whole; Claude flagged the concrete HTTPS-spawn duplication)
+**Instances:** startup preflight/start/repair `main.rs:54,71,83,95,105,373`; settings enable/disable `commands.rs:134,141,152,157,170`. The spawn-HTTPS sequence is duplicated (`main.rs:83-89` has a `reset_safari_support` recovery path; `commands.rs:153-162` omits it — a behavioural divergence).
+**Fix:** Extract Class `SafariSupportManager` owning cert-load → spawn → repair; both call sites delegate. **Effort:** ~0.5-1 day.
+
+### Structural
+
+#### [structural] Q8: The HTTP contract is stringly-typed (error tuple + `json!` + magic headers)
+**Confidence:** high · **Mapping:** Primitive Obsession · **Found by:** both
+**Instances:** `ProveError = (StatusCode, String)` `server.rs:280`; **19** `json!(...)` error assemblies, 7 of which bypass the `json_error` helper (`server.rs:315,338,351,368,374,398,421,457,505,517,565`); magic header literals `server.rs:206,208,216,526,572` (`x-aztec-version`, `x-prove-duration-ms`).
+Adding a field (`request_id`, `Retry-After`), renaming a header, or changing the error schema is a string-hunt instead of a typed edit. **Fix:** `ProveErrorBody { error: &'static str, message: String }` implementing `Serialize` + `IntoResponse`; header-name constants. **Effort:** ~0.5 day.
+
+#### [structural] Q9: Config "lock → mutate → save" boilerplate ×6 — with one error-swallow divergence
+**Confidence:** high · **Mapping:** Duplicate Code → Shotgun Surgery · **Found by:** both
+**Instances:** `commands.rs:49,60,147,171,195,217` (+ `server.rs:382`, `main.rs:105`). **Latent inconsistency:** 5 sites do `config::save(&cfg).map_err(|e| e.to_string())?` (propagate); `respond_update_prompt` (`commands.rs:219-220`) does `if let Err(e) = config::save(&cfg) { tracing::warn!(...) }` — silently swallows the failure. Copy-paste drift.
+**Fix:** `fn mutate_config(&ConfigState, impl FnOnce(&mut AcceleratorConfig)) -> Result<(),String>`; all 6 become one-liners and the swallow becomes a visible, deliberate choice. **Effort:** ~0.5 day. *(Worth doing first — cheap, and it surfaces the divergence.)*
+
+#### [structural] Q10: Tray animation is driven by display copy, not state
+**Confidence:** high · **Mapping:** Primitive Obsession (UI state in strings) · **Found by:** both
+**Instances:** `main.rs:356` `text.contains("Proving") || text.contains("Downloading")`, coupled to the human-readable strings emitted at `server.rs:437,465,531`. The `StatusCallback = Arc<dyn Fn(&str)>` carries no structured payload.
+Reword "Downloading bb…" or add an "Uploading" busy phase and the animation silently breaks. **Fix:** replace the `&str` callback with `enum ServerStatus { Idle, Proving, Downloading, Error(String) }` exposing `is_busy()` + `display_text()`. **Effort:** ~0.5 day.
+
+#### [structural] Q11: `download_bb` owns too many phases
+**Confidence:** high · **Mapping:** Long Method · **Found by:** both
+**Instances:** `versions.rs:272-421` (149 LOC: guard/cache → bounded stream → digest verify → temp extract → atomic rename → chmod → macOS xattr+codesign, with two separate `remove_dir_all` cleanup arms).
+Adding mirror-fallback, retry, progress, or another platform post-step means editing one long block with many exits. **Fix:** Extract `download_tarball`, `verify_digest`, `install_version_dir(bytes, version_dir)` (folding the duplicate cleanup), `postprocess_macos`. **Effort:** ~0.5 day. *(Note: this file was just touched by #99; do this as a separate refactor PR.)*
+
+#### [structural] Q12: SDK `AcceleratorStatus` + phase events are primitives, not types
+**Confidence:** high · **Mapping:** Primitive Obsession · **Found by:** both
+**Instances:** `accelerator-prover.ts:46-59` (flat interface, 6 optionals = implicit discriminated union); phase events are `string + optional data?` bag (`:11-25,36-43`), payload only on `"proved"`.
+Consumers re-derive which field combination they got; the first phase-specific payload (denial metadata, download progress) has nowhere typed to live. **Fix:** discriminated unions for both `AcceleratorStatus` and the phase event (`{ type: "proved", durationMs }`). **Effort:** ~0.5 day.
+
+#### [structural] Q13: `copy-bb.ts` repeats the platform/arch matrix
+**Confidence:** high · **Mapping:** Repeated Switches · **Found by:** both
+**Instances:** `copy-bb.ts:31-46` (`getTargetTriple`), `:152-170` (platform/ext/arch/os routing), `:172-178` (darwin-only post-step). Plus the Windows path is an extracted function while the Unix path is inlined in `main()` (asymmetric depth).
+Adding `windows-arm64` / `linux-musl` means editing multiple branch trees that drift. **Fix:** Replace Conditional with Table — one `TargetSpec` lookup; extract `copyUnixBb` to match `fetchWindowsBb`. **Effort:** ~0.5 day.
+
+#### [structural] Q14: `is_auto_approved` re-implements `canonicalize_origin`'s parser
+**Confidence:** high · **Mapping:** Duplicate Code / parallel parsers · **Found by:** claude (single-model)
+**Instances:** `authorization.rs:126-147` (manual `strip_prefix` + IPv6-bracket find + `split(':')`) duplicates the `url::Url` parse at `:21-57`. The `is_approved` contract says "input is already canonical" yet `is_auto_approved` re-parses raw input.
+Adding a localhost alias means updating two parsers in two idioms. **Fix:** canonicalize once, `matches!` on `url.host_str()`. **Effort:** ~2 hours.
+
+#### [local] Q15: 60s auth-timeout duplicated across modules
+**Confidence:** high · **Mapping:** Duplicate Code · **Found by:** both (3 finders)
+**Instances:** `server.rs:361` (server-side `timeout`) + `windows.rs:72` (popup auto-deny `sleep`). Two halves of one UX contract; a mismatch produces a hung request or an orphaned popup. **Fix:** `pub const AUTH_DECISION_TIMEOUT: Duration` in the lib crate, imported by both. **Effort:** ~15 min. *(Cheapest win on the board.)*
+
+---
+
+## Findings NOT pursued (with reasoning)
+
+- **`enable/disable_safari_support` `#[cfg]` stubs** (`commands.rs:179-190`) — both a Claude finder and Codex rejected this: the macOS impl and non-macOS stubs are genuinely different (real logic vs error, `async` vs sync); the `#[cfg]` split is correct, no shared shape to extract.
+- **`tauri-bridge.js` "duplicated"** — refuted: all 3 HTML pages *do* call `wireToggle`/`wireButton`/`showErrorHint` from the shared bridge. The real (smaller) finding is partial: page *bootstrap* + the speed-control bypass the abstraction (folded into the minor bucket as frontend Global-Data coupling).
+- **`style.css` per-popup blocks** — well-factored into shared utility classes; not a smell.
+- **In-file Rust test blocks inflating LOC** — Rust co-location convention; not change-amplifying. (Two cosmetic test-quality nits noted: a tautological `assert!(x.is_ok() || x.is_err())` at `server.rs:1259` and two misleadingly-named `prove_*` tests — local, optional.)
+- **`is_valid_version` doc-comment placement** (versions.rs) — too weak to action on its own; resolves naturally under Q3.
+
+## Minor cleanups (local/cosmetic — batch into one sweep PR)
+
+SDK WASM-fallback duplicated twice (`accelerator-prover.ts:336,384` → `#fallbackToWasm`); home-dir fallback inconsistent (`"."` `certs.rs:14` vs `"~"` `crash_recovery.rs:84` — the `"~"` literal is a latent bug-shaped smell) → shared `home_dir()`; 3 near-identical window-open helpers (`windows.rs:20,41,88`); `AppState` clone-stutter patching `https_port` twice (`main.rs:347,377,397`); `MAX_BODY_SIZE` named const defined 272 lines after the inline `50*1024*1024` it should replace (`server.rs:213,485`); `bb_asset_name` format duplicated (`versions.rs:121,331`); `write_pem_file` sets `0o600` twice across the rename (`certs.rs:177,193`); two cert tests rebuild CA+leaf verbatim with **stale constants** (`3650` not `CA_VALIDITY_DAYS`, `825` not the `824` production value — `certs.rs:414,448`); `VerifiedSite` carries 3 `#[allow(dead_code)]` fields across a 3-struct parallel hierarchy (`verified_sites.rs:24-34,43-51` + `commands.rs:84`); `default_config_version` serde-default indirection (`config.rs:69`); popup HTML scaffolding duplicated (`authorize.html` ≈ `update-prompt.html:11-30`).
+
+## Cross-cutting observations
+
+1. **Two value objects retire the most debt.** `AztecVersion` (Q3) and a `ServerStatus` enum (Q10) each dissolve a finding *and* several minor items (the `versions_to_evict` re-parse, the tray substring coupling, the validated-string invariant). Highest leverage per unit effort.
+2. **The headless/GUI duality is the architectural seam.** Q1 (`AppState`), Q2 (`server.rs` split), and the `Option`-guard sprawl are all the same underlying tension: one type serving two runtimes. Addressing Q1 first makes Q2 cheaper.
+3. **Copy-paste has started drifting.** Q9's error-swallow and Q7's missing-recovery-path are both cases where a duplicated block silently diverged. The duplications are individually cheap to fix and each removal closes a divergence class — do these opportunistically alongside feature work.
+4. **This is a mature codebase past the risky-refactor window for free.** None of these block shipping. Sequence them behind feature work, leading with the cheap converged wins (Q15, Q9, Q8, Q10) and the two value objects.


### PR DESCRIPTION
Adds the `/harden quality` report under `audit/quality/2026-06-05-sdk-accel/` (report + verified findings + raw Claude/Codex passes + repo maps). **Report only — no code changes.**

Map-reduce: 6 Claude Sonnet cluster finders × 2 Codex xhigh cross-model passes → reduce → line-verified. 15 primary findings (13 cross-model-converged) + a minor-cleanups bucket. Top items: `AppState` headless/GUI conflation, `/prove`+`authorize_origin` workflow sprawl, Aztec-version Primitive Obsession, stringly-typed HTTP contract + tray animation, config lock-mutate-save boilerplate (one copy silently swallows a save error).

Deliverable for follow-up blueprinting; nothing here blocks shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)