### PR TITLE
refactor(sdk): dedup WASM-fallback phases into #fallbackToWasm (Phase 9)

### DIFF
--- a/packages/sdk/src/lib/accelerator-prover.ts
+++ b/packages/sdk/src/lib/accelerator-prover.ts
@@ -374,10 +374,7 @@ export class AcceleratorProver extends BBLazyPrivateKernelProver {
 
     if (!status.available) {
       logger.info("Accelerator not available, falling back to WASM");
-      this.#onPhase?.("fallback");
-      const proof = await this.#proveLocally(executionSteps, "Local proof completed");
-      this.#onPhase?.("receive");
-      return proof;
+      return this.#fallbackToWasm(executionSteps, "Local proof completed");
     }
 
     if (status.needsDownload) {
@@ -422,13 +419,7 @@ export class AcceleratorProver extends BBLazyPrivateKernelProver {
           message: body?.message,
         });
         this.#onPhase?.("denied");
-        this.#onPhase?.("fallback");
-        const proof = await this.#proveLocally(
-          executionSteps,
-          "Local proof completed after denial",
-        );
-        this.#onPhase?.("receive");
-        return proof;
+        return this.#fallbackToWasm(executionSteps, "Local proof completed after denial");
       }
       throw err;
     }
@@ -461,6 +452,20 @@ export class AcceleratorProver extends BBLazyPrivateKernelProver {
     const durationMs = Math.round(performance.now() - start);
     logger.info(logLabel, { durationMs });
     this.#onPhase?.("proved", { durationMs });
+    return proof;
+  }
+
+  /**
+   * WASM fallback wrapper: emit "fallback" → run the local prover → emit "receive". Shared by the
+   * accelerator-unavailable and 403-denied paths (the "denied" phase stays at its call site).
+   */
+  async #fallbackToWasm(
+    executionSteps: PrivateExecutionStep[],
+    logLabel: string,
+  ): Promise<ChonkProofWithPublicInputs> {
+    this.#onPhase?.("fallback");
+    const proof = await this.#proveLocally(executionSteps, logLabel);
+    this.#onPhase?.("receive");
     return proof;
   }
 


### PR DESCRIPTION
## Phase 9 — SDK fallback dedup

The accelerator-unavailable path and the 403-denied path in `createChonkProof` both repeated `onPhase("fallback") → #proveLocally → onPhase("receive") → return`. Extracted `#fallbackToWasm(steps, label)`. The denied path keeps its `onPhase("denied")` at the call site (it's specific to that path).

Behavior-preserving. Now unblocked since #315 (the Q12 union) landed — both touch `createChonkProof`.

## Validation
- SDK `build` (tsc) + `test:lint` (typecheck incl. tests) + `test:unit` (26 pass) + biome — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)