### PR TITLE
refactor(accelerator): extract server::auth (authorize_origin) from server.rs (Q2 4/n)

### DIFF
--- a/packages/accelerator/src-tauri/src/server.rs
+++ b/packages/accelerator/src-tauri/src/server.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::set_header::SetResponseHeaderLayer;
 
-use crate::authorization::{AuthDecision, AuthorizationManager};
+use crate::authorization::AuthorizationManager;
 use crate::{bb, config, versions};
 use parking_lot::RwLock;
 use tokio::sync::Semaphore;
@@ -24,6 +24,8 @@ mod tls;
 pub use tls::start_https;
 mod probe;
 pub use probe::healthy_aztec_on_port;
+mod auth;
+use auth::authorize_origin;
 
 const PORT: u16 = 59833;
 pub const HTTPS_PORT: u16 = 59834;
@@ -206,130 +208,6 @@ struct ProveErrorBody<'a> {
 /// Build a consistent JSON error response body for the /prove endpoint.
 fn json_error(error: &str, message: &str) -> String {
     serde_json::to_string(&ProveErrorBody { error, message }).unwrap()
-}
-
-/// Check if the request origin is authorized. Returns Ok(()) if approved.
-async fn authorize_origin(
-    state: &AppState,
-    headers: &axum::http::HeaderMap,
-) -> Result<(), ProveError> {
-    let auth_manager = match state.auth_manager {
-        Some(ref am) => am,
-        None => return Ok(()), // No auth_manager → auto-approve all (headless mode)
-    };
-
-    let raw_origin = match headers
-        .get(http::header::ORIGIN)
-        .and_then(|v| v.to_str().ok())
-    {
-        Some(o) => o,
-        // No Origin header → auto-approve. Browsers always send Origin on cross-origin
-        // requests, so this only applies to curl/scripts/same-origin. Non-browser clients
-        // can bypass auth by omitting Origin, but this is inherent to localhost services —
-        // CORS/Origin is a browser-only mechanism, not a general access control boundary.
-        None => return Ok(()),
-    };
-
-    let origin = match crate::authorization::canonicalize_origin(raw_origin) {
-        Some(canon) => canon,
-        None => {
-            tracing::warn!(raw_origin = %raw_origin, "Invalid Origin header (path/query/userinfo/unknown scheme); rejecting");
-            return Err((
-                StatusCode::BAD_REQUEST,
-                json_error(
-                    "invalid_origin",
-                    "Origin header is not a valid RFC 6454 origin",
-                ),
-            ));
-        }
-    };
-
-    let approved = state.config.as_ref().is_some_and(|cfg| {
-        let cfg = cfg.read();
-        AuthorizationManager::is_approved(&origin, &cfg.approved_origins)
-    });
-
-    if approved {
-        return Ok(());
-    }
-
-    // No popup callback = headless mode → deny immediately
-    if state.show_auth_popup.is_none() {
-        tracing::info!(origin = %origin, "Origin not approved (no popup available), denying");
-        return Err((
-            StatusCode::FORBIDDEN,
-            json_error(
-                "origin_denied",
-                &format!("Access denied for origin: {origin}"),
-            ),
-        ));
-    }
-
-    tracing::info!(origin = %origin, "Origin not approved, requesting authorization");
-    let (rx, is_first) = auth_manager.request(&origin).map_err(|_| {
-        tracing::warn!(origin = %origin, "Too many pending authorization requests");
-        (
-            StatusCode::TOO_MANY_REQUESTS,
-            json_error(
-                "too_many_requests",
-                "Too many pending authorization requests",
-            ),
-        )
-    })?;
-
-    if is_first {
-        if let Some(ref show_popup) = state.show_auth_popup {
-            show_popup(&origin);
-        }
-    }
-
-    let decision = tokio::time::timeout(AUTH_DECISION_TIMEOUT, rx)
-        .await
-        .map_err(|_| {
-            tracing::warn!(origin = %origin, "Authorization timed out");
-            auth_manager.resolve(&origin, AuthDecision::Deny);
-            (
-                StatusCode::FORBIDDEN,
-                json_error("authorization_timeout", "Authorization request timed out"),
-            )
-        })?
-        .map_err(|_| {
-            (
-                StatusCode::FORBIDDEN,
-                json_error(
-                    "authorization_cancelled",
-                    "Authorization request was cancelled",
-                ),
-            )
-        })?;
-
-    match decision {
-        AuthDecision::Allow { remember } => {
-            tracing::info!(origin = %origin, remember, "Origin authorized");
-            if remember {
-                if let Some(ref cfg_lock) = state.config {
-                    let mut cfg = cfg_lock.write();
-                    if !cfg.approved_origins.contains(&origin) {
-                        cfg.approved_origins.push(origin);
-                        if let Err(e) = config::save(&cfg) {
-                            tracing::warn!(error = %e, "Failed to persist approved origin");
-                        }
-                    }
-                }
-            }
-            Ok(())
-        }
-        AuthDecision::Deny => {
-            tracing::info!(origin = %origin, "Origin denied");
-            Err((
-                StatusCode::FORBIDDEN,
-                json_error(
-                    "origin_denied",
-                    &format!("Access denied for origin: {origin}"),
-                ),
-            ))
-        }
-    }
 }
 
 /// Validate and resolve the requested Aztec version. Downloads the bb binary if needed.

--- a/packages/accelerator/src-tauri/src/server/auth.rs
+++ b/packages/accelerator/src-tauri/src/server/auth.rs
@@ -1,0 +1,135 @@
+//! `/prove` origin authorization.
+//!
+//! Auto-approves localhost + persisted origins; otherwise popup-gates the request with a 60s
+//! auto-deny (`AUTH_DECISION_TIMEOUT`). Headless mode (no popup callback) denies unknown origins.
+//! Extracted from server.rs (Q2).
+
+use crate::authorization::{AuthDecision, AuthorizationManager};
+use crate::config;
+use axum::http::StatusCode;
+
+use super::{json_error, AppState, ProveError, AUTH_DECISION_TIMEOUT};
+
+/// Check if the request origin is authorized. Returns Ok(()) if approved.
+pub(crate) async fn authorize_origin(
+    state: &AppState,
+    headers: &axum::http::HeaderMap,
+) -> Result<(), ProveError> {
+    let auth_manager = match state.auth_manager {
+        Some(ref am) => am,
+        None => return Ok(()), // No auth_manager → auto-approve all (headless mode)
+    };
+
+    let raw_origin = match headers
+        .get(http::header::ORIGIN)
+        .and_then(|v| v.to_str().ok())
+    {
+        Some(o) => o,
+        // No Origin header → auto-approve. Browsers always send Origin on cross-origin
+        // requests, so this only applies to curl/scripts/same-origin. Non-browser clients
+        // can bypass auth by omitting Origin, but this is inherent to localhost services —
+        // CORS/Origin is a browser-only mechanism, not a general access control boundary.
+        None => return Ok(()),
+    };
+
+    let origin = match crate::authorization::canonicalize_origin(raw_origin) {
+        Some(canon) => canon,
+        None => {
+            tracing::warn!(raw_origin = %raw_origin, "Invalid Origin header (path/query/userinfo/unknown scheme); rejecting");
+            return Err((
+                StatusCode::BAD_REQUEST,
+                json_error(
+                    "invalid_origin",
+                    "Origin header is not a valid RFC 6454 origin",
+                ),
+            ));
+        }
+    };
+
+    let approved = state.config.as_ref().is_some_and(|cfg| {
+        let cfg = cfg.read();
+        AuthorizationManager::is_approved(&origin, &cfg.approved_origins)
+    });
+
+    if approved {
+        return Ok(());
+    }
+
+    // No popup callback = headless mode → deny immediately
+    if state.show_auth_popup.is_none() {
+        tracing::info!(origin = %origin, "Origin not approved (no popup available), denying");
+        return Err((
+            StatusCode::FORBIDDEN,
+            json_error(
+                "origin_denied",
+                &format!("Access denied for origin: {origin}"),
+            ),
+        ));
+    }
+
+    tracing::info!(origin = %origin, "Origin not approved, requesting authorization");
+    let (rx, is_first) = auth_manager.request(&origin).map_err(|_| {
+        tracing::warn!(origin = %origin, "Too many pending authorization requests");
+        (
+            StatusCode::TOO_MANY_REQUESTS,
+            json_error(
+                "too_many_requests",
+                "Too many pending authorization requests",
+            ),
+        )
+    })?;
+
+    if is_first {
+        if let Some(ref show_popup) = state.show_auth_popup {
+            show_popup(&origin);
+        }
+    }
+
+    let decision = tokio::time::timeout(AUTH_DECISION_TIMEOUT, rx)
+        .await
+        .map_err(|_| {
+            tracing::warn!(origin = %origin, "Authorization timed out");
+            auth_manager.resolve(&origin, AuthDecision::Deny);
+            (
+                StatusCode::FORBIDDEN,
+                json_error("authorization_timeout", "Authorization request timed out"),
+            )
+        })?
+        .map_err(|_| {
+            (
+                StatusCode::FORBIDDEN,
+                json_error(
+                    "authorization_cancelled",
+                    "Authorization request was cancelled",
+                ),
+            )
+        })?;
+
+    match decision {
+        AuthDecision::Allow { remember } => {
+            tracing::info!(origin = %origin, remember, "Origin authorized");
+            if remember {
+                if let Some(ref cfg_lock) = state.config {
+                    let mut cfg = cfg_lock.write();
+                    if !cfg.approved_origins.contains(&origin) {
+                        cfg.approved_origins.push(origin);
+                        if let Err(e) = config::save(&cfg) {
+                            tracing::warn!(error = %e, "Failed to persist approved origin");
+                        }
+                    }
+                }
+            }
+            Ok(())
+        }
+        AuthDecision::Deny => {
+            tracing::info!(origin = %origin, "Origin denied");
+            Err((
+                StatusCode::FORBIDDEN,
+                json_error(
+                    "origin_denied",
+                    &format!("Access denied for origin: {origin}"),
+                ),
+            ))
+        }
+    }
+}


### PR DESCRIPTION
## What

Extracts the `/prove` origin-authorization handler (`authorize_origin`, ~123 lines) from `server.rs` into a new `server/auth.rs` child module. Part 4 of the Q2 server.rs split (bind #309, tls #310, probe #311 already merged).

## Why

`server.rs` is the largest module in the crate; the `/harden quality` audit (Q2) flagged it for extraction into coherent submodules. `authorize_origin` is a self-contained, well-bounded handler — it's the natural next slice.

## Behavior preservation

- `authorize_origin` moved verbatim (`pub(crate)`); the child module reaches the parent's private `json_error` / `ProveError` / `AUTH_DECISION_TIMEOUT` via `super::`.
- The `prove_*` tests in `server::tests` exercise `authorize_origin` end-to-end via `/prove` (auto-approve localhost, remembered-origin approve, unknown-origin popup, no-Origin skip) — all green (127 lib tests pass).
- Drops the now-unused `AuthDecision` import from `server.rs`.

## Validation

- `cargo test --lib` → 127 passed
- `cargo clippy --lib --bins -- -D warnings` → clean
- `cargo check` (headless `accelerator-server`) → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)