### PR TITLE
test(accelerator): Phase 0 — Rust hot-path characterization harness

### DIFF
--- a/implementations-plan/quality-refactor-2026-06-05/lessons/phase-0.md
+++ b/implementations-plan/quality-refactor-2026-06-05/lessons/phase-0.md
@@ -1,0 +1,20 @@
+# Phase 0 — characterization harness (lessons)
+
+## PR 1 — Rust hot-path characterization (branch `refactor/phase0-rust-characterization`)
+Three pins landed, all test-only, full suite 125 passed:
+- **`0622670` — Q8 error wire contract.** `/prove` error responses are `{error,message}` JSON-shaped but served as **`text/plain`** (via `(StatusCode, String)`, not `axum::Json`). Verified against real behavior. Pins status + error-id + Content-Type for invalid_version / invalid_origin / origin_denied. This is the Q8 regression guard: the SDK's `ky` keys `HTTPError.data` on Content-Type, so a switch to `axum::Json` would silently change SDK behavior.
+- **`427bc45` — Q3 eviction edges.** `versions_to_evict` empty / only-bundled / under-limit — the AztecVersion refactor (signature `&[String]`→`&[AztecVersion]`) must preserve these.
+- **`d4d766b` — Q2 ordering + Q10 status, via fake `bb`.** Added `serial_test` (dev-dep) to make `BB_BINARY_PATH` env tests race-safe (no serial_test existed; the existing `find_bb` env tests are now `#[serial]`). A fake `bb` shell script (writes a `proof` file to `-o`, exit 0) pins the SUCCESS path: 200 + `{proof}` base64 + `x-prove-duration-ms`, and the on_status sequence `["Status: Proving...", "Status: Idle"]`. Exercises auth→body→semaphore→status→resolve→bb end-to-end.
+
+## Key findings / decisions
+- **Confirmed `/prove` ordering** (codex's critical correction): auth → body-buffer → **semaphore → resolve_version/download** → bb (server.rs:493-537). The semaphore is acquired BEFORE resolve, so the download is already race-protected — the audit's worry was that the PLAN mis-stated it; the harness now pins the real order so Q2 can't regress it.
+- **Success path is already `application/json`** (`axum::Json`); only the ERROR paths are `text/plain`. Q8's text/plain constraint applies to errors only — confirmed.
+- **`StatusGuard::drop` emits `"Status: Idle"`** — the Q10 enum must reproduce that exact reset.
+
+## Deferred (principled, not skipped)
+- **`download_bb` atomic-rename-cleanup** → deferred to **Q11**: `download_bb` always hits the network with no injection seam; Q11 extracts `download_tarball`/`install_version_dir`, which makes the cleanup unit-testable. The extract+cleanup logic itself is already covered (extract_bb_* tests).
+- **`find_bb` search-chain order beyond env** → not pinned: the non-env steps depend on real fs locations (current_exe dir, ~/.aztec-accelerator, ~/.bb, PATH) with no clean injection; env-based order is racy. The env-precedence is covered by the (now `#[serial]`) existing tests.
+- **crash-recovery disarm→install→rearm sequence** → **Windows-only** (`#[cfg(windows)]`, updater.rs:86-119); the macOS dev box + macOS rc exercise a no-op `disable()`. Per opus: the real proof gate is the **Windows `_e2e-updater-windows.yml` rc run**, not a macOS unit test.
+
+## Next
+PR 1 → CI → merge. Then PR 2 (SDK contract characterization: phase sequences + status field-combinations). Then Phase 1 refactors begin.

--- a/packages/accelerator/src-tauri/Cargo.lock
+++ b/packages/accelerator/src-tauri/Cargo.lock
@@ -272,6 +272,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2 0.11.0",
  "tar",
  "tauri",
@@ -953,7 +954,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1133,7 +1134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1551,7 +1552,7 @@ dependencies = [
  "gobject-sys 0.21.5",
  "libc",
  "system-deps 7.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2604,7 +2605,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3763,7 +3764,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3830,7 +3831,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4158,6 +4159,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4282,7 +4308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4913,7 +4939,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5842,7 +5868,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/packages/accelerator/src-tauri/Cargo.toml
+++ b/packages/accelerator/src-tauri/Cargo.toml
@@ -63,6 +63,7 @@ url = "2"
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }
 tokio = { version = "1", features = ["test-util"] }
+serial_test = "3"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/packages/accelerator/src-tauri/src/bb.rs
+++ b/packages/accelerator/src-tauri/src/bb.rs
@@ -175,6 +175,7 @@ fn truncate_stderr(stderr: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn truncate_stderr_cuts_at_char_boundary_without_panic() {
@@ -229,6 +230,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_find_bb_respects_bb_binary_path_env() {
         // Set BB_BINARY_PATH to the current executable (guaranteed to exist)
         let exe = std::env::current_exe().unwrap();
@@ -243,6 +245,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_find_bb_ignores_nonexistent_bb_binary_path() {
         std::env::set_var("BB_BINARY_PATH", "/nonexistent/path/to/bb");
         // Should not return the nonexistent path — falls through to other checks

--- a/packages/accelerator/src-tauri/src/server.rs
+++ b/packages/accelerator/src-tauri/src/server.rs
@@ -912,6 +912,96 @@ mod tests {
         );
     }
 
+    /// CHARACTERIZATION (quality-refactor Phase 0 — Q8 wire-contract guard).
+    /// `/prove` error responses are a `{error,message}` JSON-shaped body served as **`text/plain`**
+    /// (they go out via `(StatusCode, String)`, not `axum::Json`). The SDK's `ky` client keys
+    /// `HTTPError.data` parsing on Content-Type, so a Q8 refactor that switches to `axum::Json` would
+    /// flip this to `application/json` and silently change SDK runtime behavior. Pin status + error-id
+    /// + `text/plain` for the reachable (no-bb) error paths so that regression fails loudly.
+    #[tokio::test]
+    async fn prove_error_responses_stay_text_plain_json_string() {
+        async fn assert_error(
+            app: Router,
+            req: Request<Body>,
+            want_status: StatusCode,
+            want_error: &str,
+        ) {
+            let resp = app.oneshot(req).await.unwrap();
+            assert_eq!(resp.status(), want_status, "status for {want_error}");
+            let ct = resp
+                .headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("")
+                .to_string();
+            assert!(
+                ct.starts_with("text/plain"),
+                "{want_error} must stay text/plain (Q8 wire contract — SDK ky keys on it), got {ct:?}"
+            );
+            let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let json: serde_json::Value =
+                serde_json::from_slice(&body).expect("error body is JSON-shaped");
+            assert_eq!(json["error"], want_error, "error id for {want_error}");
+            assert!(json["message"].is_string(), "{want_error} needs a message");
+        }
+
+        // invalid_version (400) — default state, traversal-y x-aztec-version
+        assert_error(
+            router(AppState::default()),
+            Request::builder()
+                .method("POST")
+                .uri("/prove")
+                .header("content-type", "application/octet-stream")
+                .header("x-aztec-version", "../../../etc/passwd")
+                .body(Body::from(vec![0u8; 10]))
+                .unwrap(),
+            StatusCode::BAD_REQUEST,
+            "invalid_version",
+        )
+        .await;
+
+        // invalid_origin (400) — auth present, malformed Origin (rejected before popup)
+        let (_origin_tx, _origin_rx) = std::sync::mpsc::channel();
+        let (state, _auth) = auth_state_with_popup(_origin_tx);
+        assert_error(
+            router(state),
+            Request::builder()
+                .method("POST")
+                .uri("/prove")
+                .header("content-type", "application/octet-stream")
+                .header("origin", "not-a-valid-origin")
+                .body(Body::from(vec![0u8; 10]))
+                .unwrap(),
+            StatusCode::BAD_REQUEST,
+            "invalid_origin",
+        )
+        .await;
+
+        // origin_denied (403) — auth + deny
+        let (popup_tx, _popup_rx) = std::sync::mpsc::channel();
+        let (state, auth) = auth_state_with_popup(popup_tx);
+        let auth_clone = auth.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            auth_clone.resolve("https://evil.com", crate::authorization::AuthDecision::Deny);
+        });
+        assert_error(
+            router(state),
+            Request::builder()
+                .method("POST")
+                .uri("/prove")
+                .header("content-type", "application/octet-stream")
+                .header("origin", "https://evil.com")
+                .body(Body::from(vec![0u8; 10]))
+                .unwrap(),
+            StatusCode::FORBIDDEN,
+            "origin_denied",
+        )
+        .await;
+    }
+
     #[tokio::test]
     async fn health_includes_available_versions() {
         let state = AppState {

--- a/packages/accelerator/src-tauri/src/server.rs
+++ b/packages/accelerator/src-tauri/src/server.rs
@@ -581,6 +581,7 @@ mod tests {
     use super::*;
     use axum::body::Body;
     use axum::http::Request;
+    use serial_test::serial;
     use tower::util::ServiceExt;
 
     #[test]
@@ -1000,6 +1001,73 @@ mod tests {
             "origin_denied",
         )
         .await;
+    }
+
+    /// CHARACTERIZATION (quality-refactor Phase 0 — Q2 ordering + Q10 status guards).
+    /// Pins the `/prove` SUCCESS path via a fake `bb` (`BB_BINARY_PATH`): 200 + `{proof}` base64 body
+    /// + `x-prove-duration-ms` header, and the on_status sequence `["Status: Proving...",
+    /// "Status: Idle"]` (the bundled path sets Proving, `StatusGuard` resets to Idle on exit).
+    /// `#[serial]` because `find_bb` reads the process-global `BB_BINARY_PATH`. Q2 (server split)
+    /// must preserve this ordering; Q10 (ServerStatus enum) must reproduce these exact strings.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial]
+    async fn prove_success_path_and_status_sequence() {
+        use std::os::unix::fs::PermissionsExt;
+        // Fake bb: parse `-o <dir>`, write a 32-byte `proof` file there, exit 0.
+        let dir = tempfile::tempdir().unwrap();
+        let fake_bb = dir.path().join("fake-bb");
+        std::fs::write(
+            &fake_bb,
+            "#!/bin/sh\nprev=\"\"\nfor a in \"$@\"; do [ \"$prev\" = \"-o\" ] && out=\"$a\"; prev=\"$a\"; done\nprintf '%032d' 0 > \"$out/proof\"\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&fake_bb, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::env::set_var("BB_BINARY_PATH", &fake_bb);
+
+        let recorded = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let rec = recorded.clone();
+        let state = AppState {
+            on_status: Some(std::sync::Arc::new(move |s: &str| {
+                rec.lock().unwrap().push(s.to_string())
+            })),
+            prove_semaphore: Some(std::sync::Arc::new(tokio::sync::Semaphore::new(1))),
+            ..Default::default()
+        };
+
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/prove")
+                    .header("content-type", "application/octet-stream")
+                    .body(Body::from(vec![0u8; 16]))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        std::env::remove_var("BB_BINARY_PATH");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(
+            response.headers().contains_key("x-prove-duration-ms"),
+            "success must carry x-prove-duration-ms"
+        );
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            json["proof"].as_str().is_some_and(|s| !s.is_empty()),
+            "proof base64 present"
+        );
+
+        let seq = recorded.lock().unwrap().clone();
+        assert_eq!(
+            seq,
+            vec!["Status: Proving...".to_string(), "Status: Idle".to_string()],
+            "bundled success path status sequence (Q10 pin)"
+        );
     }
 
     #[tokio::test]

--- a/packages/accelerator/src-tauri/src/versions.rs
+++ b/packages/accelerator/src-tauri/src/versions.rs
@@ -630,6 +630,25 @@ mod tests {
         assert!(evicted.contains(&"5.0.0-nightly.20260301".to_string()));
     }
 
+    /// CHARACTERIZATION (quality-refactor Phase 0 — Q3 guard). Edge cases the AztecVersion refactor
+    /// (Q3 changes `versions_to_evict`'s signature `&[String]` → `&[AztecVersion]`) must preserve.
+    #[test]
+    fn versions_to_evict_edge_cases() {
+        // Empty cache → nothing to evict.
+        assert!(versions_to_evict(&[], "5.0.0-nightly.20260301").is_empty());
+
+        // The only cached version IS the bundled one → never evicted (even alone, even over a limit).
+        let only_bundled = vec!["5.0.0-nightly.20260301".to_string()];
+        assert!(versions_to_evict(&only_bundled, "5.0.0-nightly.20260301").is_empty());
+
+        // Non-bundled nightlies at/under the tier limit (2) all stay.
+        let under_limit = vec![
+            "5.0.0-nightly.20260301".to_string(),
+            "5.0.0-nightly.20260302".to_string(),
+        ];
+        assert!(versions_to_evict(&under_limit, "5.0.0").is_empty());
+    }
+
     #[test]
     fn download_url_format() {
         let url = download_url("5.0.0-nightly.20260307");


### PR DESCRIPTION
**quality-refactor Phase 0, PR 1** — characterization tests that pin current behavior BEFORE any refactor (test-only, no production change).

Pins:
- **Q8 error wire contract** — `/prove` errors stay `text/plain` (JSON-shaped); guards against an `axum::Json` switch that would change the SDK's `ky` error parsing.
- **Q2 ordering + Q10 status** — fake-`bb` (`BB_BINARY_PATH`) success path: 200 + `{proof}` + `x-prove-duration-ms`, and the `[Proving, Idle]` on_status sequence. Adds `serial_test` (dev-dep) so env tests are race-safe.
- **Q3 eviction edges** — `versions_to_evict` empty/only-bundled/under-limit.

`cargo test --lib`: 125 passed. Principled deferrals (download_bb cleanup → Q11; crash-recovery → Windows CI) in `lessons/phase-0.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)