### PR TITLE
refactor(accelerator): extract download_tarball + verify_digest (Q11 2/2)

### DIFF
--- a/implementations-plan/quality-refactor-2026-06-05/lessons/phase-5.md
+++ b/implementations-plan/quality-refactor-2026-06-05/lessons/phase-5.md
@@ -41,9 +41,22 @@ fresh extract, stale-entry wholesale replace, temp-dir cleanup — using the exi
 fixture pattern + a `tempfile::tempdir()` so it never touches the real `~/.aztec-accelerator`. 127 lib
 tests + clippy -D warnings green.
 
-## Remaining Q11 extracts (part 2, this branch or follow-up)
-`download_tarball` (bounded streaming GET, versions.rs ~350-391) · `verify_digest` (GitHub asset digest
-fetch + sha256 compare, ~394-417) · `postprocess_unix`/`postprocess_macos` (chmod / xattr+codesign +
-cleanup-on-failure, ~438-486). Orchestrator `download_bb` keeps the guard+cache fast-path + the
-digest→extract ordering. Then the Q3-followup (`versions_to_evict` → `&[AztecVersion]`).
+## Q11 part 2 — extract `download_tarball` + `verify_digest` (#TBD)
+Extracted the two cfg-free async units: `download_tarball(&str) -> Vec<u8>` (bounded-streaming GET with
+the 64 MB cap) and `verify_digest(&str, &[u8])` (GitHub asset SHA-256 fetch + fail-closed compare).
+`download_bb`'s orchestrator is now a clean sequence: `download_tarball → verify_digest →
+install_version_dir → postprocess`, preserving the **verify-BEFORE-install ordering**. Pure byte-identical
+extractions — covered by the gated real-download integration test. 127 lib tests + clippy -D warnings green.
+
+**Deliberately left `postprocess` inline** (NOT extracted to `postprocess_unix`/`postprocess_macos` as the
+plan sketched): the chmod is `#[cfg(unix)]` and the xattr+codesign is `#[cfg(target_os = "macos")]`, so
+extracted fns would have **unused params on non-macOS** (`version_dir`/`version` only used by the macOS
+cleanup-on-failure) → `clippy -D warnings` failures across the platform matrix, the exact cfg trap the
+Q15 bin-crate lesson warned about. The inline `#[cfg]` blocks are already clearly delimited; extracting
+them trades real cross-platform risk for cosmetic gain. Logged as a conscious scope cut.
+
+## Next
+Q11 done (modulo the noted postprocess decision) → `/code-review max --fix` on the complete `download_bb`
+split → then the Q3-followup (`versions_to_evict` → `&[AztecVersion]`, using the precomputed
+`tier()`/`sort_key()`) → Phase 6 (Q4 crash-recovery trait, SAFETY-CRITICAL, needs the rc dry-run).
 LESSONS_FILE=implementations-plan/quality-refactor-2026-06-05/lessons/phase-5.md

--- a/packages/accelerator/src-tauri/src/versions.rs
+++ b/packages/accelerator/src-tauri/src/versions.rs
@@ -347,75 +347,16 @@ pub async fn download_bb(version: &AztecVersion) -> Result<PathBuf, Box<dyn Erro
         return Ok(bb_path);
     }
 
-    let url = download_url(version);
-    tracing::info!(version, %url, "Downloading bb");
-
-    let response = http_client().get(&url).send().await?;
-    if !response.status().is_success() {
-        return Err(format!(
-            "Failed to download bb v{version}: HTTP {}",
-            response.status()
-        )
-        .into());
-    }
-
-    // Bounded streaming download: read the body in chunks with a running counter so a server that
-    // omits Content-Length (chunked encoding) cannot OOM us by streaming gigabytes. The advertised
-    // length is an early fail-fast; the per-chunk counter is the real ceiling. 64 MB cap: download_bb
-    // fetches the platform tarball (barretenberg-amd64-linux is ~17 MB today, avm-class builds ~30 MB),
-    // so this is ~2x the largest current asset with room to grow. Mirrors copy-bb.ts
-    // MAX_BB_TARBALL_BYTES (64 MB) — the sibling build-time fetch of the same artifact.
-    const MAX_DOWNLOAD_BYTES: usize = 64 * 1024 * 1024;
-    if let Some(len) = response.content_length() {
-        if len > MAX_DOWNLOAD_BYTES as u64 {
-            return Err(format!(
-                "bb v{version} download too large (advertised {len} bytes, max {MAX_DOWNLOAD_BYTES})"
-            )
-            .into());
-        }
-    }
-    let mut response = response; // chunk() takes &mut self
-    let mut bytes: Vec<u8> = Vec::with_capacity(8 * 1024 * 1024);
-    while let Some(chunk) = response.chunk().await? {
-        if bytes.len().saturating_add(chunk.len()) > MAX_DOWNLOAD_BYTES {
-            return Err(format!(
-                "bb v{version} download exceeded {MAX_DOWNLOAD_BYTES} bytes — aborting"
-            )
-            .into());
-        }
-        bytes.extend_from_slice(&chunk);
-    }
+    // Download the tarball (bounded streaming) and verify its integrity before touching the fs
+    // (Q11: extracted to `download_tarball` + `verify_digest`; the digest→extract ordering — verify
+    // BEFORE install — is preserved here in the orchestrator).
+    let bytes = download_tarball(version).await?;
     tracing::info!(
         version,
         bytes = bytes.len(),
         "Download complete, verifying integrity"
     );
-
-    // Verify download integrity against GitHub API digest.
-    // Fail closed: if we can't verify, we don't execute. The bundled bb sidecar
-    // always works without verification; this only affects on-demand downloads.
-    let asset_name = format!("barretenberg-{}.tar.gz", current_platform());
-    match fetch_github_asset_digest(version, &asset_name).await {
-        Ok(Some(expected)) => {
-            let actual = sha256_hex(&bytes);
-            if actual != expected {
-                return Err(format!(
-                    "Integrity check failed for bb v{version}: expected sha256:{expected}, got sha256:{actual}"
-                )
-                .into());
-            }
-            tracing::info!(version, digest = %actual, "Download integrity verified");
-        }
-        Ok(None) => {
-            return Err(format!(
-                "Cannot verify bb v{version}: no digest available from GitHub API"
-            )
-            .into());
-        }
-        Err(e) => {
-            return Err(format!("Cannot verify bb v{version}: digest fetch failed: {e}").into());
-        }
-    }
+    verify_digest(version, &bytes).await?;
 
     // Extract into the version's cache dir via temp dir + atomic rename (Q11: extracted to
     // `install_version_dir` so the cleanup/rename is unit-testable without the network).
@@ -471,6 +412,71 @@ pub async fn download_bb(version: &AztecVersion) -> Result<PathBuf, Box<dyn Erro
 
     tracing::info!(version, "bb cached successfully");
     Ok(final_path)
+}
+
+/// Download the bb tarball for `version` with a bounded-streaming read. The 64 MB cap (advertised
+/// Content-Length is an early fail-fast; the running per-chunk counter is the real ceiling) stops a
+/// Content-Length-omitting server from OOM-ing us by streaming gigabytes. Mirrors copy-bb.ts
+/// `MAX_BB_TARBALL_BYTES`. Byte-identical to the pre-Q11 inline block.
+async fn download_tarball(version: &str) -> Result<Vec<u8>, Box<dyn Error + Send + Sync>> {
+    let url = download_url(version);
+    tracing::info!(version, %url, "Downloading bb");
+
+    let response = http_client().get(&url).send().await?;
+    if !response.status().is_success() {
+        return Err(format!(
+            "Failed to download bb v{version}: HTTP {}",
+            response.status()
+        )
+        .into());
+    }
+
+    const MAX_DOWNLOAD_BYTES: usize = 64 * 1024 * 1024;
+    if let Some(len) = response.content_length() {
+        if len > MAX_DOWNLOAD_BYTES as u64 {
+            return Err(format!(
+                "bb v{version} download too large (advertised {len} bytes, max {MAX_DOWNLOAD_BYTES})"
+            )
+            .into());
+        }
+    }
+    let mut response = response; // chunk() takes &mut self
+    let mut bytes: Vec<u8> = Vec::with_capacity(8 * 1024 * 1024);
+    while let Some(chunk) = response.chunk().await? {
+        if bytes.len().saturating_add(chunk.len()) > MAX_DOWNLOAD_BYTES {
+            return Err(format!(
+                "bb v{version} download exceeded {MAX_DOWNLOAD_BYTES} bytes — aborting"
+            )
+            .into());
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(bytes)
+}
+
+/// Verify the downloaded `bytes` against the GitHub release asset's published SHA-256 digest.
+/// **Fail-closed:** a missing digest (`Ok(None)`) or a fetch error is an error, not a skip — we never
+/// install unverified code. The bundled sidecar path never reaches here. Byte-identical to the
+/// pre-Q11 inline block.
+async fn verify_digest(version: &str, bytes: &[u8]) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let asset_name = format!("barretenberg-{}.tar.gz", current_platform());
+    match fetch_github_asset_digest(version, &asset_name).await {
+        Ok(Some(expected)) => {
+            let actual = sha256_hex(bytes);
+            if actual != expected {
+                return Err(format!(
+                    "Integrity check failed for bb v{version}: expected sha256:{expected}, got sha256:{actual}"
+                )
+                .into());
+            }
+            tracing::info!(version, digest = %actual, "Download integrity verified");
+            Ok(())
+        }
+        Ok(None) => {
+            Err(format!("Cannot verify bb v{version}: no digest available from GitHub API").into())
+        }
+        Err(e) => Err(format!("Cannot verify bb v{version}: digest fetch failed: {e}").into()),
+    }
 }
 
 /// Install an extracted bb tarball into `version_dir` via a temp dir + atomic rename.


### PR DESCRIPTION
## Phase 5 / Q11 — `download_bb` split, part 2 (completes the split)

Extracts the two remaining cfg-free async units from `download_bb`:
- **`download_tarball(&str) -> Vec<u8>`** — the bounded-streaming GET (64 MB cap; advertised Content-Length is an early fail-fast, the per-chunk counter is the real ceiling).
- **`verify_digest(&str, &[u8])`** — the GitHub asset SHA-256 fetch + **fail-closed** compare.

The orchestrator is now a clean sequence — `download_tarball → verify_digest → install_version_dir → postprocess` — **preserving the verify-BEFORE-install ordering**.

### Behavior-preserving
Pure byte-identical extractions (logic moved verbatim), covered by the gated real-download integration test. `cargo test --lib` **127/127** · `clippy --lib --bins -D warnings` clean.

### Deliberate scope cut: `postprocess` left inline
NOT extracted to `postprocess_unix`/`postprocess_macos` as the plan sketched: chmod is `#[cfg(unix)]`, xattr+codesign is `#[cfg(target_os = "macos")]`, so extracted fns would have **unused params on non-macOS** under `-D warnings` (the Q15 cfg trap). The inline `#[cfg]` blocks are already clearly delimited; extraction trades real cross-platform risk for cosmetic gain. Logged in `lessons/phase-5.md`.

> Together with #301 (`install_version_dir`), this completes the Q11 `download_bb` split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)