### PR TITLE
refactor(accelerator): extract server::probe health-probe from server.rs (Q2 3/n)

### DIFF
--- a/packages/accelerator/src-tauri/src/server.rs
+++ b/packages/accelerator/src-tauri/src/server.rs
@@ -22,6 +22,8 @@ mod bind;
 use bind::bind_with_retry;
 mod tls;
 pub use tls::start_https;
+mod probe;
+pub use probe::healthy_aztec_on_port;
 
 const PORT: u16 = 59833;
 pub const HTTPS_PORT: u16 = 59834;
@@ -106,42 +108,6 @@ pub async fn start(state: AppState) -> Result<(), Box<dyn std::error::Error + Se
     tracing::info!("Accelerator server listening on {addr}");
     axum::serve(listener, app).await?;
     Ok(())
-}
-
-/// True iff a `/health` body looks like a healthy Aztec accelerator
-/// (`status=="ok"` and `api_version==1`). Pure (unit-tested) so the redundant-vs-foreign
-/// classification can't silently accept an arbitrary process answering on :59833.
-fn is_healthy_aztec_response(body: &serde_json::Value) -> bool {
-    body.get("status").and_then(|s| s.as_str()) == Some("ok")
-        && body.get("api_version").and_then(|v| v.as_u64()) == Some(1)
-}
-
-/// Probe `http://127.0.0.1:59833/health` and return true iff a HEALTHY Aztec instance
-/// answers. Used to classify a lost `:59833` bind: the autostart entry AND the
-/// crash-recovery launcher (Task Scheduler / launchd / systemd) can both start us at
-/// logon, so a redundant instance should bow out — but only if the incumbent is really
-/// us, not some foreign process squatting on the port.
-pub async fn healthy_aztec_on_port() -> bool {
-    let url = format!("http://127.0.0.1:{PORT}/health");
-    let client = match reqwest::Client::builder()
-        .timeout(Duration::from_secs(3))
-        .build()
-    {
-        Ok(c) => c,
-        Err(_) => return false,
-    };
-    let Ok(resp) = client.get(&url).send().await else {
-        return false;
-    };
-    // Require a 2xx so a non-success responder that happens to echo the right JSON
-    // shape isn't mistaken for a healthy Aztec instance.
-    if !resp.status().is_success() {
-        return false;
-    }
-    let Ok(body) = resp.json::<serde_json::Value>().await else {
-        return false;
-    };
-    is_healthy_aztec_response(&body)
 }
 
 pub fn router(state: AppState) -> Router {
@@ -550,29 +516,6 @@ mod tests {
     use axum::http::Request;
     use serial_test::serial;
     use tower::util::ServiceExt;
-
-    #[test]
-    fn classifies_health_responses() {
-        // Healthy Aztec: bow out (redundant instance).
-        assert!(is_healthy_aztec_response(
-            &json!({"status": "ok", "api_version": 1})
-        ));
-        assert!(is_healthy_aztec_response(
-            &json!({"status": "ok", "api_version": 1, "version": "1.2.3"})
-        ));
-        // Foreign / wrong / malformed: do NOT treat as Aztec (must surface the error,
-        // never silently exit and leave the user with no accelerator).
-        assert!(!is_healthy_aztec_response(
-            &json!({"status": "ok", "api_version": 2})
-        ));
-        assert!(!is_healthy_aztec_response(
-            &json!({"status": "error", "api_version": 1})
-        ));
-        assert!(!is_healthy_aztec_response(&json!({"api_version": 1})));
-        assert!(!is_healthy_aztec_response(&json!({"hello": "world"})));
-        assert!(!is_healthy_aztec_response(&json!({})));
-        assert!(!is_healthy_aztec_response(&json!("not even an object")));
-    }
 
     #[tokio::test]
     async fn health_returns_ok() {

--- a/packages/accelerator/src-tauri/src/server/probe.rs
+++ b/packages/accelerator/src-tauri/src/server/probe.rs
@@ -1,0 +1,74 @@
+//! Redundant-instance health probe.
+//!
+//! Classifies a lost `:59833` bind — the autostart entry AND the crash-recovery launcher can both
+//! start us at logon, so a redundant instance should bow out, but ONLY if the incumbent is really us
+//! and not a foreign process squatting on the port. Extracted from server.rs (Q2).
+
+use std::time::Duration;
+
+use super::PORT;
+
+/// True iff a `/health` body looks like a healthy Aztec accelerator
+/// (`status=="ok"` and `api_version==1`). Pure (unit-tested) so the redundant-vs-foreign
+/// classification can't silently accept an arbitrary process answering on :59833.
+fn is_healthy_aztec_response(body: &serde_json::Value) -> bool {
+    body.get("status").and_then(|s| s.as_str()) == Some("ok")
+        && body.get("api_version").and_then(|v| v.as_u64()) == Some(1)
+}
+
+/// Probe `http://127.0.0.1:59833/health` and return true iff a HEALTHY Aztec instance
+/// answers. Used to classify a lost `:59833` bind: the autostart entry AND the
+/// crash-recovery launcher (Task Scheduler / launchd / systemd) can both start us at
+/// logon, so a redundant instance should bow out — but only if the incumbent is really
+/// us, not some foreign process squatting on the port.
+pub async fn healthy_aztec_on_port() -> bool {
+    let url = format!("http://127.0.0.1:{PORT}/health");
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(3))
+        .build()
+    {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    let Ok(resp) = client.get(&url).send().await else {
+        return false;
+    };
+    // Require a 2xx so a non-success responder that happens to echo the right JSON
+    // shape isn't mistaken for a healthy Aztec instance.
+    if !resp.status().is_success() {
+        return false;
+    }
+    let Ok(body) = resp.json::<serde_json::Value>().await else {
+        return false;
+    };
+    is_healthy_aztec_response(&body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn classifies_health_responses() {
+        // Healthy Aztec: bow out (redundant instance).
+        assert!(is_healthy_aztec_response(
+            &json!({"status": "ok", "api_version": 1})
+        ));
+        assert!(is_healthy_aztec_response(
+            &json!({"status": "ok", "api_version": 1, "version": "1.2.3"})
+        ));
+        // Foreign / wrong / malformed: do NOT treat as Aztec (must surface the error,
+        // never silently exit and leave the user with no accelerator).
+        assert!(!is_healthy_aztec_response(
+            &json!({"status": "ok", "api_version": 2})
+        ));
+        assert!(!is_healthy_aztec_response(
+            &json!({"status": "error", "api_version": 1})
+        ));
+        assert!(!is_healthy_aztec_response(&json!({"api_version": 1})));
+        assert!(!is_healthy_aztec_response(&json!({"hello": "world"})));
+        assert!(!is_healthy_aztec_response(&json!({})));
+        assert!(!is_healthy_aztec_response(&json!("not even an object")));
+    }
+}


### PR DESCRIPTION
## Phase 7 / Q2 — server.rs split, part 3 (`server::probe`)

The redundant-instance health probe (`is_healthy_aztec_response` + `healthy_aztec_on_port` — classifies a lost `:59833` bind as the incumbent-us vs a foreign squatter) + its test move **verbatim** into `src/server/probe.rs`.

- server.rs gets `mod probe; pub use probe::healthy_aztec_on_port;` (so `server::healthy_aztec_on_port` stays the public path for main.rs).
- probe.rs reaches the parent's private `PORT` const via `super::PORT`.

### Behavior-preserving
`cargo test --lib` **127/127** (the test now runs as `server::probe::tests::*`) · clippy `-D warnings` · headless green. Builds on bind (#309) + tls (#310), both merged.

### Scope
server.rs is now 1418→~1380 lines. The remaining Q2 work is the handlers core (`health` + `prove` + `authorize_origin` + `resolve_version`) — the coupled request-handling, a careful follow-up. Then the thin router+start stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)