### PR TITLE
refactor(accelerator): extract CrashRecovery trait + per-platform dispatch (Q4, Phase 6)

### DIFF
--- a/implementations-plan/quality-refactor-2026-06-05/lessons/phase-6.md
+++ b/implementations-plan/quality-refactor-2026-06-05/lessons/phase-6.md
@@ -1,0 +1,54 @@
+# Phase 6 — Crash-recovery trait (Q4) [SAFETY-CRITICAL] — research + design
+
+## Key finding: the safety-critical ordering is OUTSIDE the refactor scope
+The #96/#97 **disarm-before-install ordering** lives in `updater.rs::perform_update` (L86-119) and is
+**entirely `#[cfg(target_os = "windows")]`-gated** — it calls the *free* `disable_crash_recovery()`
+(Windows → bool), aborts+rearms if disarm can't be confirmed, then installs, then rearms. macOS/Linux
+have **no disarm dance** at install (launchd KeepAlive / systemd don't have the Windows always-armed-
+repeating-task-ticks-during-NSIS-mutation race).
+
+**Therefore the Q4 trait extraction leaves `updater.rs` UNTOUCHED.** The brick-risk ordering is not
+refactored at all — it keeps calling the free `disable_crash_recovery()`. This de-risks Q4 massively vs
+the plan's "preserve the ordering byte-for-byte" framing (there's nothing to preserve in the refactored
+file — the ordering is in a file we don't touch).
+
+## Current platform-divergent surface (crash_recovery.rs, 452 lines)
+- `enable_crash_recovery()`: macOS L23 (plist KeepAlive), Linux L93 (systemd), Windows L216 (schtasks).
+- `disable_crash_recovery()`: macOS L76 → `()`, Linux L163 → `()`, **Windows L281 → `bool`** (the
+  /Delete-then-/Query-confirm; returns true if never armed).
+- Callers: updater.rs:92 (`if !disable()`, **windows-cfg only**), commands.rs:47/50 (set_autostart),
+  main.rs:276/294. The mac/linux callers use `disable()` as a statement (ignore any return).
+
+## Design (Extract Interface — behavior-preserving)
+```rust
+pub trait CrashRecovery { fn enable(&self); fn disable(&self) -> bool; }
+#[cfg(target_os="macos")]  pub struct PlatformRecovery; // + impl: bodies verbatim, disable appends `true`
+#[cfg(target_os="linux")]  pub struct PlatformRecovery; // + impl
+#[cfg(target_os="windows")] pub struct PlatformRecovery; // + impl: disable returns the bool verbatim
+// free fns become thin dispatch; disable_crash_recovery() now -> bool on ALL platforms
+pub fn enable_crash_recovery()  { PlatformRecovery.enable() }
+pub fn disable_crash_recovery() -> bool { PlatformRecovery.disable() }
+```
+- **Unify the free `disable` to `-> bool` everywhere** (mac/linux now return `true`). Caller-compatible:
+  the mac/linux call sites ignore the return (statement position; `bool` isn't `#[must_use]` → no clippy
+  warning). updater.rs (windows) already used the bool.
+- Bodies move **verbatim** → behavior-preserving.
+
+## Test safety net
+- **Generation** pinned by existing `task_xml_uses_repeating_trigger_and_escapes_exe` (windows, asserts
+  NOT `<RestartOnFailure>`) + `patch_plist_*` (macOS). These survive the move (bodies unchanged).
+- **Ordering** (disarm→install→rearm) is NOT a unit test — it's the **updater-smoke CI gate** (the
+  `_e2e-updater-windows.yml` from #96/#97). Since updater.rs is untouched, this gate's behavior is
+  unchanged; the **1.0.x-rc dry-run** is the validation per the /goal.
+
+## Validation gap (why this is a careful pass, not a deep-tail crank)
+Only macOS compiles locally; Windows + Linux trait impls compile **only via CI** (accelerator gate runs
+all three). A cfg typo in the windows/linux block is CI-caught (~15 min), not local — so implement the
+3 blocks carefully, `cargo check` macOS locally, then lean on the gate. Then **rc dry-run** before any
+stable cut (blocking updater-smoke green).
+
+## Plan
+1. Implement the trait + 3 ZST impls + dispatch (verbatim body moves).
+2. `cargo test --lib` + `clippy` (macOS local) → PR → accelerator gate (all 3 platforms) green.
+3. rc dry-run (autonomous-allowed; rc only) validates the Windows updater path.
+LESSONS_FILE=implementations-plan/quality-refactor-2026-06-05/lessons/phase-6.md

--- a/implementations-plan/quality-refactor-2026-06-05/lessons/phase-6.md
+++ b/implementations-plan/quality-refactor-2026-06-05/lessons/phase-6.md
@@ -47,8 +47,30 @@ all three). A cfg typo in the windows/linux block is CI-caught (~15 min), not lo
 3 blocks carefully, `cargo check` macOS locally, then lean on the gate. Then **rc dry-run** before any
 stable cut (blocking updater-smoke green).
 
-## Plan
-1. Implement the trait + 3 ZST impls + dispatch (verbatim body moves).
-2. `cargo test --lib` + `clippy` (macOS local) → PR → accelerator gate (all 3 platforms) green.
-3. rc dry-run (autonomous-allowed; rc only) validates the Windows updater path.
+## Concrete implementation plan (bodies read — ready for a focused pass)
+**Structural finding:** on each platform `enable` and `disable` are NOT contiguous — a helper sits
+between them (macOS `patch_plist_with_keepalive` L55-71 + `macos_plist_path` L82-88; linux inline;
+windows `schtasks_exe`/`task_xml`/`xml_escape`). So the impl block can't just wrap a line range.
+
+**~8 edits, all behavior-preserving (bodies verbatim):**
+1. Trait def at top (platform-agnostic): `pub trait CrashRecovery { fn enable(&self); fn disable(&self) -> bool; }`.
+2-4. Per platform: replace `pub fn enable_crash_recovery() {<body>}` with
+   `pub struct PlatformRecovery;` + `impl CrashRecovery for PlatformRecovery { fn enable(&self){<enable body>} fn disable(&self)->bool{<disable body>; true /*mac,linux*/} }`,
+   pulling the disable body up into the impl. Helpers stay as free fns after the impl.
+5-7. Per platform: delete the old standalone `disable_crash_recovery` fn (its body moved into the impl).
+8. Non-cfg dispatch free fns (signatures preserved; disable now `-> bool` on ALL platforms):
+   `pub fn enable_crash_recovery() { PlatformRecovery.enable() }` /
+   `pub fn disable_crash_recovery() -> bool { PlatformRecovery.disable() }`.
+   (`PlatformRecovery` is the per-platform cfg'd ZST; the trait is in-module so methods resolve.)
+
+**Callers unchanged** (commands.rs:47/50, main.rs:276/294, updater.rs:92-windows). The mac/linux
+callers ignore the now-`bool` return (statement position; not `#[must_use]` → no clippy warning).
+Windows `disable` already returned the bool. **updater.rs untouched → disarm ordering preserved.**
+
+**Validation:** `cargo test --lib` (macOS: `task_xml`/`patch_plist` generation tests guard bodies) +
+`cargo check` macOS local → PR → accelerator gate compiles windows+linux → **rc dry-run** (Windows
+updater-smoke) before any stable cut.
+
+**Design note (resolved):** plan's "free fns → thin dispatch [to ZST]" chosen over trait-wraps-fns —
+the former makes the free fns the trait's consumer (not a dead abstraction). No codex needed.
 LESSONS_FILE=implementations-plan/quality-refactor-2026-06-05/lessons/phase-6.md

--- a/packages/accelerator/src-tauri/src/crash_recovery.rs
+++ b/packages/accelerator/src-tauri/src/crash_recovery.rs
@@ -3,6 +3,45 @@
 //! - **macOS**: Patches the LaunchAgent plist to add `KeepAlive` + `ThrottleInterval`,
 //!   so launchd restarts the app if it crashes.
 //! - **Linux**: Manages a systemd user service with `Restart=on-failure`.
+//!
+//! The per-platform logic lives behind the [`CrashRecovery`] trait, implemented by the
+//! platform-specific `PlatformRecovery` ZST. The `enable_crash_recovery` / `disable_crash_recovery`
+//! free functions are thin dispatch onto it, so callers stay platform-agnostic and the surface is
+//! mockable in tests.
+
+/// Platform crash-recovery control. `disable` returns whether the recovery mechanism is confirmed
+/// disarmed — always `true` where disarm is unconditional (macOS/Linux), the real /Query-verified
+/// result on Windows (where the updater MUST know the always-armed task is gone before NSIS mutates
+/// files).
+pub trait CrashRecovery {
+    fn enable(&self);
+    fn disable(&self) -> bool;
+}
+
+/// Enable crash recovery for the current platform (thin dispatch to the platform `CrashRecovery`).
+pub fn enable_crash_recovery() {
+    PlatformRecovery.enable();
+}
+
+/// Disable crash recovery. See [`CrashRecovery::disable`] for the `bool` contract — callers that must
+/// know the recovery is gone (the updater, before install) check it.
+pub fn disable_crash_recovery() -> bool {
+    PlatformRecovery.disable()
+}
+
+/// The current platform's crash-recovery implementation. A unit struct — the actual state lives in
+/// the OS (launchd plist / systemd unit / Task Scheduler task). Dispatches to the `#[cfg]`-selected
+/// `enable_impl` / `disable_impl`.
+pub struct PlatformRecovery;
+
+impl CrashRecovery for PlatformRecovery {
+    fn enable(&self) {
+        enable_impl();
+    }
+    fn disable(&self) -> bool {
+        disable_impl()
+    }
+}
 
 /// Must match `productName` in tauri.conf.json — the auto-launch crate uses this
 /// (not the identifier) as the LaunchAgent plist filename.
@@ -20,7 +59,7 @@ const SYSTEMD_NAME: &str = "aztec-accelerator";
 /// Previous implementation used `.replace("</dict>", ...)` which replaced ALL occurrences
 /// and could corrupt plists with nested dicts.
 #[cfg(target_os = "macos")]
-pub fn enable_crash_recovery() {
+fn enable_impl() {
     let plist_path = macos_plist_path();
     match std::fs::read_to_string(&plist_path) {
         Ok(content) => {
@@ -73,10 +112,11 @@ fn patch_plist_with_keepalive(content: &str) -> Option<String> {
 /// Remove crash recovery keys from the LaunchAgent plist.
 /// Call this after `manager.disable()` to clean up.
 #[cfg(target_os = "macos")]
-pub fn disable_crash_recovery() {
+fn disable_impl() -> bool {
     // The plugin recreates the plist from scratch on enable(), so disabling
     // just means the standard disable() removes the plist entirely. Nothing extra needed.
     tracing::info!("macOS crash recovery disabled (plist removed by plugin)");
+    true
 }
 
 #[cfg(target_os = "macos")]
@@ -90,7 +130,7 @@ fn macos_plist_path() -> std::path::PathBuf {
 /// Create and enable a systemd user service with `Restart=on-failure`.
 /// Call this after `manager.enable()`.
 #[cfg(target_os = "linux")]
-pub fn enable_crash_recovery() {
+fn enable_impl() {
     let exe = match std::env::current_exe() {
         Ok(p) => p,
         Err(e) => {
@@ -160,7 +200,7 @@ pub fn enable_crash_recovery() {
 /// Disable and remove the systemd user service.
 /// Call this after `manager.disable()`.
 #[cfg(target_os = "linux")]
-pub fn disable_crash_recovery() {
+fn disable_impl() -> bool {
     let _ = std::process::Command::new("systemctl")
         .args(["--user", "disable", SYSTEMD_NAME])
         .output();
@@ -174,6 +214,7 @@ pub fn disable_crash_recovery() {
     }
 
     tracing::info!("systemd user service disabled (crash recovery)");
+    true
 }
 
 // ── Windows ──────────────────────────────────────────────────────────────────
@@ -213,7 +254,7 @@ fn schtasks_exe() -> std::path::PathBuf {
 
 /// Register the Task Scheduler crash-recovery task. Call after `manager.enable()`.
 #[cfg(target_os = "windows")]
-pub fn enable_crash_recovery() {
+fn enable_impl() {
     use std::io::Write;
 
     let exe = match std::env::current_exe() {
@@ -278,7 +319,7 @@ pub fn enable_crash_recovery() {
 /// (removed or already absent), `false` if removal could not be verified — callers that rely on
 /// the task being gone (the updater, before NSIS mutates files) MUST check this and not proceed.
 #[cfg(target_os = "windows")]
-pub fn disable_crash_recovery() -> bool {
+fn disable_impl() -> bool {
     // Deletion is correctness-critical now: the repeating-trigger task relaunches the app a
     // minute after an intentional quit if it survives. So retry, and verify via /Query
     // (locale-independent — it exits non-zero when the task is absent) rather than trusting


### PR DESCRIPTION
## Phase 6 / Q4 — `CrashRecovery` trait [SAFETY-CRITICAL]

Extracts a `trait CrashRecovery { fn enable(&self); fn disable(&self) -> bool; }` impl'd by a `PlatformRecovery` ZST. `enable_crash_recovery`/`disable_crash_recovery` become thin dispatch; the per-platform bodies are **renamed in place** to private `enable_impl`/`disable_impl` (no re-indent, no logic change).

- **Uniform `disable -> bool`:** macOS/Linux now return `true` (disarm is unconditional there); Windows keeps its `/Query`-verified bool. Fixes the prior `()` vs `bool` divergence.
- **SAFETY — the brick-risk ordering is untouched:** `updater.rs`'s `#[cfg(windows)]` disarm-before-install sequence (#96/#97) still calls the free `disable_crash_recovery()`, so it's preserved *by construction* — this PR doesn't touch `updater.rs` at all.
- Callers (`commands.rs`, `main.rs`) ignore the now-`bool` return (statement position; `bool` isn't `#[must_use]` → no warning).

### Validation
- **macOS local:** `cargo test --lib` **127/127** (the `patch_plist_*` generation tests guard the macOS enable body) + `clippy --lib --bins -D warnings` + bin all green.
- **Windows/Linux** `*_impl` are `#[cfg]`-gated → compiled+tested by the **accelerator CI gate** (incl. the `task_xml` windows test).
- The Windows updater disarm path → the **1.0.x-rc dry-run** (blocking updater-smoke) before any stable cut.

> Behavior-preserving Extract-Interface. The rc-dry-run is the safety-critical sign-off gate per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)