### PR TITLE
refactor(accelerator): extract install_version_dir + atomic-rename char test (Q11 1/2)

### DIFF
--- a/implementations-plan/quality-refactor-2026-06-05/lessons/phase-5.md
+++ b/implementations-plan/quality-refactor-2026-06-05/lessons/phase-5.md
@@ -1,0 +1,49 @@
+# Phase 5 — `download_bb` split (Q11) + codex post-impl audit of Q3/Q10
+
+## Codex post-impl audit of Q3 (AztecVersion) + Q10 (ServerStatus) — session 019e9a1e
+Ran `/codex xhigh` (read-only) on the merged Q3+Q10 refactors. **Verdict: "at-risk — no currently
+reachable app-level behavior/security break, but Q3 narrows the safety guarantee and weakens the
+regression net, so 'strictly behavior-preserving' is too strong."**
+
+**Looks fine (codex confirmed):**
+- No `is_valid_version` vs `AztecVersion::parse` divergence — `parse` is a straight wrapper; `Display`/
+  `Deref`/`AsRef` emit identical bytes.
+- No unvalidated path into `remove_dir_all`: `/prove` parses once at ingress; `download_bb` only takes
+  `&AztecVersion`; `cleanup_old_versions` only removes `read_dir` names (can't synthesize `/` traversal).
+- Q10 `display_text()` strings exact; `is_busy()` matches the old spinner for the only emitted states.
+
+**Findings + disposition:**
+- **Med-1 (raw-path helpers not fully encapsulated):** `version_bb_path`/`find_bb` are still `pub` +
+  take raw `&str`. Non-destructive today (they build paths; the destructive sink is `download_bb`, now
+  typed). *Accepted* — closing this means typing the whole module surface; out of Q3's behavior-
+  preserving scope. Logged for a future hardening pass.
+- **Med-2 (sink-boundary regression net weakened):** the old `download_bb_rejects_unsafe_version_at_sink`
+  exercised the destructive sink with unsafe input; retargeting it to the ctor lost that. *Partially
+  mitigated already* by `resolve_version_rejects_invalid_version` (ingress 400) + `AztecVersion`'s
+  **private fields** (so `parse` is the ONLY constructor — an unchecked one can't be added externally).
+  *Accepted* for the merged Q3; no live bug.
+- **Low (crate-API breaks):** `download_bb(&str)→(&AztecVersion)`, `StatusCallback` signature. Expected —
+  this lib isn't published as a Rust crate (it's the app's internal lib + the headless server consumes it,
+  which we recompiled). Not behavior-preserving at the *crate* boundary, but is at the *app* boundary.
+
+**Direct relevance to Phase 5:** codex's Med-1 (raw-path sink helpers) is exactly why the new
+`install_version_dir(version_dir: &Path, bytes)` is kept **private + single-caller** — `download_bb` only
+ever passes `versions_base_dir().join(version)` for a validated `AztecVersion`, so its `remove_dir_all`
+never sees an attacker-derived path. (Taking `&Path` rather than `&AztecVersion` is purely for tempdir
+unit-testability; the safety comes from the private/single-caller invariant, documented on the fn.)
+
+## Q11 part 1 — extract `install_version_dir` (#TBD)
+First Extract-Method unit: the extract-to-tmp + 2 `remove_dir_all` cleanup arms + atomic rename, pulled
+out of `download_bb` into a private `install_version_dir(&Path, &[u8])`. Byte-identical: the temp dir is
+still `.{name}.tmp` where `name = version_dir.file_name()` (== the validated version). Char test
+`install_version_dir_replaces_stale_and_extracts_atomically` (plan's "atomic-rename-cleanup first") pins:
+fresh extract, stale-entry wholesale replace, temp-dir cleanup — using the existing GzEncoder+tar::Builder
+fixture pattern + a `tempfile::tempdir()` so it never touches the real `~/.aztec-accelerator`. 127 lib
+tests + clippy -D warnings green.
+
+## Remaining Q11 extracts (part 2, this branch or follow-up)
+`download_tarball` (bounded streaming GET, versions.rs ~350-391) · `verify_digest` (GitHub asset digest
+fetch + sha256 compare, ~394-417) · `postprocess_unix`/`postprocess_macos` (chmod / xattr+codesign +
+cleanup-on-failure, ~438-486). Orchestrator `download_bb` keeps the guard+cache fast-path + the
+digest→extract ordering. Then the Q3-followup (`versions_to_evict` → `&[AztecVersion]`).
+LESSONS_FILE=implementations-plan/quality-refactor-2026-06-05/lessons/phase-5.md

--- a/packages/accelerator/src-tauri/src/versions.rs
+++ b/packages/accelerator/src-tauri/src/versions.rs
@@ -417,23 +417,10 @@ pub async fn download_bb(version: &AztecVersion) -> Result<PathBuf, Box<dyn Erro
         }
     }
 
-    // Extract to a temporary directory, then atomically rename
+    // Extract into the version's cache dir via temp dir + atomic rename (Q11: extracted to
+    // `install_version_dir` so the cleanup/rename is unit-testable without the network).
     let version_dir = versions_base_dir().join(version);
-    let tmp_dir = version_dir.with_file_name(format!(".{version}.tmp"));
-
-    // Clean up any leftover partial download
-    if tmp_dir.exists() {
-        std::fs::remove_dir_all(&tmp_dir)?;
-    }
-    std::fs::create_dir_all(&tmp_dir)?;
-
-    extract_bb_from_tarball(&bytes, &tmp_dir)?;
-
-    // Atomic rename
-    if version_dir.exists() {
-        std::fs::remove_dir_all(&version_dir)?;
-    }
-    std::fs::rename(&tmp_dir, &version_dir)?;
+    install_version_dir(&version_dir, &bytes)?;
 
     let final_path = version_dir.join(bb_binary_name());
     #[cfg(unix)]
@@ -484,6 +471,43 @@ pub async fn download_bb(version: &AztecVersion) -> Result<PathBuf, Box<dyn Erro
 
     tracing::info!(version, "bb cached successfully");
     Ok(final_path)
+}
+
+/// Install an extracted bb tarball into `version_dir` via a temp dir + atomic rename.
+///
+/// Cleans up any stale partial-download temp dir, extracts into it, then removes any pre-existing
+/// `version_dir` and renames the temp dir into place — so the cache swap is atomic and a previously
+/// corrupt entry is replaced wholesale. The temp dir is a sibling named `.{name}.tmp` (derived from
+/// `version_dir`'s file name), matching the pre-Q11 inline behavior byte-for-byte.
+///
+/// Private + single-caller by design: `download_bb` passes `versions_base_dir().join(version)` where
+/// `version` came from a validated `AztecVersion`, so the `remove_dir_all` here never sees an
+/// attacker-derived path. Pinned by `install_version_dir_replaces_stale_and_extracts_atomically`.
+fn install_version_dir(
+    version_dir: &std::path::Path,
+    bytes: &[u8],
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let name = version_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or("invalid version dir (no file name)")?;
+    let tmp_dir = version_dir.with_file_name(format!(".{name}.tmp"));
+
+    // Clean up any leftover partial download
+    if tmp_dir.exists() {
+        std::fs::remove_dir_all(&tmp_dir)?;
+    }
+    std::fs::create_dir_all(&tmp_dir)?;
+
+    extract_bb_from_tarball(bytes, &tmp_dir)?;
+
+    // Atomic rename — replace any pre-existing cache entry wholesale
+    if version_dir.exists() {
+        std::fs::remove_dir_all(version_dir)?;
+    }
+    std::fs::rename(&tmp_dir, version_dir)?;
+
+    Ok(())
 }
 
 /// Extract the `bb` binary from a gzipped tarball.
@@ -871,6 +895,59 @@ mod tests {
         assert!(bb.exists());
         let contents = std::fs::read_to_string(&bb).unwrap();
         assert!(contents.contains("echo hello"));
+    }
+
+    /// Q11 atomic-rename-cleanup: `install_version_dir` extracts into a sibling temp dir then renames
+    /// it into place, replacing any stale cache entry wholesale and leaving no temp dir behind. Pins
+    /// the behavior the pre-Q11 inline block in `download_bb` had, now that it's a testable unit.
+    #[test]
+    fn install_version_dir_replaces_stale_and_extracts_atomically() {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+
+        // Minimal valid tarball containing the platform bb binary name.
+        let bb_content = b"#!/bin/sh\necho fake-bb\n";
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
+        {
+            let mut builder = tar::Builder::new(&mut encoder);
+            let mut header = tar::Header::new_gnu();
+            header.set_size(bb_content.len() as u64);
+            header.set_mode(0o755);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, bb_binary_name(), &bb_content[..])
+                .unwrap();
+            builder.finish().unwrap();
+        }
+        let tarball = encoder.finish().unwrap();
+
+        let base = tempfile::tempdir().unwrap();
+        let version_dir = base.path().join("5.0.0-test");
+
+        // Fresh install → bb present.
+        install_version_dir(&version_dir, &tarball).unwrap();
+        assert!(
+            version_dir.join(bb_binary_name()).exists(),
+            "bb extracted on fresh install"
+        );
+
+        // A stale cache entry (junk file) is replaced wholesale by the atomic rename.
+        std::fs::write(version_dir.join("STALE_JUNK"), b"old").unwrap();
+        install_version_dir(&version_dir, &tarball).unwrap();
+        assert!(
+            version_dir.join(bb_binary_name()).exists(),
+            "bb re-extracted after replace"
+        );
+        assert!(
+            !version_dir.join("STALE_JUNK").exists(),
+            "stale entry removed by atomic replace"
+        );
+
+        // No leftover temp dir after the rename.
+        assert!(
+            !version_dir.with_file_name(".5.0.0-test.tmp").exists(),
+            "temp dir cleaned up after rename"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Phase 5 / Q11 — `download_bb` split, part 1 (quality-refactor-2026-06-05)

First Extract-Method unit of the `download_bb` orchestrator split.

### What
Pulled the extract-to-tmp + two `remove_dir_all` cleanup arms + atomic rename out of `download_bb` into a private `install_version_dir(version_dir: &Path, bytes: &[u8])`.

**Byte-identical:** the temp dir is still `.{name}.tmp` where `name == version_dir.file_name()` (== the validated version, since `download_bb` passes `versions_base_dir().join(version)`).

### Char test first (plan's "atomic-rename-cleanup")
New `install_version_dir_replaces_stale_and_extracts_atomically` pins: fresh extract, **stale cache entry replaced wholesale** by the atomic rename, and temp-dir cleanup — via `tempfile::tempdir()` so it never touches the real `~/.aztec-accelerator`. This destructive-rename path had no fast unit test before.

### Security (addresses the codex post-impl audit's Med-1)
The new fn is a raw-`&Path` sink (`remove_dir_all`), so it's kept **private + single-caller**: `download_bb` only ever passes a dir derived from a validated `AztecVersion`. Taking `&Path` (vs `&AztecVersion`) is purely for tempdir testability; safety comes from the documented private/single-caller invariant.

### Validation
`cargo test --lib` **127/127** · `clippy --lib --bins -D warnings` clean.

### Scope
Part 1 of Q11. Remaining extracts (`download_tarball` / `verify_digest` / `postprocess_unix`+`postprocess_macos`) ride a follow-up — they're pure mechanical extractions covered by the gated real-download integration test. Orchestrator keeps the guard+cache fast-path + digest→extract ordering.

> Codex post-impl audit of the prior Q3+Q10 phases ran clean ("at-risk" nuances only, no live break — see `lessons/phase-5.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)