### PR TITLE
feat(sdk)!: AcceleratorStatus discriminated union (Q12 — part 1)

### DIFF
--- a/implementations-plan/quality-refactor-2026-06-05/lessons/phase-8.md
+++ b/implementations-plan/quality-refactor-2026-06-05/lessons/phase-8.md
@@ -1,0 +1,42 @@
+# Phase 8 — Q12 SDK type break (discriminated unions) — SCOPED, execution plan
+
+Branch: `refactor/q12-sdk-break` (off main). Owner decision (Phase 0 #2 + Phase-8 memory): clean breaking
+type change on the dev line + MIGRATION.md + publish-guard; NO heavy standalone-semver prerequisite
+(Ask A resolved — SDK version stays derived from `@aztec/stdlib` at publish). Claude builds + cuts the SDK rc;
+only the STABLE SDK publish is joint.
+
+## Break targets (packages/sdk/src/lib/accelerator-prover.ts)
+1. **`AcceleratorStatus`** (L46-59) — flat boolean-soup interface: `available`+`needsDownload`+4 optionals
+   (`acceleratorVersion?`, `availableVersions?`, `sdkAztecVersion?`, `protocol?`). Illegal combos are
+   representable (e.g. `available:false` with a version). → **discriminated union** mirroring the REAL
+   reachable states. **NEXT TURN FIRST: read `checkAcceleratorStatus` (L202) + `#probeAndParseHealth`
+   (L219-~300)** to enumerate the exact states the SDK produces, then model the union (likely:
+   `{ kind:"unavailable" } | { kind:"available", acceleratorVersion, availableVersions, sdkAztecVersion, protocol }
+   | { kind:"needs-download", ... }` — confirm against the Phase-0 sdk-contract-characterization fixtures
+   so it mirrors today's combinations exactly; HTTP WIRE CONTRACT stays unchanged — this is TS-only).
+2. **`AcceleratorPhase`** (L11-20, 9-string union) + **`AcceleratorPhaseData`** (L23-25, `{durationMs}`) +
+   **`onPhase(phase, data?)`** (L42, L182 setOnPhase, L129 field). The `data` is only meaningful for
+   `"proved"`. → fold into ONE **discriminated phase-event union**, e.g.
+   `type AcceleratorPhaseEvent = { phase:"proved"; durationMs:number } | { phase: Exclude<...,"proved"> }`
+   and change `onPhase(event)` so the payload can't be silently dropped/mismatched.
+
+## Consumers to migrate IN THE SAME PR (free in-repo typecheck = the safety net)
+- `packages/playground/src/aztec.ts` — ~5 `onPhase`/`setOnPhase` passthrough sites (L410,423,517,526,537,574,583,595,727).
+- `packages/playground/src/ascii-animation.ts` — the phase→animation mapping (the real `onPhase` consumer).
+- `AcceleratorStatus` consumers: grep `.available`/`.needsDownload` across playground (checkAcceleratorStatus callers).
+- The `aztec-accelerator` skill doc (mentions the types) — update in the same PR (Ask A).
+
+## Guardrails
+- **publish-guard (Ask E):** the SDK auto-publishes on upstream Aztec bumps (`_aztec-update.yml` +
+  `get-sdk-publish-version.ts`). A half-migrated break must NOT auto-ship → **freeze `_aztec-update.yml`
+  for the Q12 window** (or land everything atomically in one PR). Confirm before merge.
+- **MIGRATION.md** at packages/sdk root: before/after for both types + a codemod sketch.
+- Split Q5·2 (PhaseReporter) is LOW-VALUE churn + a likely CUT (Q6 precedent) — assess/skip, don't gate Q12 on it.
+
+## Execution order (next fresh-context turn)
+1. Read checkAcceleratorStatus + #probeAndParseHealth → enumerate reachable states.
+2. Define the two unions; keep a thin back-compat note in MIGRATION.md.
+3. Update accelerator-prover.ts internals to construct the union states + emit the phase events.
+4. Migrate playground (aztec.ts + ascii-animation.ts) + skill doc — `bun run --cwd packages/playground build` + monorepo typecheck is the net.
+5. Add MIGRATION.md + the publish-guard.
+6. `bun run test` + `bun run lint` + (SDK build) green. PR. Then Claude cuts the SDK **rc** (autonomous-allowed).

--- a/implementations-plan/quality-refactor-2026-06-05/lessons/phase-8.md
+++ b/implementations-plan/quality-refactor-2026-06-05/lessons/phase-8.md
@@ -40,3 +40,24 @@ only the STABLE SDK publish is joint.
 4. Migrate playground (aztec.ts + ascii-animation.ts) + skill doc — `bun run --cwd packages/playground build` + monorepo typecheck is the net.
 5. Add MIGRATION.md + the publish-guard.
 6. `bun run test` + `bun run lint` + (SDK build) green. PR. Then Claude cuts the SDK **rc** (autonomous-allowed).
+
+---
+
+## Q12 progress — AcceleratorStatus union DONE (commit 53ddd3a); phase-event = owner call
+
+### DONE: AcceleratorStatus discriminated union (high value — fixed real illegal states)
+Enumerated the 5 reachable states from `#probeAndParseHealth` → modelled as 4 variants:
+- `{ available:true, needsDownload, acceleratorVersion?, availableVersions?, sdkAztecVersion?, protocol }` (legacy + multi-version collapse here)
+- `{ available:false, reason:"offline", sdkAztecVersion? }`
+- `{ available:false, reason:"error", protocol, sdkAztecVersion? }`
+- `{ available:false, reason:"version-mismatch", acceleratorVersion, protocol, sdkAztecVersion? }`
+The 3 `available:false` producers swapped `needsDownload:false`→`reason`; the 2 `available:true` producers already matched. Internal `createChonkProof` consumer narrows (`if(!status.available)`) instead of destructuring. **HTTP wire UNCHANGED.** SDK build + `test:lint` typecheck + 26 unit tests + **playground build** all green (playground does NOT consume AcceleratorStatus — zero migration needed). committed `53ddd3a` on `refactor/q12-sdk-break`.
+
+### phase-event union — RECOMMEND CUT/DEFER (marginal value, mechanical churn) — SURFACE to owner
+`onPhase(phase: AcceleratorPhase, data?)` — 17 SDK call sites, only **1** carries data (`("proved",{durationMs})` L442). Converting `AcceleratorPhase` (string) → object union FIGHTS the playground: `ascii-animation.ts` does `type AnimationPhase = AcceleratorPhase | "app:simulate"|...` + `switch(phase){case "detect":...}` — a string model. Viable design = KEEP `AcceleratorPhase` string, ADD `AcceleratorPhaseEvent = {phase:Exclude<...,"proved">} | {phase:"proved";durationMs}` for the callback (~25 mechanical edits: 17 SDK + signature + ~5 aztec.ts wiring that extract `event.phase`). **Value = tie durationMs to "proved" only; cost = ~25 edits + a 2nd phase type (arguably MORE complex).** Like Q6: recommend the owner decide cut-vs-do at the Q12 PR.
+
+### Remaining Q12 finalization (next turn)
+1. MIGRATION.md (packages/sdk): AcceleratorStatus before→after + narrow-on-`available` codemod note (+ phase-event if owner keeps it).
+2. Skill doc: grep `aztec-accelerator` skill for AcceleratorStatus mentions; update.
+3. **publish-guard (Ask E):** freeze `_aztec-update.yml` (or a guard) so the SDK can't auto-publish the break mid-window. REQUIRED before pushing the Q12 PR.
+4. Push `refactor/q12-sdk-break` + PR (flag BREAKING + the phase-event cut question). Then Claude cuts the SDK **rc**.

--- a/packages/sdk/MIGRATION.md
+++ b/packages/sdk/MIGRATION.md
@@ -1,0 +1,83 @@
+# Migration guide
+
+## `AcceleratorStatus` is now a discriminated union (Q12)
+
+`AcceleratorStatus` (returned by `AcceleratorProver.checkAcceleratorStatus()`) changed from a flat
+interface — where every field was optional and illegal combinations typechecked — to a **discriminated
+union on `available`**. The HTTP wire contract is unchanged; this is a TypeScript-only break.
+
+### Before
+
+```ts
+interface AcceleratorStatus {
+  available: boolean;
+  needsDownload: boolean;
+  acceleratorVersion?: string;
+  availableVersions?: string[];
+  sdkAztecVersion?: string;
+  protocol?: "http" | "https";
+}
+```
+
+### After
+
+```ts
+type AcceleratorStatus =
+  | {
+      available: true;
+      needsDownload: boolean;
+      acceleratorVersion?: string;
+      availableVersions?: string[];
+      sdkAztecVersion?: string;
+      protocol: AcceleratorProtocol;            // "http" | "https"
+    }
+  | { available: false; reason: "offline"; sdkAztecVersion?: string }
+  | { available: false; reason: "error"; protocol: AcceleratorProtocol; sdkAztecVersion?: string }
+  | {
+      available: false;
+      reason: "version-mismatch";
+      acceleratorVersion: string;
+      protocol: AcceleratorProtocol;
+      sdkAztecVersion?: string;
+    };
+```
+
+### What to change
+
+**Narrow on `available` before reading state-specific fields.** Accessing `needsDownload`,
+`availableVersions`, or `acceleratorVersion` without narrowing is now a type error — which is the point:
+those fields were never meaningful on an unavailable result.
+
+```ts
+// Before — fields read without narrowing
+const status = await prover.checkAcceleratorStatus();
+if (status.available && !status.needsDownload) {
+  /* ... */
+}
+
+// After — narrow first; the compiler then exposes exactly the valid fields
+const status = await prover.checkAcceleratorStatus();
+if (status.available) {
+  // status.needsDownload, status.availableVersions, status.protocol available here
+  if (!status.needsDownload) {
+    /* ... */
+  }
+} else {
+  // status.reason: "offline" | "error" | "version-mismatch"
+  switch (status.reason) {
+    case "version-mismatch":
+      console.warn(`accelerator is on ${status.acceleratorVersion}, SDK wants ${status.sdkAztecVersion}`);
+      break;
+    case "offline":
+    case "error":
+      // fall back to WASM
+      break;
+  }
+}
+```
+
+Most callers that already wrote `if (status.available) { … }` need **no change** — the narrowing they
+already do is exactly what the union requires. Only code that read `needsDownload`/version fields
+*without* first checking `available` must add the narrowing.
+
+The new `AcceleratorProtocol` type (`"http" | "https"`) is exported for convenience.

--- a/packages/sdk/src/lib/accelerator-prover.ts
+++ b/packages/sdk/src/lib/accelerator-prover.ts
@@ -42,21 +42,54 @@ export interface AcceleratorProverOptions {
   onPhase?: (phase: AcceleratorPhase, data?: AcceleratorPhaseData) => void;
 }
 
-/** Status of the local native accelerator, returned by {@link AcceleratorProver.checkAcceleratorStatus}. */
-export interface AcceleratorStatus {
-  /** Whether the accelerator is reachable and compatible. */
-  available: boolean;
-  /** Whether the accelerator needs to download `bb` for the SDK's Aztec version. */
-  needsDownload: boolean;
-  /** Accelerator version string from the `/health` endpoint (legacy `aztec_version` field). */
-  acceleratorVersion?: string;
-  /** Aztec versions the accelerator already has cached. */
-  availableVersions?: string[];
-  /** The Aztec version this SDK expects (from its `@aztec/stdlib` dependency). */
-  sdkAztecVersion?: string;
-  /** Which protocol was used to reach the accelerator (`"http"` or `"https"`). */
-  protocol?: "http" | "https";
-}
+/** Protocol used to reach the accelerator's `/health` + `/prove` endpoints. */
+export type AcceleratorProtocol = "http" | "https";
+
+/**
+ * Status of the local native accelerator, returned by {@link AcceleratorProver.checkAcceleratorStatus}.
+ *
+ * A discriminated union on `available` (Q12). The prior flat interface let illegal field combinations
+ * typecheck (e.g. `available: false` carrying `availableVersions`, or `needsDownload` on an offline
+ * result). Narrow on `available` first — and on `reason` for the unavailable cases — to access only the
+ * fields valid for that state.
+ */
+export type AcceleratorStatus =
+  | {
+      /** The accelerator is reachable and version-compatible. */
+      available: true;
+      /** Whether it must download `bb` for the SDK's Aztec version before it can prove. */
+      needsDownload: boolean;
+      /** Accelerator version from `/health` (`aztec_version`); absent on the multi-version protocol. */
+      acceleratorVersion?: string;
+      /** Aztec versions the accelerator already has cached (multi-version protocol). */
+      availableVersions?: string[];
+      /** The Aztec version this SDK expects (from its `@aztec/stdlib` dependency). */
+      sdkAztecVersion?: string;
+      /** Which protocol reached the accelerator. */
+      protocol: AcceleratorProtocol;
+    }
+  | {
+      available: false;
+      /** Both the HTTP and HTTPS probes failed — the accelerator isn't running. */
+      reason: "offline";
+      sdkAztecVersion?: string;
+    }
+  | {
+      available: false;
+      /** Reachable, but `/health` returned a non-OK HTTP status. */
+      reason: "error";
+      sdkAztecVersion?: string;
+      protocol: AcceleratorProtocol;
+    }
+  | {
+      available: false;
+      /** Reachable, but its Aztec version doesn't match the SDK's (legacy single-version protocol). */
+      reason: "version-mismatch";
+      /** The mismatched accelerator version. */
+      acceleratorVersion: string;
+      sdkAztecVersion?: string;
+      protocol: AcceleratorProtocol;
+    };
 
 /**
  * Create a lazy-loading proxy for CircuitSimulator that dynamically imports
@@ -260,7 +293,7 @@ export class AcceleratorProver extends BBLazyPrivateKernelProver {
         // would permanently set the wrong protocol for subsequent /prove calls.
         return cacheAndReturn({
           available: false,
-          needsDownload: false,
+          reason: "error",
           sdkAztecVersion,
           protocol,
         });
@@ -306,7 +339,7 @@ export class AcceleratorProver extends BBLazyPrivateKernelProver {
           });
           return cacheAndReturn({
             available: false,
-            needsDownload: false,
+            reason: "version-mismatch",
             acceleratorVersion,
             sdkAztecVersion,
             protocol,
@@ -322,7 +355,7 @@ export class AcceleratorProver extends BBLazyPrivateKernelProver {
       });
     } catch {
       this.#acceleratorProtocol = null;
-      return cacheAndReturn({ available: false, needsDownload: false, sdkAztecVersion });
+      return cacheAndReturn({ available: false, reason: "offline", sdkAztecVersion });
     }
   }
 
@@ -337,9 +370,9 @@ export class AcceleratorProver extends BBLazyPrivateKernelProver {
     logger.info("Using accelerated prover");
 
     this.#onPhase?.("detect");
-    const { available, needsDownload } = await this.checkAcceleratorStatus();
+    const status = await this.checkAcceleratorStatus();
 
-    if (!available) {
+    if (!status.available) {
       logger.info("Accelerator not available, falling back to WASM");
       this.#onPhase?.("fallback");
       const proof = await this.#proveLocally(executionSteps, "Local proof completed");
@@ -347,7 +380,7 @@ export class AcceleratorProver extends BBLazyPrivateKernelProver {
       return proof;
     }
 
-    if (needsDownload) {
+    if (status.needsDownload) {
       logger.info("Accelerator needs to download bb for this version");
       this.#onPhase?.("downloading");
     }


### PR DESCRIPTION
## What (Q12 — the SDK type break, part 1 of up to 2)

`AcceleratorStatus` (from `checkAcceleratorStatus()`) goes from a flat interface — every field optional, illegal combinations like `available: false` carrying `availableVersions` representable — to a **4-variant discriminated union on `available`**. Consumers must narrow on `available` (+ `reason` for the unavailable cases) before reading state-specific fields. **HTTP wire contract unchanged** (TS-only break).

See `packages/sdk/MIGRATION.md` for before/after + the narrow-on-`available` codemod.

## ⚠️ BREAKING (SDK type) — do not merge until the publish-guard is in place

The SDK auto-publishes on upstream Aztec bumps (`_aztec-update.yml` + `get-sdk-publish-version.ts`), and its version is derived from `@aztec/stdlib` (no independent semver). A breaking type change must not auto-ship unannounced. **Required before merge (Ask E):** freeze `_aztec-update.yml` for the release window (or a publish-guard) so the break ships deliberately with `MIGRATION.md` + release notes. Not in this PR yet — flagging.

## 🟡 Owner decision needed: the phase-event union (Q12 part 2)?

The plan's Q12 also called for a discriminated **phase event**. On investigation it's **marginal-value churn**: `onPhase(phase, data?)` has 17 call sites, only 1 carries data (`"proved"` → `durationMs`). Converting `AcceleratorPhase` (a string union) to objects fights the playground's string-based `ascii-animation` model; the viable design adds a *second* phase type (`AcceleratorPhaseEvent`) purely to tie `durationMs` to `"proved"` — ~25 mechanical sites + a more complex API. **I recommend cutting it** (same cost/value logic as the Q6 cut). Full analysis in `implementations-plan/quality-refactor-2026-06-05/lessons/phase-8.md`. Want it, or ship AcceleratorStatus-only as Q12?

## Validation

- SDK `build` (tsc) + `test:lint` (typecheck incl. tests) + `test:unit` (26 pass) + **playground build** all green
- Biome clean on the changed file
- Playground does **not** consume `AcceleratorStatus` → zero migration needed for this part

🤖 Generated with [Claude Code](https://claude.com/claude-code)