### PR TITLE
refactor(accelerator): AztecVersion value object + thread through download sink (Q3, Phase 4)

### DIFF
--- a/implementations-plan/quality-refactor-2026-06-05/lessons/phase-4.md
+++ b/implementations-plan/quality-refactor-2026-06-05/lessons/phase-4.md
@@ -1,0 +1,49 @@
+# Phase 4 — `AztecVersion` value object (Q3) — lessons
+
+Shipped as PR #300 (two commits: type-first checkpoint, then sink threading), rebased onto the
+Q10-main (#299) before merge.
+
+## Design — validation-as-constructor + Deref bounds the blast radius
+`AztecVersion { raw, tier, sort_key }` with `parse()` running the exact `is_valid_version` predicate.
+The key decision that kept this a *small* behavior-preserving PR: implementing `Deref<Target = str>`
+(+ `AsRef<str>` + `Display`). With Deref, `&AztecVersion` **auto-coerces to `&str`** at every
+`&str`-taking call site — so `version_bb_path`, `find_bb`, and all of `bb.rs` stayed **untouched**
+(they accept `&av` for free). Only the signatures where the type adds real enforcement changed.
+
+## The #99 traversal guard became *structural*
+`download_bb(&AztecVersion)` is the win: a value of this type can only have been built by `parse`
+(which validated), so an unsafe version literally cannot reach the `remove_dir_all` sink — the bypass
+the old sink-side recheck defended against is now impossible to express. Inside `download_bb`, a single
+`let version: &str = version;` deref-shadow kept the entire body (8 tracing sites + path/URL calls)
+byte-identical, so the signature change was the only diff. The old `download_bb_rejects_unsafe_version_at_sink`
+test (which fed `download_bb` invalid strings) became un-expressible — **retargeted** to the ctor as
+`unsafe_version_cannot_be_constructed_for_download_sink`, preserving the threat-model intent.
+
+`resolve_version` constructs the `AztecVersion` ONCE at the HTTP ingress (replacing the bare
+`is_valid_version` call). Pre-existing char tests `resolve_version_rejects_invalid_version` +
+`_passes_valid_version` stayed green through the new parse path — proof the 400-on-invalid contract is
+identical.
+
+## Deferred (kept this PR tight)
+The plan folds `versions_to_evict` re-parse subsumption (`&[String]` → `&[AztecVersion]`, using the
+precomputed `tier()`/`sort_key()`) + the `bb_asset_name` minor into Q3. Split to a follow-up to keep
+the sink-threading PR small and behavior-preserving. `tier()`/`sort_key()` are `pub` so they're not
+dead-code while unused internally (the char test exercises them).
+
+## Rebase gotchas
+1. **Q3↔Q10 `resolve_version` overlap auto-merged cleanly.** Both PRs edit the same function's download
+   block (Q10: `cb(ServerStatus::Downloading)`; Q3: `version_bb_path(&version)` / `download_bb(&version)`),
+   but on non-adjacent lines, so git's 3-way merge combined them with no conflict. **Auto-merged adjacent
+   changes in one function are where silent breakage hides** — verified by re-running the full suite
+   (126/126, incl. both `prove_success_path_and_status_sequence` and the Q3 tests together) + eyeballing
+   the merged function, NOT by trusting the clean rebase.
+2. **1Password commit *signing* failed mid-rebase** ("failed to write commit object / 1Password: failed
+   to fill whole buffer") — distinct from the earlier SSH-*transport* outage (that was port 22; this is
+   the signing agent). Continued with `git -c commit.gpgsign=false rebase main` per standing guidance.
+   The signing-vs-transport distinction matters: same vendor, two independent failure modes this session.
+
+## Next
+Phase 4 (Q3) merges → **Phase 5 / Q11** (`download_bb` split — Extract Method, operates on the new
+`AztecVersion`; char test the atomic-rename-cleanup first). Then the Q3 follow-up (`versions_to_evict`)
+can ride alongside or precede it.
+LESSONS_FILE=implementations-plan/quality-refactor-2026-06-05/lessons/phase-4.md

--- a/packages/accelerator/src-tauri/src/server.rs
+++ b/packages/accelerator/src-tauri/src/server.rs
@@ -465,29 +465,35 @@ async fn resolve_version<'a>(
         None => return Ok(None),
     };
 
-    if !versions::is_valid_version(v) {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            json_error(
-                "invalid_version",
-                &format!("Invalid x-aztec-version header (got '{v}')"),
-            ),
-        ));
-    }
-    tracing::info!(version = %v, "Requested Aztec version");
+    // Construct the validated value object ONCE at the ingress boundary (Q3). Parse failure returns
+    // the same 400 the bare `is_valid_version` check did; every downstream sink takes `&AztecVersion`,
+    // so the #99 traversal guard is enforced by construction rather than re-checked per sink.
+    let version = match versions::AztecVersion::parse(v) {
+        Some(av) => av,
+        None => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                json_error(
+                    "invalid_version",
+                    &format!("Invalid x-aztec-version header (got '{v}')"),
+                ),
+            ));
+        }
+    };
+    tracing::info!(version = %version, "Requested Aztec version");
 
     let bundled = state
         .bundled_version
         .as_deref()
         .unwrap_or(env!("AZTEC_BB_VERSION"));
 
-    if v != bundled && !versions::version_bb_path(v).exists() {
-        tracing::info!(version = %v, "Version not cached, downloading");
+    if v != bundled && !versions::version_bb_path(&version).exists() {
+        tracing::info!(version = %version, "Version not cached, downloading");
         if let Some(ref cb) = state.on_status {
             cb(ServerStatus::Downloading);
         }
 
-        match versions::download_bb(v).await {
+        match versions::download_bb(&version).await {
             Ok(_) => {
                 tracing::info!(version = %v, "Download complete");
                 let bundled_owned = bundled.to_string();

--- a/packages/accelerator/src-tauri/src/versions.rs
+++ b/packages/accelerator/src-tauri/src/versions.rs
@@ -63,6 +63,71 @@ impl NetworkTier {
     }
 }
 
+/// A validated Aztec version string — the Q3 value object.
+///
+/// Construction (`parse`) is the single validation gate: it runs the exact `is_valid_version`
+/// predicate, so any `&AztecVersion` that reaches a cache-path or download-URL sink is traversal-safe
+/// *by construction* — the #99 guard can no longer be bypassed by forgetting to call it. Carries the
+/// precomputed network `tier` and `sort_key` so eviction no longer re-parses each element.
+/// `Deref<Target = str>` + `AsRef<str>` expose the raw string at the `&str` boundaries that build
+/// paths/URLs, keeping those sinks byte-identical to the pre-Q3 `&str` callees.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AztecVersion {
+    raw: String,
+    tier: NetworkTier,
+    sort_key: (String, u64),
+}
+
+impl AztecVersion {
+    /// Parse an untrusted version string, running the full `is_valid_version` gate. Returns `None`
+    /// for exactly the inputs `is_valid_version` rejects (pinned by
+    /// `aztec_version_parse_matches_is_valid_version`).
+    pub fn parse(version: &str) -> Option<Self> {
+        if !is_valid_version(version) {
+            return None;
+        }
+        Some(Self {
+            tier: NetworkTier::from_version(version),
+            sort_key: version_sort_key(version),
+            raw: version.to_string(),
+        })
+    }
+
+    /// The raw version string (e.g. `"5.0.0-rc.1"`).
+    pub fn as_str(&self) -> &str {
+        &self.raw
+    }
+
+    /// The precomputed network tier (drives cache retention).
+    pub fn tier(&self) -> NetworkTier {
+        self.tier
+    }
+
+    /// The precomputed `(base, numeric-suffix)` sort key for retention ordering.
+    pub fn sort_key(&self) -> &(String, u64) {
+        &self.sort_key
+    }
+}
+
+impl std::ops::Deref for AztecVersion {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.raw
+    }
+}
+
+impl AsRef<str> for AztecVersion {
+    fn as_ref(&self) -> &str {
+        &self.raw
+    }
+}
+
+impl std::fmt::Display for AztecVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.raw)
+    }
+}
+
 /// Returns the base directory for cached bb versions: `~/.aztec-accelerator/versions/`.
 pub fn versions_base_dir() -> PathBuf {
     dirs::home_dir()
@@ -509,6 +574,65 @@ mod tests {
             !is_valid_version(&"a".repeat(129)),
             "should reject an over-long version"
         );
+    }
+
+    /// Q3 value object: `AztecVersion::parse` MUST accept exactly the set `is_valid_version` accepts
+    /// (validation-as-constructor — the ctor is now the single traversal gate, so it can't drift from
+    /// the predicate it replaces). Also pins that a parsed version round-trips byte-identically
+    /// (`as_str`/`Deref`) and precomputes the same `tier`/`sort_key` the eviction + path/URL sinks
+    /// rely on — the properties that keep threading `&AztecVersion` behavior-preserving.
+    #[test]
+    fn aztec_version_parse_matches_is_valid_version() {
+        let corpus = [
+            "5.0.0",
+            "5.0.0-rc.1",
+            "5.0.0-nightly.20260307",
+            "5.0.0-devnet.20260307",
+            "4.2.0-aztecnr-rc.2",
+            "1.2.3-alpha_beta",
+            "",
+            "..",
+            ".",
+            ".foo",
+            "1..2",
+            "5.0.0.",
+            "../../../etc/passwd",
+            "5.0.0; rm -rf /",
+            "5.0.0\n",
+            "a\\b",
+        ];
+        for v in corpus {
+            assert_eq!(
+                AztecVersion::parse(v).is_some(),
+                is_valid_version(v),
+                "parse/is_valid_version disagree on {v:?}"
+            );
+        }
+        assert!(
+            AztecVersion::parse(&"a".repeat(129)).is_none(),
+            "over-long rejected identically"
+        );
+
+        // Valid versions round-trip byte-identically and precompute the same tier.
+        for v in [
+            "5.0.0",
+            "5.0.0-rc.1",
+            "5.0.0-nightly.20260307",
+            "5.0.0-devnet.20260307",
+        ] {
+            let av = AztecVersion::parse(v).expect("valid");
+            assert_eq!(av.as_str(), v, "as_str round-trip");
+            assert_eq!(&*av, v, "Deref round-trip");
+            assert_eq!(
+                av.tier(),
+                NetworkTier::from_version(v),
+                "tier matches from_version"
+            );
+        }
+        // sort_key precomputed (read so the field is exercised); rc.10 sorts after rc.2 numerically.
+        let rc10 = AztecVersion::parse("5.0.0-rc.10").unwrap();
+        let rc2 = AztecVersion::parse("5.0.0-rc.2").unwrap();
+        assert!(rc10.sort_key() > rc2.sort_key(), "rc.10 sorts after rc.2");
     }
 
     /// The sink-side guard must fire BEFORE any path derivation or network/fs access, so a direct

--- a/packages/accelerator/src-tauri/src/versions.rs
+++ b/packages/accelerator/src-tauri/src/versions.rs
@@ -334,12 +334,13 @@ pub fn is_valid_version(version: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_')
 }
 
-pub async fn download_bb(version: &str) -> Result<PathBuf, Box<dyn Error + Send + Sync>> {
-    // Defense-in-depth: reject an unsafe version BEFORE deriving any path or touching the network/fs
-    // (this fn + version_bb_path are public; `remove_dir_all(version_dir)` below is the dangerous sink).
-    if !is_valid_version(version) {
-        return Err(format!("Refusing to download bb for invalid version {version:?}").into());
-    }
+pub async fn download_bb(version: &AztecVersion) -> Result<PathBuf, Box<dyn Error + Send + Sync>> {
+    // The `&AztecVersion` parameter IS the #99 traversal guard: a value of this type can only have
+    // been built by `AztecVersion::parse`, which ran `is_valid_version`. An unsafe version therefore
+    // cannot reach this sink (`remove_dir_all` below) — the bypass the old sink-side recheck defended
+    // against is now structurally impossible. Deref to `&str` once so the existing path/URL/log sites
+    // stay byte-identical to the pre-Q3 callee.
+    let version: &str = version;
     let bb_path = version_bb_path(version);
     if bb_path.exists() {
         tracing::info!(version, "bb already cached");
@@ -635,17 +636,17 @@ mod tests {
         assert!(rc10.sort_key() > rc2.sort_key(), "rc.10 sorts after rc.2");
     }
 
-    /// The sink-side guard must fire BEFORE any path derivation or network/fs access, so a direct
-    /// caller (bypassing the server.rs ingress) can't steer `remove_dir_all` toward a traversal path.
-    #[tokio::test]
-    async fn download_bb_rejects_unsafe_version_at_sink() {
+    /// #99 traversal guard, post-Q3. The guard is now the `AztecVersion` constructor: `download_bb`
+    /// takes `&AztecVersion`, so an unsafe version can't be built into the type the `remove_dir_all`
+    /// sink requires — a direct caller bypassing the server.rs ingress is *structurally* unable to
+    /// steer the sink toward a traversal path (stronger than the prior runtime recheck). This pins
+    /// that the ctor rejects the exact corpus the sink-side check used to.
+    #[test]
+    fn unsafe_version_cannot_be_constructed_for_download_sink() {
         for v in ["..", ".", "../etc", ".5.0.0", "a/b"] {
-            let err = download_bb(v)
-                .await
-                .expect_err("download_bb must reject an unsafe version");
             assert!(
-                err.to_string().contains("invalid version"),
-                "expected guard rejection for {v:?}, got: {err}"
+                AztecVersion::parse(v).is_none(),
+                "ctor must reject unsafe {v:?} so it cannot reach download_bb(&AztecVersion)"
             );
         }
     }
@@ -1071,7 +1072,8 @@ mod tests {
         );
 
         // Download — exercises the full pipeline: HTTP GET → SHA-256 → extract → codesign
-        let bb_path = download_bb(&version)
+        let av = AztecVersion::parse(&version).expect("bundled version is valid");
+        let bb_path = download_bb(&av)
             .await
             .unwrap_or_else(|e| panic!("download_bb({version}) failed: {e}"));
 


### PR DESCRIPTION
## Phase 4 / Q3 — `AztecVersion` value object (quality-refactor-2026-06-05)

Introduces a validated value object for Aztec version strings and threads it through the security-critical download sink.

### What
- **`AztecVersion { raw, tier, sort_key }`** (versions.rs) — *validation-as-constructor*: `parse()` runs the exact `is_valid_version` predicate, carries the precomputed network `tier` + `sort_key`, and exposes the raw string via `Deref<str>` / `AsRef<str>` / `Display`.
- **`download_bb(&AztecVersion)`** — the type **is** the #99 traversal guard now: a value can only have been built by `parse` (which validated), so an unsafe version cannot reach the `remove_dir_all` sink. The prior sink-side recheck is gone (structurally redundant).
- **`resolve_version`** constructs the `AztecVersion` once at the HTTP ingress, replacing the bare `is_valid_version` call.
- `version_bb_path` / `find_bb` / `bb.rs` stay `&str` — `&AztecVersion` deref-coerces at those call sites, bounding the blast radius.

### Behavior-preserving — proof
- Pre-existing char tests `resolve_version_rejects_invalid_version` + `resolve_version_passes_valid_version` stay green **through the new parse path** (the 400-on-invalid contract is identical).
- New char test `aztec_version_parse_matches_is_valid_version`: `parse` accepts exactly what `is_valid_version` accepts, round-trips byte-identically, precomputes the same tier/sort_key.
- The #99 sink-guard test is **retargeted to the ctor** (`unsafe_version_cannot_be_constructed_for_download_sink`) — the guard's new structural location.

### Local validation
`cargo test --lib` 126/126 · `clippy --lib --bins -D warnings` clean · bin + headless compile.

### Scope note
Deferred to a small Q3 follow-up to keep this PR tight: the `versions_to_evict` re-parse subsumption (`&[String]` → `&[AztecVersion]`, using the precomputed tier/sort_key) + the `bb_asset_name` minor.

> ⚠️ **Sequencing:** overlaps with #299 (Q10) in `resolve_version`'s download block. #299 (Phase 3) should merge first; this branch will be rebased onto the resulting main (small mechanical resolve) before merge. Not auto-merge-armed for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)