### PR TITLE
refactor(accelerator): extract server::tls module (start_https) from server.rs (Q2 2/n)

### DIFF
--- a/packages/accelerator/src-tauri/src/server.rs
+++ b/packages/accelerator/src-tauri/src/server.rs
@@ -10,7 +10,6 @@ use serde_json::json;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio_rustls::TlsAcceptor;
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::set_header::SetResponseHeaderLayer;
 
@@ -21,6 +20,8 @@ use tokio::sync::Semaphore;
 
 mod bind;
 use bind::bind_with_retry;
+mod tls;
+pub use tls::start_https;
 
 const PORT: u16 = 59833;
 pub const HTTPS_PORT: u16 = 59834;
@@ -141,62 +142,6 @@ pub async fn healthy_aztec_on_port() -> bool {
         return false;
     };
     is_healthy_aztec_response(&body)
-}
-
-/// Start an HTTPS listener using the provided TLS config.
-/// Runs independently from HTTP — errors are logged but never crash the app.
-pub async fn start_https(
-    state: AppState,
-    tls_config: Arc<tokio_rustls::rustls::ServerConfig>,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let app = router(state);
-    let addr = SocketAddr::from(([127, 0, 0, 1], HTTPS_PORT));
-    // Same restart race as the HTTP listener: an in-place update relaunches while
-    // the old process still holds 59834. Retry first; only fall back to HTTP-only
-    // if the port is genuinely unavailable past the budget (HTTPS must never
-    // crash the app — it's optional Safari support).
-    let listener = match bind_with_retry(addr).await {
-        Ok(l) => l,
-        Err(e) => {
-            tracing::warn!("HTTPS port {HTTPS_PORT} unavailable: {e} — continuing HTTP-only");
-            return Ok(());
-        }
-    };
-
-    let acceptor = TlsAcceptor::from(tls_config);
-    tracing::info!("HTTPS server listening on {addr}");
-
-    loop {
-        let (stream, _peer) = match listener.accept().await {
-            Ok(conn) => conn,
-            Err(e) => {
-                tracing::debug!("TCP accept error: {e}");
-                continue;
-            }
-        };
-
-        let acceptor = acceptor.clone();
-        let app = app.clone();
-
-        tokio::spawn(async move {
-            let tls_stream = match acceptor.accept(stream).await {
-                Ok(s) => s,
-                Err(e) => {
-                    tracing::debug!("TLS handshake failed: {e}");
-                    return;
-                }
-            };
-            let io = hyper_util::rt::TokioIo::new(tls_stream);
-            let hyper_service = hyper_util::service::TowerToHyperService::new(app);
-            if let Err(e) =
-                hyper_util::server::conn::auto::Builder::new(hyper_util::rt::TokioExecutor::new())
-                    .serve_connection(io, hyper_service)
-                    .await
-            {
-                tracing::debug!("HTTPS connection error: {e}");
-            }
-        });
-    }
 }
 
 pub fn router(state: AppState) -> Router {

--- a/packages/accelerator/src-tauri/src/server/tls.rs
+++ b/packages/accelerator/src-tauri/src/server/tls.rs
@@ -1,0 +1,67 @@
+//! HTTPS listener for optional Safari support.
+//!
+//! Runs independently from the HTTP server — errors are logged but never crash the app (HTTPS is
+//! optional). Extracted from server.rs (Q2).
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio_rustls::TlsAcceptor;
+
+use super::bind::bind_with_retry;
+use super::{router, AppState, HTTPS_PORT};
+
+/// Start an HTTPS listener using the provided TLS config.
+/// Runs independently from HTTP — errors are logged but never crash the app.
+pub async fn start_https(
+    state: AppState,
+    tls_config: Arc<tokio_rustls::rustls::ServerConfig>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let app = router(state);
+    let addr = SocketAddr::from(([127, 0, 0, 1], HTTPS_PORT));
+    // Same restart race as the HTTP listener: an in-place update relaunches while
+    // the old process still holds 59834. Retry first; only fall back to HTTP-only
+    // if the port is genuinely unavailable past the budget (HTTPS must never
+    // crash the app — it's optional Safari support).
+    let listener = match bind_with_retry(addr).await {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::warn!("HTTPS port {HTTPS_PORT} unavailable: {e} — continuing HTTP-only");
+            return Ok(());
+        }
+    };
+
+    let acceptor = TlsAcceptor::from(tls_config);
+    tracing::info!("HTTPS server listening on {addr}");
+
+    loop {
+        let (stream, _peer) = match listener.accept().await {
+            Ok(conn) => conn,
+            Err(e) => {
+                tracing::debug!("TCP accept error: {e}");
+                continue;
+            }
+        };
+
+        let acceptor = acceptor.clone();
+        let app = app.clone();
+
+        tokio::spawn(async move {
+            let tls_stream = match acceptor.accept(stream).await {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::debug!("TLS handshake failed: {e}");
+                    return;
+                }
+            };
+            let io = hyper_util::rt::TokioIo::new(tls_stream);
+            let hyper_service = hyper_util::service::TowerToHyperService::new(app);
+            if let Err(e) =
+                hyper_util::server::conn::auto::Builder::new(hyper_util::rt::TokioExecutor::new())
+                    .serve_connection(io, hyper_service)
+                    .await
+            {
+                tracing::debug!("HTTPS connection error: {e}");
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Phase 7 / Q2 — server.rs split, part 2 (`server::tls`)

`start_https` (the HTTPS listener for optional Safari support) moves **verbatim** into `src/server/tls.rs`. server.rs gets `mod tls; pub use tls::start_https;` (so `server::start_https` stays the public path for main.rs + commands.rs) and drops the now-unused `TlsAcceptor` import. `tls.rs` imports `router`/`AppState`/`HTTPS_PORT` + `bind::bind_with_retry` from the parent.

### Behavior-preserving
`cargo test --lib` **127/127** · `clippy --lib --bins -D warnings` · headless all green. Builds on the bind extraction (Q2 1/n, #309, merged).

### Scope
Part 2 of Q2. Continues with `handlers/` (prove/health/authorize_origin) — the thin router+start stays in server.rs. RISKY-CORE-PATH → batched rc-dry-run before any cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)