### PR TITLE
refactor(accelerator): typed ServerStatus enum replaces stringly status callback (Q10)

### DIFF
--- a/implementations-plan/quality-refactor-2026-06-05/lessons/phase-1.md
+++ b/implementations-plan/quality-refactor-2026-06-05/lessons/phase-1.md
@@ -32,8 +32,35 @@ warn!}`). Per Ask B (refactor + ship the fixes, communicate each), Q9 will make 
 too — a real, user-visible change (a failed auto-update-pref save now surfaces instead of being lost).
 This will be surfaced to the owner explicitly in the Q9 PR, as a separately-labeled commit.
 
+## Q10 — typed ServerStatus enum (#299, auto-merging)
+Replaced `StatusCallback = Arc<dyn Fn(&str)>` with `Arc<dyn Fn(ServerStatus)>`.
+`enum ServerStatus { Idle, Downloading, Proving }` + `display_text()` (byte-identical to the prior
+`"Status: …"` literals) + `is_busy()` (true iff `Downloading|Proving`). The 4 emit sites
+(`StatusGuard` drop, download transition, two proving transitions) pass variants; the main.rs tray
+consumer matches on `is_busy()` instead of `text.contains("Proving") || text.contains("Downloading")`.
+Behavior-preserving: the Phase-0 `prove_success_path_and_status_sequence` test's assertion is
+**unchanged** (`["Status: Proving...", "Status: Idle"]`) — now produced via `display_text()`.
+
+**Gotcha 1 (compiler-caught):** the two `cb("Status: Proving...")` sites had **different indentation**
+(12 vs 8 spaces), so an `Edit replace_all` on the 12-space literal silently missed the 8-space one.
+`cargo test --lib` caught it (`E0308 expected ServerStatus, found &str` at the survivor). Lesson:
+after a `replace_all` on a string that recurs at varying indent, grep the literal again to confirm zero
+survivors before trusting it.
+
+**Gotcha 2 (process, not code):** `git checkout -b refactor/phase1-q10-server-status` **failed**
+("already exists" — a stale branch from a prior abandoned attempt at the pre-Q8/Q9 base), which left
+HEAD on `main`. The subsequent commit landed on **local main**, and the explicit-refspec push then
+shipped the *stale* branch tip, not the new commit (`gh pr create` → "No commits between"). Fix:
+`branch -f <q10> <commit>`, `reset --hard <real-main>`, re-push (fast-forward, since the stale tip was
+an ancestor). Lesson: when `checkout -b` can fail on a pre-existing name, verify `git branch
+--show-current` before committing — don't assume the branch switched.
+
+**Infra note:** SSH transport to github.com (port 22) was down this session while keys were loaded and
+`gh` (HTTPS) worked — so pull/push were routed through `gh`'s credential helper over HTTPS via
+`git -c credential.helper='!gh auth git-credential'` (no token-in-URL, no persistent config change).
+Diagnosis matters: it was the transport, NOT 1Password/the agent.
+
 ## Next
-Q8 merges → Q9 (mutate_config + the swallow fix) → Q10 (ServerStatus enum, coordinated server emit +
-main.rs tray consumer; the Phase-0 `prove_success_path_and_status_sequence` test pins the exact
-`["Status: Proving...", "Status: Idle"]` strings the enum must reproduce). Then Phase 2+ (value objects,
-splits). LESSONS_FILE=implementations-plan/quality-refactor-2026-06-05/lessons/phase-1.md
+Phase 1 cheap-wins COMPLETE (Q15 #295, Q8 #296, Q9 #298, Q10 #299). Next: **Phase 2 value objects** —
+Q3 `AztecVersion` (versions.rs/bb.rs), Q11 `download_bb` split, Q5 SDK extraction. Characterization
+tests FIRST per phase. LESSONS_FILE=implementations-plan/quality-refactor-2026-06-05/lessons/phase-1.md

--- a/packages/accelerator/server/Cargo.lock
+++ b/packages/accelerator/server/Cargo.lock
@@ -262,6 +262,7 @@ dependencies = [
  "base64 0.22.1",
  "dirs 6.0.0",
  "flate2",
+ "hex",
  "http",
  "hyper",
  "hyper-util",
@@ -286,6 +287,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "url",
  "urlencoding",
  "which",
  "x509-parser 0.18.1",
@@ -3083,6 +3085,7 @@ dependencies = [
  "time",
  "x509-parser 0.16.0",
  "yasna",
+ "zeroize",
 ]
 
 [[package]]

--- a/packages/accelerator/src-tauri/src/main.rs
+++ b/packages/accelerator/src-tauri/src/main.rs
@@ -6,7 +6,7 @@ mod windows;
 
 use aztec_accelerator::authorization::AuthorizationManager;
 use aztec_accelerator::commands::{AuthState, ConfigState, PendingUpdate, SharedAppState};
-use aztec_accelerator::server::{AppState, HTTPS_PORT};
+use aztec_accelerator::server::{AppState, ServerStatus, HTTPS_PORT};
 use aztec_accelerator::{certs, commands, config, log_dir, verified_sites};
 use parking_lot::RwLock;
 use std::path::Path;
@@ -345,7 +345,8 @@ fn main() {
 
             let is_animating_for_status = is_animating.clone();
             let state = AppState {
-                on_status: Some(Arc::new(move |text: &str| {
+                on_status: Some(Arc::new(move |status: ServerStatus| {
+                    let text = status.display_text();
                     tracing::info!(text, "on_status callback fired");
                     if let Err(e) = status_clone.set_text(text) {
                         tracing::error!("set_text failed: {e}");
@@ -353,8 +354,7 @@ fn main() {
                     if let Err(e) = tray_clone.set_tooltip(Some(text)) {
                         tracing::error!("set_tooltip failed: {e}");
                     }
-                    let active = text.contains("Proving") || text.contains("Downloading");
-                    is_animating_for_status.store(active, Ordering::Release);
+                    is_animating_for_status.store(status.is_busy(), Ordering::Release);
                 })),
                 bundled_version: Some(bundled_version),
                 on_versions_changed: Some(on_versions_changed),

--- a/packages/accelerator/src-tauri/src/server.rs
+++ b/packages/accelerator/src-tauri/src/server.rs
@@ -29,7 +29,37 @@ pub const HTTPS_PORT: u16 = 59834;
 /// imports this).
 pub const AUTH_DECISION_TIMEOUT: Duration = Duration::from_secs(60);
 
-pub type StatusCallback = Arc<dyn Fn(&str) + Send + Sync>;
+/// Status surfaced to the tray via the `on_status` callback during a `/prove` request.
+/// `display_text()` MUST stay byte-identical to the legacy `"Status: …"` string literals — the
+/// tray label and the `prove_success_path_and_status_sequence` characterization test both pin
+/// them. `is_busy()` drives the tray spinner (true ⟺ work in flight: Downloading or Proving).
+/// Replaces the prior stringly-typed `Fn(&str)` callback so the tray consumer matches on variants
+/// instead of substring-sniffing the label text (Q10).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServerStatus {
+    Idle,
+    Downloading,
+    Proving,
+}
+
+impl ServerStatus {
+    /// Tray label text. Byte-identical to the pre-Q10 string literals (behavior-preserving).
+    pub fn display_text(self) -> &'static str {
+        match self {
+            ServerStatus::Idle => "Status: Idle",
+            ServerStatus::Downloading => "Status: Downloading bb...",
+            ServerStatus::Proving => "Status: Proving...",
+        }
+    }
+
+    /// Whether work is in flight (drives the tray spinner). True for exactly Downloading + Proving
+    /// — matching the prior `text.contains("Proving") || text.contains("Downloading")` consumer.
+    pub fn is_busy(self) -> bool {
+        matches!(self, ServerStatus::Downloading | ServerStatus::Proving)
+    }
+}
+
+pub type StatusCallback = Arc<dyn Fn(ServerStatus) + Send + Sync>;
 pub type VersionsChangedCallback = Arc<dyn Fn() + Send + Sync>;
 
 /// Callback to show the authorization popup window. Takes the origin string.
@@ -278,7 +308,7 @@ struct StatusGuard {
 impl Drop for StatusGuard {
     fn drop(&mut self) {
         if let Some(ref cb) = self.cb {
-            cb("Status: Idle");
+            cb(ServerStatus::Idle);
         }
     }
 }
@@ -454,7 +484,7 @@ async fn resolve_version<'a>(
     if v != bundled && !versions::version_bb_path(v).exists() {
         tracing::info!(version = %v, "Version not cached, downloading");
         if let Some(ref cb) = state.on_status {
-            cb("Status: Downloading bb...");
+            cb(ServerStatus::Downloading);
         }
 
         match versions::download_bb(v).await {
@@ -482,7 +512,7 @@ async fn resolve_version<'a>(
         }
 
         if let Some(ref cb) = state.on_status {
-            cb("Status: Proving...");
+            cb(ServerStatus::Proving);
         }
     }
 
@@ -548,7 +578,7 @@ async fn prove(
         .map(|v| v.to_string());
 
     if let Some(ref cb) = state.on_status {
-        cb("Status: Proving...");
+        cb(ServerStatus::Proving);
     }
     let _guard = StatusGuard {
         cb: state.on_status.clone(),
@@ -1048,8 +1078,8 @@ mod tests {
         let recorded = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
         let rec = recorded.clone();
         let state = AppState {
-            on_status: Some(std::sync::Arc::new(move |s: &str| {
-                rec.lock().unwrap().push(s.to_string())
+            on_status: Some(std::sync::Arc::new(move |s: ServerStatus| {
+                rec.lock().unwrap().push(s.display_text().to_string())
             })),
             prove_semaphore: Some(std::sync::Arc::new(tokio::sync::Semaphore::new(1))),
             ..Default::default()


### PR DESCRIPTION
## Q10 — Phase 1 cheap win (quality-refactor-2026-06-05)

Replaces the stringly-typed tray-status callback with a typed enum.

**Before:** `StatusCallback = Arc<dyn Fn(&str)>`; the tray consumer in `main.rs` sniffed the label text (`text.contains("Proving") || text.contains("Downloading")`) to decide whether to animate the spinner.

**After:** `StatusCallback = Arc<dyn Fn(ServerStatus)>` where
```rust
enum ServerStatus { Idle, Downloading, Proving }
```
- `display_text()` → byte-identical to the prior `"Status: …"` literals (tray label unchanged).
- `is_busy()` → `true` iff `Downloading | Proving` (exactly what the substring match computed).

The 4 emit sites (`StatusGuard` drop + the download/proving transitions) now pass variants; `main.rs` matches on `is_busy()`.

### Behavior-preserving — proof
The Phase-0 characterization test `prove_success_path_and_status_sequence` is **unchanged** in its assertion: it still pins `["Status: Proving...", "Status: Idle"]`, now produced via `display_text()`. If the enum's strings drifted, that test fails.

### Local validation (CI bar)
- `cargo test --lib` → **125 passed, 0 failed**
- `cargo clippy --lib --bins -- -D warnings` → clean
- `cargo check --bin aztec-accelerator` → compiles (bin crate isn't built by `--lib`; the Q15-class gotcha)
- `cargo check` headless `accelerator-server` → compiles

Also syncs the stale `server/Cargo.lock` (`hex`/`url`/`zeroize` the lib already pulls in via window-label hashing, verified-sites `url::Url`, and cert zeroization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)