### PR TITLE
refactor(accelerator): split AppState into HeadlessState core + GUI callbacks (Q1)

### DIFF
--- a/implementations-plan/quality-refactor-2026-06-05/lessons/phase-7.md
+++ b/implementations-plan/quality-refactor-2026-06-05/lessons/phase-7.md
@@ -1,0 +1,66 @@
+# Phase 7 — architectural splits [RISKY CORE PATH] — progress + designs
+
+## Done
+- **Q5·1** (#306, MERGED): extracted `#probeAndParseHealth` from `checkAcceleratorStatus` (SDK). Single
+  surgical split (cache fast-path stays in caller; body moved verbatim, no re-indent). 26 SDK tests + tsc.
+- **Q14** (#307, armed): `is_auto_approved` rewritten to reuse `url::Url` parsing (Substitute Algorithm)
+  instead of hand-rolled prefix-strip/`:`-split. **Ask-B resolved: PURE REFACTOR** — the auto-approve set
+  is unchanged (the decider tests `auto_approved_localhost_variants` incl. `[::1]` + `non_localhost_not_
+  auto_approved` stay green; `url::Url::host_str()` returns `[::1]` WITH brackets). Nothing to surface.
+
+## rc-dry-run timing (correction)
+The 1.0.x-rc dry-run is a **pre-stable-cut BATCH gate**, NOT per-phase: it validates Q4+Q6+Q7+Q1+Q2
+together before the next stable cut (plan: "the server/updater/safari ones gate on an rc dry-run before
+the next stable cut"). Dispatching it after Q4 alone is premature — Q4 doesn't even touch updater.rs, so
+the updater-smoke path is unchanged. Run ONE rc-dry-run once the risky/safety-critical set is complete.
+
+## Q1 — `AppState` split [KEYSTONE, Q2 depends on it] — COMPLETE DESIGN
+Central state on the hot `/prove` path → multi-file restructure. NOT a single-file crank.
+
+**Target shape:**
+```rust
+pub struct HeadlessState {           // the 5 server-relevant fields
+    pub bundled_version: Option<String>,
+    pub https_port: Option<u16>,
+    pub config: Option<Arc<RwLock<config::AcceleratorConfig>>>,
+    pub auth_manager: Option<Arc<AuthorizationManager>>,
+    pub prove_semaphore: Option<Arc<Semaphore>>,
+}
+pub struct GuiCallbacks {            // the 3 GUI callbacks (present iff a GUI is wired)
+    pub on_status: StatusCallback,
+    pub on_versions_changed: VersionsChangedCallback,
+    pub show_auth_popup: ShowAuthPopupCallback,
+}
+#[derive(Clone, Default)]
+pub struct AppState { pub core: Arc<HeadlessState>, pub gui: Option<Arc<GuiCallbacks>> }
+```
+
+**Blast radius (measured):**
+- **~12 core accesses** — uniform rewrite `state.<f>` → `state.core.<f>` (config×5, https_port×3,
+  auth_manager×2, prove_semaphore×1, bundled_version in resolve_version).
+- **~7 gui accesses** — the intricate part: `state.on_status` (was `Option<Callback>`) →
+  `state.gui.as_ref().map(|g| &g.on_status)` (the Option now lives on `gui`, not per-field). on_status×4,
+  show_auth_popup×2, on_versions_changed×1. Each `if let Some(ref cb) = state.on_status` site becomes
+  `if let Some(g) = state.gui.as_ref()` then use `g.on_status`. THE care-sensitive sites (the prove
+  handler's status emits, the auth-popup trigger).
+- **Construction:** headless (server/src/main.rs:62 — 3 fields + Default) →
+  `AppState { core: Arc::new(HeadlessState{auth_manager, config, prove_semaphore, ..Default::default()}), gui: None }`.
+  GUI (main.rs:347 — all 8) → core fields into `HeadlessState`, the 3 callbacks into
+  `Some(Arc::new(GuiCallbacks{...}))`. Plus `state_with_https.https_port = ...` (main.rs:377) →
+  needs HeadlessState mutation before the Arc (build HeadlessState, set https_port, then Arc::new).
+- **~8 test construction sites** in server.rs (most are `AppState::default()` or `..Default::default()`
+  with 1-2 fields) + the Phase-0 char tests that set `on_status`/`prove_semaphore` → update to the new shape.
+
+**Validation:** `cargo test --lib` (the Phase-0 char tests — prove ordering, status sequence — are the
+behavior guard) + `cargo check --bin` + `cargo check -p accelerator-server` (the headless crate consumes
+AppState — MUST stay green) + clippy. Then Q2 (server.rs module split) builds on this.
+
+**Why a focused pass, not deep-tail:** ~19 access rewrites across server.rs handlers + main.rs + the
+headless crate + Default + the gui-Option-of-struct intricacy. A compaction mid-rewrite leaves a broken
+hot path across 3 files. Implement in one focused pass with full budget; the char tests are the net.
+
+## Remaining P7
+Q1 (designed↑) → Q2 (server.rs → bind.rs/tls.rs/handlers/, depends on Q1) → Q6 (UpdateCoordinator,
+safety-critical) → Q7 (SafariSupportManager + the missing-recovery Ask-B fix, safety-critical) → Q5·2
+(PhaseReporter, low-value churn). Then ONE rc-dry-run (Q4+Q6+Q7+Q1+Q2) before any stable cut.
+LESSONS_FILE=implementations-plan/quality-refactor-2026-06-05/lessons/phase-7.md

--- a/implementations-plan/quality-refactor-2026-06-05/lessons/phase-7.md
+++ b/implementations-plan/quality-refactor-2026-06-05/lessons/phase-7.md
@@ -55,9 +55,48 @@ pub struct AppState { pub core: Arc<HeadlessState>, pub gui: Option<Arc<GuiCallb
 behavior guard) + `cargo check --bin` + `cargo check -p accelerator-server` (the headless crate consumes
 AppState — MUST stay green) + clippy. Then Q2 (server.rs module split) builds on this.
 
-**Why a focused pass, not deep-tail:** ~19 access rewrites across server.rs handlers + main.rs + the
-headless crate + Default + the gui-Option-of-struct intricacy. A compaction mid-rewrite leaves a broken
-hot path across 3 files. Implement in one focused pass with full budget; the char tests are the net.
+### RESOLVED design fork (the hard part — found while implementing)
+**The plan's `gui: Option<Arc<GuiCallbacks>>` (all-or-nothing) does NOT fit:** the gui callbacks are
+*individually* `Option` today — the Phase-0 char test `prove_success_path_and_status_sequence` sets
+`on_status` ALONE (no `show_auth_popup`/`on_versions_changed`). An all-or-nothing `GuiCallbacks` struct
+can't represent "only on_status set," so it would break that test.
+
+**Resolution — option (b), behavior-preserving + minimal-churn:**
+```rust
+#[derive(Clone, Default)]
+pub struct HeadlessState { bundled_version, https_port, config, auth_manager, prove_semaphore }  // 5 core, each Option
+#[derive(Clone, Default)]
+pub struct AppState {
+    pub core: Arc<HeadlessState>,
+    pub on_status: Option<StatusCallback>,            // gui callbacks stay FLAT on AppState (individually Option)
+    pub on_versions_changed: Option<VersionsChangedCallback>,
+    pub show_auth_popup: Option<ShowAuthPopupCallback>,
+}
+impl Deref for AppState { type Target = HeadlessState; fn deref(&self)->&HeadlessState { &self.core } }
+```
+- **`Deref<Target=HeadlessState>` ⇒ the ~12 core reads (`state.config`, `state.bundled_version`, …) are
+  UNCHANGED** (auto-deref through AppState→core for field reads). The ~7 gui reads (`state.on_status`)
+  are ALSO unchanged (flat fields). **Net: ZERO access-site rewrites.** Churn = struct def + Deref +
+  construction sites only.
+- This deviates from the plan's `gui: Option<Arc<GuiCallbacks>>` (which doesn't fit the per-field-Option
+  reality) but delivers the plan's actual VALUE: the headless crate uses `HeadlessState`; cloning AppState
+  Arc-clones the 5 core fields (the clone-stutter fix). Grouping the 3 gui callbacks into a struct adds the
+  per-field-Option complexity for ~no benefit — rejected.
+- **Construction edits (the only churn):** GUI (main.rs:347): core fields → `Arc::new(HeadlessState{…})`,
+  3 callbacks stay flat. Headless (server/src/main.rs:62): `core: Arc::new(HeadlessState{auth_manager,
+  config, prove_semaphore, ..Default})`, `..Default`. **main.rs:377 `state_with_https.https_port = x`** →
+  `Arc::make_mut(&mut state_with_https.core).https_port = x` (the ONLY post-construction core mutation;
+  impl `Deref` but NOT `DerefMut`, so this one site is explicit). ~8 test sites that set a core field
+  (e.g. `prove_semaphore`) move it into a `HeadlessState{…}`; sites using only `AppState::default()` or
+  gui fields are unchanged.
+
+**Validation:** `cargo test --lib` (Phase-0 char tests = the behavior net) + `cargo check --bin` +
+`cargo check -p accelerator-server` (headless MUST stay green) + clippy.
+
+**Why a focused pass, not deep-tail:** even bounded to construction sites, it's ~12 coordinated edits
+across server.rs + main.rs + the headless crate + ~8 tests; a compaction mid-rewrite leaves a broken hot
+path across 3 files. The DESIGN (above) is now complete + the access-churn eliminated via Deref — the
+implementation is mechanical, so the next focused pass executes it fast with the char tests as the net.
 
 ## Remaining P7
 Q1 (designed↑) → Q2 (server.rs → bind.rs/tls.rs/handlers/, depends on Q1) → Q6 (UpdateCoordinator,

--- a/packages/accelerator/server/src/main.rs
+++ b/packages/accelerator/server/src/main.rs
@@ -8,7 +8,7 @@
 
 use aztec_accelerator::authorization::AuthorizationManager;
 use aztec_accelerator::config::AcceleratorConfig;
-use aztec_accelerator::server::{start, AppState};
+use aztec_accelerator::server::{start, AppState, HeadlessState};
 use parking_lot::RwLock;
 use std::sync::Arc;
 use tracing_subscriber::fmt;
@@ -60,9 +60,12 @@ async fn main() {
     };
 
     let state = AppState {
-        auth_manager,
-        config,
-        prove_semaphore: Some(Arc::new(tokio::sync::Semaphore::new(1))),
+        core: Arc::new(HeadlessState {
+            auth_manager,
+            config,
+            prove_semaphore: Some(Arc::new(tokio::sync::Semaphore::new(1))),
+            ..Default::default()
+        }),
         ..Default::default()
     };
 

--- a/packages/accelerator/src-tauri/src/commands.rs
+++ b/packages/accelerator/src-tauri/src/commands.rs
@@ -156,7 +156,8 @@ pub async fn enable_safari_support(
     let tls_config =
         certs::load_rustls_config().map_err(|e| format!("Failed to load TLS config: {e}"))?;
     let mut state = (**shared_state).clone();
-    state.https_port = Some(HTTPS_PORT);
+    // https_port lives in the Arc'd core now (Q1); make_mut copies-on-write since the Arc is shared.
+    Arc::make_mut(&mut state.core).https_port = Some(HTTPS_PORT);
     tauri::async_runtime::spawn(async move {
         if let Err(e) = crate::server::start_https(state, tls_config).await {
             tracing::error!("HTTPS server error: {e}");

--- a/packages/accelerator/src-tauri/src/main.rs
+++ b/packages/accelerator/src-tauri/src/main.rs
@@ -6,7 +6,7 @@ mod windows;
 
 use aztec_accelerator::authorization::AuthorizationManager;
 use aztec_accelerator::commands::{AuthState, ConfigState, PendingUpdate, SharedAppState};
-use aztec_accelerator::server::{AppState, ServerStatus, HTTPS_PORT};
+use aztec_accelerator::server::{AppState, HeadlessState, ServerStatus, HTTPS_PORT};
 use aztec_accelerator::{certs, commands, config, log_dir, verified_sites};
 use parking_lot::RwLock;
 use std::path::Path;
@@ -81,7 +81,7 @@ fn try_start_https(state: &AppState) -> Option<u16> {
     };
 
     let mut state_for_https = state.clone();
-    state_for_https.https_port = Some(HTTPS_PORT);
+    Arc::make_mut(&mut state_for_https.core).https_port = Some(HTTPS_PORT);
     tauri::async_runtime::spawn(async move {
         if let Err(e) = aztec_accelerator::server::start_https(state_for_https, tls_config).await {
             tracing::error!("HTTPS server error: {e}");
@@ -345,6 +345,13 @@ fn main() {
 
             let is_animating_for_status = is_animating.clone();
             let state = AppState {
+                core: Arc::new(HeadlessState {
+                    bundled_version: Some(bundled_version),
+                    https_port: None,
+                    config: Some(config_state.clone()),
+                    auth_manager: Some(auth_manager.clone()),
+                    prove_semaphore: Some(Arc::new(tokio::sync::Semaphore::new(1))),
+                }),
                 on_status: Some(Arc::new(move |status: ServerStatus| {
                     let text = status.display_text();
                     tracing::info!(text, "on_status callback fired");
@@ -356,13 +363,8 @@ fn main() {
                     }
                     is_animating_for_status.store(status.is_busy(), Ordering::Release);
                 })),
-                bundled_version: Some(bundled_version),
                 on_versions_changed: Some(on_versions_changed),
-                https_port: None,
-                config: Some(config_state.clone()),
-                auth_manager: Some(auth_manager.clone()),
                 show_auth_popup: Some(show_auth_popup),
-                prove_semaphore: Some(Arc::new(tokio::sync::Semaphore::new(1))),
             };
 
             // ── HTTPS startup ──
@@ -374,7 +376,7 @@ fn main() {
 
             // Manage the shared state for Tauri commands (e.g. enable_safari_support)
             let mut state_with_https = state.clone();
-            state_with_https.https_port = https_port;
+            Arc::make_mut(&mut state_with_https.core).https_port = https_port;
             app.manage::<SharedAppState>(Arc::new(state_with_https));
 
             // ── Startup diagnostics ──
@@ -394,7 +396,7 @@ fn main() {
 
             // ── HTTP server ──
             let mut http_state = state;
-            http_state.https_port = https_port;
+            Arc::make_mut(&mut http_state.core).https_port = https_port;
             let status_for_server = status_for_diagnostics;
             let server_app_handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {

--- a/packages/accelerator/src-tauri/src/server.rs
+++ b/packages/accelerator/src-tauri/src/server.rs
@@ -65,17 +65,35 @@ pub type VersionsChangedCallback = Arc<dyn Fn() + Send + Sync>;
 /// Callback to show the authorization popup window. Takes the origin string.
 pub type ShowAuthPopupCallback = Arc<dyn Fn(&str) + Send + Sync>;
 
+/// The server-side core state — everything the headless `accelerator-server` needs, with no GUI
+/// coupling. Lives behind an `Arc` in [`AppState`] so cloning the state is cheap (fixes the main.rs
+/// clone-stutter) (Q1).
 #[derive(Clone, Default)]
-pub struct AppState {
-    pub on_status: Option<StatusCallback>,
+pub struct HeadlessState {
     pub bundled_version: Option<String>,
-    pub on_versions_changed: Option<VersionsChangedCallback>,
     pub https_port: Option<u16>,
     pub config: Option<Arc<RwLock<config::AcceleratorConfig>>>,
     pub auth_manager: Option<Arc<AuthorizationManager>>,
-    pub show_auth_popup: Option<ShowAuthPopupCallback>,
     /// Limits concurrent proving to 1 — bb already uses all cores.
     pub prove_semaphore: Option<Arc<Semaphore>>,
+}
+
+/// Full app state: the headless `core` plus the optional GUI callbacks. `Deref`s to `core`, so the
+/// existing `state.<core_field>` reads are unchanged; the 3 GUI callbacks stay flat (each individually
+/// optional — a headless build or a focused test sets only a subset) (Q1).
+#[derive(Clone, Default)]
+pub struct AppState {
+    pub core: Arc<HeadlessState>,
+    pub on_status: Option<StatusCallback>,
+    pub on_versions_changed: Option<VersionsChangedCallback>,
+    pub show_auth_popup: Option<ShowAuthPopupCallback>,
+}
+
+impl std::ops::Deref for AppState {
+    type Target = HeadlessState;
+    fn deref(&self) -> &HeadlessState {
+        &self.core
+    }
 }
 
 pub async fn start(state: AppState) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -774,8 +792,11 @@ mod tests {
             ..Default::default()
         };
         let state = AppState {
-            config: Some(Arc::new(RwLock::new(cfg))),
-            https_port: Some(59834),
+            core: Arc::new(HeadlessState {
+                config: Some(Arc::new(RwLock::new(cfg))),
+                https_port: Some(59834),
+                ..Default::default()
+            }),
             ..Default::default()
         };
         let app = router(state);
@@ -1084,10 +1105,13 @@ mod tests {
         let recorded = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
         let rec = recorded.clone();
         let state = AppState {
+            core: std::sync::Arc::new(HeadlessState {
+                prove_semaphore: Some(std::sync::Arc::new(tokio::sync::Semaphore::new(1))),
+                ..Default::default()
+            }),
             on_status: Some(std::sync::Arc::new(move |s: ServerStatus| {
                 rec.lock().unwrap().push(s.display_text().to_string())
             })),
-            prove_semaphore: Some(std::sync::Arc::new(tokio::sync::Semaphore::new(1))),
             ..Default::default()
         };
 
@@ -1129,7 +1153,10 @@ mod tests {
     #[tokio::test]
     async fn health_includes_available_versions() {
         let state = AppState {
-            bundled_version: Some("5.0.0-nightly.20260307".into()),
+            core: Arc::new(HeadlessState {
+                bundled_version: Some("5.0.0-nightly.20260307".into()),
+                ..Default::default()
+            }),
             ..Default::default()
         };
         let app = router(state);
@@ -1163,12 +1190,15 @@ mod tests {
         let auth_for_state = auth.clone();
         let cfg = crate::config::AcceleratorConfig::default();
         let state = AppState {
-            auth_manager: Some(auth_for_state),
-            config: Some(Arc::new(RwLock::new(cfg))),
+            core: Arc::new(HeadlessState {
+                auth_manager: Some(auth_for_state),
+                config: Some(Arc::new(RwLock::new(cfg))),
+                prove_semaphore: Some(Arc::new(Semaphore::new(1))),
+                ..Default::default()
+            }),
             show_auth_popup: Some(Arc::new(move |origin: &str| {
                 let _ = popup_tx.send(origin.to_string());
             })),
-            prove_semaphore: Some(Arc::new(Semaphore::new(1))),
             ..Default::default()
         };
         (state, auth)
@@ -1345,8 +1375,11 @@ mod tests {
         let auth = Arc::new(crate::authorization::AuthorizationManager::new());
         let cfg = crate::config::AcceleratorConfig::default();
         let state = AppState {
-            auth_manager: Some(auth),
-            config: Some(Arc::new(RwLock::new(cfg))),
+            core: Arc::new(HeadlessState {
+                auth_manager: Some(auth),
+                config: Some(Arc::new(RwLock::new(cfg))),
+                ..Default::default()
+            }),
             show_auth_popup: None, // headless
             ..Default::default()
         };
@@ -1444,7 +1477,10 @@ mod tests {
             ..Default::default()
         };
         let state = AppState {
-            config: Some(Arc::new(RwLock::new(cfg))),
+            core: Arc::new(HeadlessState {
+                config: Some(Arc::new(RwLock::new(cfg))),
+                ..Default::default()
+            }),
             ..Default::default()
         };
         assert_eq!(compute_threads(&state), None);
@@ -1457,7 +1493,10 @@ mod tests {
             ..Default::default()
         };
         let state = AppState {
-            config: Some(Arc::new(RwLock::new(cfg))),
+            core: Arc::new(HeadlessState {
+                config: Some(Arc::new(RwLock::new(cfg))),
+                ..Default::default()
+            }),
             ..Default::default()
         };
         assert!(compute_threads(&state).is_some());


### PR DESCRIPTION
## Phase 7 / Q1 — `AppState` split [KEYSTONE, RISKY CORE PATH]

`AppState = { core: Arc<HeadlessState>, on_status, on_versions_changed, show_auth_popup }`. The 5 server-relevant fields move into `HeadlessState` (the headless `accelerator-server` constructs it directly); the 3 GUI callbacks stay flat. Cloning `AppState` now Arc-clones the core — the **main.rs clone-stutter fix**.

### The trick that bounded the blast radius
`impl Deref<Target = HeadlessState> for AppState` → every `state.<core_field>` **read is unchanged** (auto-deref). So **zero access-site rewrites** across the handlers/hot path. Only changes:
- construction sites (main.rs, headless, ~8 tests) wrap core fields in `HeadlessState { … }`;
- the 3 `https_port` *mutations* become `Arc::make_mut(&mut state.core).https_port = …` (copy-on-write).

### Deliberate deviation from the plan sketch
Plan said `gui: Option<Arc<GuiCallbacks>>` — but the gui callbacks are **per-field Option** today (the Phase-0 char test sets `on_status` alone), which an all-or-nothing `GuiCallbacks` can't represent. Keeping them flat preserves behavior + still delivers the plan's value (HeadlessState for the headless crate, cheap clones). Rationale in `lessons/phase-7.md`.

### Behavior-preserving
`cargo test --lib` **127/127** — incl. the Phase-0 hot-path char tests `prove_success_path_and_status_sequence` + `resolve_version_passes_valid_version` (the net) · `clippy --lib --bins -D warnings` · headless `accelerator-server` — all green on macOS; windows/linux via CI.

> Unblocks **Q2** (server.rs module split). RISKY-CORE-PATH → covered by the batched rc-dry-run before any stable cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)