### PR TITLE
refactor(accelerator): extract server::bind module from server.rs (Q2 1/n)

### DIFF
--- a/packages/accelerator/src-tauri/src/server.rs
+++ b/packages/accelerator/src-tauri/src/server.rs
@@ -10,7 +10,6 @@ use serde_json::json;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::net::TcpListener;
 use tokio_rustls::TlsAcceptor;
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::set_header::SetResponseHeaderLayer;
@@ -19,6 +18,9 @@ use crate::authorization::{AuthDecision, AuthorizationManager};
 use crate::{bb, config, versions};
 use parking_lot::RwLock;
 use tokio::sync::Semaphore;
+
+mod bind;
+use bind::bind_with_retry;
 
 const PORT: u16 = 59833;
 pub const HTTPS_PORT: u16 = 59834;
@@ -139,60 +141,6 @@ pub async fn healthy_aztec_on_port() -> bool {
         return false;
     };
     is_healthy_aztec_response(&body)
-}
-
-/// Bind the HTTP listener, retrying briefly on `AddrInUse`.
-///
-/// During an in-place updater restart the just-exited previous instance can
-/// still hold port 59833 for a moment. Without a retry the freshly-relaunched
-/// app permanently fails to bind and the accelerator server stays down — the
-/// new process binds once, hits `EADDRINUSE`, and never recovers (observed on
-/// Linux auto-update; macOS happens to dodge it on timing). The wait is bounded
-/// so a genuine conflict — a second instance the user started — still fails
-/// fast with the port-in-use signal (surfaced by main.rs) instead of hanging.
-async fn bind_with_retry(addr: SocketAddr) -> std::io::Result<TcpListener> {
-    // 100ms polling, 5s budget: the restart overlap clears in well under a
-    // second, so this is responsive AND fails a genuine second-instance
-    // conflict reasonably fast (it surfaces "port in use" rather than stalling).
-    bind_with_retry_inner(addr, Duration::from_millis(100), Duration::from_secs(5)).await
-}
-
-/// Inner form with injectable timings so tests can exercise the wait-it-out,
-/// hard-deadline, and immediate-propagation paths without real-time sleeps.
-async fn bind_with_retry_inner(
-    addr: SocketAddr,
-    interval: Duration,
-    max_wait: Duration,
-) -> std::io::Result<TcpListener> {
-    let deadline = std::time::Instant::now() + max_wait;
-    let mut warned = false;
-    loop {
-        match TcpListener::bind(addr).await {
-            Ok(listener) => return Ok(listener),
-            Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
-                // Hard deadline: sleep only the time actually left, so we give up
-                // at ~max_wait rather than overshooting by a full `interval`.
-                let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-                if remaining.is_zero() {
-                    tracing::warn!(
-                        "port {} still in use after {max_wait:?} — giving up",
-                        addr.port()
-                    );
-                    return Err(e);
-                }
-                if !warned {
-                    tracing::warn!(
-                        "port {} in use — retrying for up to {max_wait:?} (waiting out a prior instance, e.g. an in-place updater restart)",
-                        addr.port()
-                    );
-                    warned = true;
-                }
-                tokio::time::sleep(interval.min(remaining)).await;
-            }
-            // Any non-AddrInUse error propagates immediately — never masked by the retry.
-            Err(e) => return Err(e),
-        }
-    }
 }
 
 /// Start an HTTPS listener using the provided TLS config.
@@ -679,69 +627,6 @@ mod tests {
         assert!(!is_healthy_aztec_response(&json!({"hello": "world"})));
         assert!(!is_healthy_aztec_response(&json!({})));
         assert!(!is_healthy_aztec_response(&json!("not even an object")));
-    }
-
-    #[tokio::test]
-    async fn bind_with_retry_waits_out_a_transient_holder() {
-        // The in-place-restart case: hold a freshly-chosen port, release it
-        // shortly, and assert the retry binds once it frees.
-        let probe = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
-            .await
-            .unwrap();
-        let addr = probe.local_addr().unwrap();
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(80)).await;
-            drop(probe);
-        });
-        let listener =
-            bind_with_retry_inner(addr, Duration::from_millis(20), Duration::from_secs(2))
-                .await
-                .expect("should bind once the transient holder releases the port");
-        assert_eq!(listener.local_addr().unwrap().port(), addr.port());
-    }
-
-    #[tokio::test]
-    async fn bind_with_retry_gives_up_on_a_persistent_conflict_at_a_hard_deadline() {
-        // A second instance, not a restart overlap: a port held for the whole
-        // window must fail with AddrInUse (so main.rs surfaces "port in use").
-        // `interval` is deliberately LARGER than `budget` so a HARD deadline caps
-        // at ~budget (sleeping only the remaining time) while a SOFT one would
-        // sleep a full interval and overshoot — the elapsed assertion catches
-        // that regression.
-        let probe = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
-            .await
-            .unwrap();
-        let addr = probe.local_addr().unwrap();
-        let budget = Duration::from_millis(200);
-        let interval = Duration::from_millis(500);
-        let started = std::time::Instant::now();
-        let err = bind_with_retry_inner(addr, interval, budget)
-            .await
-            .expect_err("should give up while the port stays held");
-        let elapsed = started.elapsed();
-        assert_eq!(err.kind(), std::io::ErrorKind::AddrInUse);
-        assert!(
-            elapsed < budget + Duration::from_millis(150),
-            "hard deadline overshot: {elapsed:?} (budget {budget:?}, interval {interval:?}) — a soft deadline would sleep a full interval past the budget"
-        );
-        drop(probe);
-    }
-
-    #[tokio::test]
-    async fn bind_with_retry_propagates_non_addrinuse_immediately() {
-        // An unassigned TEST-NET-1 address (RFC 5737) can't be bound →
-        // AddrNotAvailable, NOT AddrInUse. It must return at once, never entering
-        // the retry budget (a 10s budget would expose a wrongful retry).
-        let bad = SocketAddr::from(([192, 0, 2, 1], 0));
-        let started = std::time::Instant::now();
-        let err = bind_with_retry_inner(bad, Duration::from_millis(100), Duration::from_secs(10))
-            .await
-            .expect_err("binding an unassigned address must fail");
-        assert_ne!(err.kind(), std::io::ErrorKind::AddrInUse);
-        assert!(
-            started.elapsed() < Duration::from_secs(1),
-            "a non-AddrInUse error must propagate immediately, not retry for the budget"
-        );
     }
 
     #[tokio::test]

--- a/packages/accelerator/src-tauri/src/server/bind.rs
+++ b/packages/accelerator/src-tauri/src/server/bind.rs
@@ -1,0 +1,124 @@
+//! TCP bind with `AddrInUse` retry.
+//!
+//! Waits out a prior instance's listener (e.g. an in-place updater restart releasing `:59833`)
+//! before failing — so a genuine conflict (a second instance the user started) still fails fast with
+//! the port-in-use signal (surfaced by main.rs) instead of hanging. Extracted from server.rs (Q2).
+
+use std::net::SocketAddr;
+use std::time::Duration;
+use tokio::net::TcpListener;
+
+/// Bind `addr`, retrying briefly on `AddrInUse` so a just-exited prior instance (a restart overlap)
+/// is waited out, while a genuine second-instance conflict still fails fast.
+pub(crate) async fn bind_with_retry(addr: SocketAddr) -> std::io::Result<TcpListener> {
+    // 100ms polling, 5s budget: the restart overlap clears in well under a
+    // second, so this is responsive AND fails a genuine second-instance
+    // conflict reasonably fast (it surfaces "port in use" rather than stalling).
+    bind_with_retry_inner(addr, Duration::from_millis(100), Duration::from_secs(5)).await
+}
+
+/// Inner form with injectable timings so tests can exercise the wait-it-out,
+/// hard-deadline, and immediate-propagation paths without real-time sleeps.
+async fn bind_with_retry_inner(
+    addr: SocketAddr,
+    interval: Duration,
+    max_wait: Duration,
+) -> std::io::Result<TcpListener> {
+    let deadline = std::time::Instant::now() + max_wait;
+    let mut warned = false;
+    loop {
+        match TcpListener::bind(addr).await {
+            Ok(listener) => return Ok(listener),
+            Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+                // Hard deadline: sleep only the time actually left, so we give up
+                // at ~max_wait rather than overshooting by a full `interval`.
+                let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+                if remaining.is_zero() {
+                    tracing::warn!(
+                        "port {} still in use after {max_wait:?} — giving up",
+                        addr.port()
+                    );
+                    return Err(e);
+                }
+                if !warned {
+                    tracing::warn!(
+                        "port {} in use — retrying for up to {max_wait:?} (waiting out a prior instance, e.g. an in-place updater restart)",
+                        addr.port()
+                    );
+                    warned = true;
+                }
+                tokio::time::sleep(interval.min(remaining)).await;
+            }
+            // Any non-AddrInUse error propagates immediately — never masked by the retry.
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn bind_with_retry_waits_out_a_transient_holder() {
+        // The in-place-restart case: hold a freshly-chosen port, release it
+        // shortly, and assert the retry binds once it frees.
+        let probe = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .await
+            .unwrap();
+        let addr = probe.local_addr().unwrap();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(80)).await;
+            drop(probe);
+        });
+        let listener =
+            bind_with_retry_inner(addr, Duration::from_millis(20), Duration::from_secs(2))
+                .await
+                .expect("should bind once the transient holder releases the port");
+        assert_eq!(listener.local_addr().unwrap().port(), addr.port());
+    }
+
+    #[tokio::test]
+    async fn bind_with_retry_gives_up_on_a_persistent_conflict_at_a_hard_deadline() {
+        // A second instance, not a restart overlap: a port held for the whole
+        // window must fail with AddrInUse (so main.rs surfaces "port in use").
+        // `interval` is deliberately LARGER than `budget` so a HARD deadline caps
+        // at ~budget (sleeping only the remaining time) while a SOFT one would
+        // sleep a full interval and overshoot — the elapsed assertion catches
+        // that regression.
+        let probe = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .await
+            .unwrap();
+        let addr = probe.local_addr().unwrap();
+        let budget = Duration::from_millis(200);
+        let interval = Duration::from_millis(500);
+        let started = std::time::Instant::now();
+        let err = bind_with_retry_inner(addr, interval, budget)
+            .await
+            .expect_err("should give up while the port stays held");
+        let elapsed = started.elapsed();
+        assert_eq!(err.kind(), std::io::ErrorKind::AddrInUse);
+        assert!(
+            elapsed < budget + Duration::from_millis(150),
+            "hard deadline overshot: {elapsed:?} (budget {budget:?}, interval {interval:?}) — a soft deadline would sleep a full interval past the budget"
+        );
+        drop(probe);
+    }
+
+    #[tokio::test]
+    async fn bind_with_retry_propagates_non_addrinuse_immediately() {
+        // An unassigned TEST-NET-1 address (RFC 5737) can't be bound →
+        // AddrNotAvailable, NOT AddrInUse. It must return at once, never entering
+        // the retry budget (a 10s budget would expose a wrongful retry).
+        let bad = SocketAddr::from(([192, 0, 2, 1], 0));
+        let started = std::time::Instant::now();
+        let err = bind_with_retry_inner(bad, Duration::from_millis(100), Duration::from_secs(10))
+            .await
+            .expect_err("binding an unassigned address must fail");
+        assert_ne!(err.kind(), std::io::ErrorKind::AddrInUse);
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "a non-AddrInUse error must propagate immediately, not retry for the budget"
+        );
+    }
+}


### PR DESCRIPTION
## Phase 7 / Q2 — server.rs split, part 1 (`server::bind`)

First module extraction of the 1588-line server.rs. `bind_with_retry` + `bind_with_retry_inner` (the `AddrInUse` retry that waits out a prior instance's `:59833` during an in-place updater restart) + their 3 tests move **verbatim** into `src/server/bind.rs`.

- server.rs gets `mod bind; use bind::bind_with_retry;` and drops the now-unused `TcpListener` import.
- `start` / `start_https` call `bind_with_retry` unchanged (now `pub(crate)`).

### Behavior-preserving
`cargo test --lib` **127/127** — the 3 bind tests now run as `server::bind::tests::*` · clippy `-D warnings` · headless all green.

### Scope
Part 1 of Q2 (the second RISKY-CORE-PATH split). Continues with `tls` (start_https) + `handlers/` (prove/health/authorize_origin) extractions; the thin router+start stays in server.rs. Validated by the **batched rc-dry-run** (Q4+Q6+Q7+Q1+Q2) before any stable cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)