### PR TITLE
refactor(accelerator): share the 60s auth-decision timeout const (Q15)

### DIFF
--- a/packages/accelerator/src-tauri/src/server.rs
+++ b/packages/accelerator/src-tauri/src/server.rs
@@ -23,6 +23,12 @@ use tokio::sync::Semaphore;
 const PORT: u16 = 59833;
 pub const HTTPS_PORT: u16 = 59834;
 
+/// How long the server waits for the user's origin-authorization decision before timing out the
+/// `/prove` request, AND how long the popup window waits before auto-denying. Two halves of one UX
+/// contract — shared so the server-side timeout and the popup auto-deny can't drift (windows.rs
+/// imports this).
+pub const AUTH_DECISION_TIMEOUT: Duration = Duration::from_secs(60);
+
 pub type StatusCallback = Arc<dyn Fn(&str) + Send + Sync>;
 pub type VersionsChangedCallback = Arc<dyn Fn() + Send + Sync>;
 
@@ -358,7 +364,7 @@ async fn authorize_origin(
         }
     }
 
-    let decision = tokio::time::timeout(Duration::from_secs(60), rx)
+    let decision = tokio::time::timeout(AUTH_DECISION_TIMEOUT, rx)
         .await
         .map_err(|_| {
             tracing::warn!(origin = %origin, "Authorization timed out");

--- a/packages/accelerator/src-tauri/src/windows.rs
+++ b/packages/accelerator/src-tauri/src/windows.rs
@@ -3,7 +3,6 @@
 use aztec_accelerator::authorization::{AuthDecision, AuthorizationManager};
 use aztec_accelerator::commands;
 use std::sync::Arc;
-use std::time::Duration;
 use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
 
 /// Focus a newly created window. We stay as Accessory (tray-only) rather than
@@ -69,7 +68,7 @@ pub fn show_auth_popup_window(
     let origin_owned = origin.to_string();
     let auth_manager = auth_manager.clone();
     tauri::async_runtime::spawn(async move {
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        tokio::time::sleep(aztec_accelerator::server::AUTH_DECISION_TIMEOUT).await;
         // Close window if still open
         if let Some(window) = app_handle.get_webview_window(&label) {
             let _ = window.close();


### PR DESCRIPTION
**quality-refactor Phase 1** — first cheap win. Shares the duplicated 60s auth-decision timeout (`server.rs` /prove gate + `windows.rs` popup auto-deny) as `pub const AUTH_DECISION_TIMEOUT`. Behavior-preserving; guarded by the existing timeout characterization test (now on main from #293). `cargo test --lib`: 125 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)