### PR TITLE
refactor(accelerator): dedup window open-or-focus (Phase 9)

### DIFF
--- a/packages/accelerator/src-tauri/src/bb.rs
+++ b/packages/accelerator/src-tauri/src/bb.rs
@@ -44,7 +44,7 @@ pub fn find_bb(version: Option<&str>) -> Result<PathBuf, String> {
     }
 
     // 3. ~/.bb/bb (bbup install location)
-    if let Some(home) = dirs_next().or_else(home_dir_fallback) {
+    if let Some(home) = dirs::home_dir().or_else(home_dir_fallback) {
         let bbup_path = home.join(".bb").join(versions::bb_binary_name());
         if bbup_path.exists() {
             return Ok(bbup_path);
@@ -61,10 +61,6 @@ pub fn find_bb(version: Option<&str>) -> Result<PathBuf, String> {
     }
 
     Err("bb binary not found. Install via bbup or bundle as sidecar.".to_string())
-}
-
-fn dirs_next() -> Option<PathBuf> {
-    dirs::home_dir()
 }
 
 fn home_dir_fallback() -> Option<PathBuf> {

--- a/packages/accelerator/src-tauri/src/certs.rs
+++ b/packages/accelerator/src-tauri/src/certs.rs
@@ -399,6 +399,37 @@ pub fn is_ca_trusted() -> bool {
 mod tests {
     use super::*;
 
+    /// CA / leaf validity used by the test fixtures, mirroring production (`generate_certs`).
+    const TEST_CA_VALIDITY_DAYS: i64 = 3650;
+    const TEST_LEAF_VALIDITY_DAYS: i64 = 825;
+
+    /// Build a self-signed test CA + a `localhost` leaf signed by it. Dedups the cert-building
+    /// boilerplate shared by `generate_ca_and_leaf_certs` and `leaf_cert_loads_into_rustls`.
+    fn build_test_ca_and_leaf() -> (rcgen::Certificate, KeyPair, rcgen::Certificate, KeyPair) {
+        let now = OffsetDateTime::now_utc();
+        let ca_key = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256).unwrap();
+        let mut ca_params = CertificateParams::default();
+        ca_params
+            .distinguished_name
+            .push(DnType::CommonName, "Test CA");
+        ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        ca_params.not_before = now;
+        ca_params.not_after = now + time::Duration::days(TEST_CA_VALIDITY_DAYS);
+        let ca_cert = ca_params.self_signed(&ca_key).unwrap();
+
+        let leaf_key = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256).unwrap();
+        let mut leaf_params = CertificateParams::default();
+        leaf_params
+            .distinguished_name
+            .push(DnType::CommonName, "localhost");
+        leaf_params.subject_alt_names = vec![SanType::IpAddress(IpAddr::V4(Ipv4Addr::LOCALHOST))];
+        leaf_params.not_before = now;
+        leaf_params.not_after = now + time::Duration::days(TEST_LEAF_VALIDITY_DAYS);
+        let leaf_cert = leaf_params.signed_by(&leaf_key, &ca_cert, &ca_key).unwrap();
+
+        (ca_cert, ca_key, leaf_cert, leaf_key)
+    }
+
     #[test]
     fn certs_dir_is_under_home() {
         let dir = certs_dir();
@@ -412,27 +443,7 @@ mod tests {
 
     #[test]
     fn generate_ca_and_leaf_certs() {
-        let now = OffsetDateTime::now_utc();
-        let ca_key = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256).unwrap();
-        let mut ca_params = CertificateParams::default();
-        ca_params
-            .distinguished_name
-            .push(DnType::CommonName, "Test CA");
-        ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
-        ca_params.not_before = now;
-        ca_params.not_after = now + time::Duration::days(3650);
-        let ca_cert = ca_params.self_signed(&ca_key).unwrap();
-
-        let leaf_key = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256).unwrap();
-        let mut leaf_params = CertificateParams::default();
-        leaf_params
-            .distinguished_name
-            .push(DnType::CommonName, "localhost");
-        leaf_params.subject_alt_names = vec![SanType::IpAddress(IpAddr::V4(Ipv4Addr::LOCALHOST))];
-        leaf_params.not_before = now;
-        leaf_params.not_after = now + time::Duration::days(825);
-
-        let leaf_cert = leaf_params.signed_by(&leaf_key, &ca_cert, &ca_key).unwrap();
+        let (ca_cert, ca_key, leaf_cert, leaf_key) = build_test_ca_and_leaf();
 
         // Verify PEM output is valid
         assert!(ca_cert.pem().starts_with("-----BEGIN CERTIFICATE-----"));
@@ -449,27 +460,7 @@ mod tests {
     fn leaf_cert_loads_into_rustls() {
         // Install a default crypto provider — needed when both aws-lc-rs and ring are available
         let _ = tokio_rustls::rustls::crypto::aws_lc_rs::default_provider().install_default();
-        let now = OffsetDateTime::now_utc();
-        let ca_key = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256).unwrap();
-        let mut ca_params = CertificateParams::default();
-        ca_params
-            .distinguished_name
-            .push(DnType::CommonName, "Test CA");
-        ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
-        ca_params.not_before = now;
-        ca_params.not_after = now + time::Duration::days(3650);
-        let ca_cert = ca_params.self_signed(&ca_key).unwrap();
-
-        let leaf_key = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256).unwrap();
-        let mut leaf_params = CertificateParams::default();
-        leaf_params
-            .distinguished_name
-            .push(DnType::CommonName, "localhost");
-        leaf_params.subject_alt_names = vec![SanType::IpAddress(IpAddr::V4(Ipv4Addr::LOCALHOST))];
-        leaf_params.not_before = now;
-        leaf_params.not_after = now + time::Duration::days(825);
-
-        let leaf_cert = leaf_params.signed_by(&leaf_key, &ca_cert, &ca_key).unwrap();
+        let (_ca_cert, _ca_key, leaf_cert, leaf_key) = build_test_ca_and_leaf();
 
         let cert_pem = leaf_cert.pem();
         let key_pem = leaf_key.serialize_pem();

--- a/packages/accelerator/src-tauri/src/windows.rs
+++ b/packages/accelerator/src-tauri/src/windows.rs
@@ -15,22 +15,59 @@ fn focus_window(window: &tauri::WebviewWindow) {
     let _ = window.set_focus();
 }
 
-/// Open or focus the Settings window.
-pub fn open_settings_window(app: &AppHandle) {
-    if let Some(window) = app.get_webview_window("settings") {
-        let _ = window.set_focus();
-        return;
+/// Parameters for [`open_or_focus_window`]. `url`, `label` are owned/borrowed as the call site needs
+/// (the auth/update labels + URLs are built per-call; settings' are static).
+struct WindowConfig<'a> {
+    label: &'a str,
+    url: String,
+    title: &'a str,
+    width: f64,
+    height: f64,
+    always_on_top: bool,
+    /// Focus an ALREADY-open window with this label? Settings does (user re-clicked "Settings");
+    /// the auth/update popups don't (they just stay put). Preserves prior per-window behavior.
+    focus_if_open: bool,
+}
+
+/// Open a window with the given config, or handle an already-open one. Returns `true` iff a window
+/// with `config.label` was ALREADY open (focused first iff `focus_if_open`); `false` if none existed,
+/// in which case a new one is built + focused. The bool lets callers (auth) do post-build work only
+/// for a freshly-handled window. Dedups the get-or-build pattern across the 3 windows.
+fn open_or_focus_window(app: &AppHandle, config: WindowConfig) -> bool {
+    if let Some(window) = app.get_webview_window(config.label) {
+        if config.focus_if_open {
+            let _ = window.set_focus();
+        }
+        return true;
     }
     if let Ok(window) =
-        WebviewWindowBuilder::new(app, "settings", WebviewUrl::App("settings.html".into()))
-            .title("Aztec Accelerator Settings")
-            .inner_size(500.0, 520.0)
+        WebviewWindowBuilder::new(app, config.label, WebviewUrl::App(config.url.into()))
+            .title(config.title)
+            .inner_size(config.width, config.height)
             .resizable(false)
             .center()
+            .always_on_top(config.always_on_top)
             .build()
     {
         focus_window(&window);
     }
+    false
+}
+
+/// Open or focus the Settings window.
+pub fn open_settings_window(app: &AppHandle) {
+    open_or_focus_window(
+        app,
+        WindowConfig {
+            label: "settings",
+            url: "settings.html".to_string(),
+            title: "Aztec Accelerator Settings",
+            width: 500.0,
+            height: 520.0,
+            always_on_top: false,
+            focus_if_open: true,
+        },
+    );
 }
 
 /// Show the authorization popup for an unknown origin.
@@ -43,20 +80,20 @@ pub fn show_auth_popup_window(
     auth_manager: &Arc<AuthorizationManager>,
 ) {
     let label = format!("auth-{}", commands::sanitize_window_label(origin));
-    if app.get_webview_window(&label).is_some() {
-        return; // popup already open for this origin
-    }
-
     let url = format!("authorize.html?origin={}", urlencoding::encode(origin));
-    if let Ok(window) = WebviewWindowBuilder::new(app, &label, WebviewUrl::App(url.into()))
-        .title("Authorize Site")
-        .inner_size(400.0, 300.0)
-        .resizable(false)
-        .center()
-        .always_on_top(true)
-        .build()
-    {
-        focus_window(&window);
+    if open_or_focus_window(
+        app,
+        WindowConfig {
+            label: &label,
+            url,
+            title: "Authorize Site",
+            width: 400.0,
+            height: 300.0,
+            always_on_top: true,
+            focus_if_open: false,
+        },
+    ) {
+        return; // popup already open for this origin — don't spawn a duplicate timeout
     }
 
     // Spawn 60s timeout — always resolve with Deny if still pending.
@@ -85,22 +122,21 @@ pub fn show_auth_popup_window(
 /// `webdriver` builds — so this is too, to keep those builds warning-clean.
 #[cfg(not(feature = "webdriver"))]
 pub fn show_update_prompt_window(app: &AppHandle, current_version: &str, new_version: &str) {
-    if app.get_webview_window("update-prompt").is_some() {
-        return;
-    }
-
     let url = format!(
         "update-prompt.html?current={}&version={}",
         urlencoding::encode(current_version),
         urlencoding::encode(new_version)
     );
-    if let Ok(window) = WebviewWindowBuilder::new(app, "update-prompt", WebviewUrl::App(url.into()))
-        .title("Aztec Accelerator Update")
-        .inner_size(420.0, 280.0)
-        .resizable(false)
-        .center()
-        .build()
-    {
-        focus_window(&window);
-    }
+    open_or_focus_window(
+        app,
+        WindowConfig {
+            label: "update-prompt",
+            url,
+            title: "Aztec Accelerator Update",
+            width: 420.0,
+            height: 280.0,
+            always_on_top: false,
+            focus_if_open: false,
+        },
+    );
 }


### PR DESCRIPTION
## Phase 9 minor sweep — window get-or-build dedup

The 3 windows (settings, auth popup, update prompt) each repeated the `get_webview_window`-or-`WebviewWindowBuilder` pattern. Extracted `WindowConfig` + `open_or_focus_window`.

**Behavior-preserving** — the helper returns `bool` (was-already-open), which preserves the per-window asymmetry:
- settings **focuses** an already-open window (`focus_if_open: true`); auth/update don't.
- auth's 60s deny-timeout still spawns **only for a freshly-handled popup** (the `bool` gates it).
- `always_on_top` stays `true` for auth, `false` (the builder default) for settings/update.

## Validation
- `cargo clippy --lib --bins -- -D warnings` clean
- `cargo check --features webdriver` clean (helper stays used when `update-prompt` is cfg'd out)
- Window-opening behavior is exercised by the WebDriver E2E suite (this PR's gate)

## Note
This is the first slice of the Phase 9 minor sweep. Remaining candidates are under critical review — e.g. the copy-bb `PLATFORM_MATRIX` (Q13) is being **cut** as negative-ROI (the current `arm64 ? aarch64 : x86_64` fallback isn't cleanly expressible as a strict lookup table; same logic as the Q6 cut).

🤖 Generated with [Claude Code](https://claude.com/claude-code)