### PR TITLE
refactor(sdk): extract #probeAndParseHealth from checkAcceleratorStatus (Q5 1/2)

### DIFF
--- a/packages/sdk/src/lib/accelerator-prover.ts
+++ b/packages/sdk/src/lib/accelerator-prover.ts
@@ -208,7 +208,15 @@ export class AcceleratorProver extends BBLazyPrivateKernelProver {
     ) {
       return this.#statusCache.result;
     }
+    return this.#probeAndParseHealth();
+  }
 
+  /**
+   * Probe the accelerator's `/health` (dual HTTP/HTTPS, one retry) and parse the response into an
+   * {@link AcceleratorStatus}, caching the result. Extracted from {@link AcceleratorProver.checkAcceleratorStatus}
+   * (Q5) — behavior-identical; the status-cache fast-path stays in the caller.
+   */
+  async #probeAndParseHealth(): Promise<AcceleratorStatus> {
     const sdkAztecVersion = this.#getAztecVersion();
     const httpUrl = `http://${this.#acceleratorHost}:${this.#acceleratorPort}/health`;
     const httpsUrl = `https://${this.#acceleratorHost}:${this.#acceleratorHttpsPort}/health`;


### PR DESCRIPTION
## Phase 7 / Q5 — SDK health-probe extraction (part 1)

`checkAcceleratorStatus` is split: it keeps the status-cache fast-path, then delegates to a new private `#probeAndParseHealth()` that holds the dual HTTP/HTTPS probe (one retry) + `/health` parse into `AcceleratorStatus`.

**Behavior-identical** (public API unchanged): the body moved *verbatim* (a single insertion split the method — no re-indent), every return still caches via the inner `cacheAndReturn`, and `#getAztecVersion()` still runs only on cache-miss.

### Validation
`bun run --cwd packages/sdk test:unit` → **26/26** · `tsc` (build) clean.

### Scope
Part 1 of Q5. The `PhaseReporter` extraction (wrapping the ~13 `#onPhase?.()` sites — *Extract Class*) rides a follow-up. This lands under the existing types (per the plan's Q5-before-Q12 split); the Q12 breaking type-change is Phase 8 (user-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)