### PR TITLE
fix(sdk): malformed /health JSON → reason 'error' not 'offline' (Q12 audit)

### DIFF
--- a/packages/sdk/src/lib/accelerator-prover.test.ts
+++ b/packages/sdk/src/lib/accelerator-prover.test.ts
@@ -293,6 +293,25 @@ describe("AcceleratorProver", () => {
       expect(status.protocol).toBeUndefined();
     });
 
+    test("reachable host with malformed JSON → unavailable reason 'error', not 'offline'", async () => {
+      // Post-impl audit guard (codex): a 200 with an unparseable body means the host ANSWERED
+      // (reachable) — so reason must be "error" (carrying the protocol), not "offline" (which is
+      // documented as both probes failing). The available:false → WASM-fallback outcome is unchanged.
+      mockFetch({
+        "/health": () => new Response("not valid json {{{", { status: 200 }),
+      });
+
+      const prover = new AcceleratorProver({ simulator: new WASMSimulator() });
+      const status = await prover.checkAcceleratorStatus();
+
+      expect(status.available).toBe(false);
+      if (status.available) throw new Error("expected unavailable");
+      expect(status.reason).toBe("error");
+      if (status.reason === "error") {
+        expect(status.protocol).toBeDefined();
+      }
+    });
+
     // CHARACTERIZATION (quality-refactor Phase 0 — Q12 guard). Pins the reachable AcceleratorStatus
     // discriminant invariants the discriminated-union refactor (Q12) must mirror exactly:
     // available:true ⟹ protocol defined + version present; available:false ⟹ protocol undefined.

--- a/packages/sdk/src/lib/accelerator-prover.ts
+++ b/packages/sdk/src/lib/accelerator-prover.ts
@@ -301,10 +301,24 @@ export class AcceleratorProver extends BBLazyPrivateKernelProver {
 
       this.#acceleratorProtocol = protocol;
 
-      const data = (await response.json()) as {
-        aztec_version?: string;
-        available_versions?: string[];
-      };
+      let data: { aztec_version?: string; available_versions?: string[] };
+      try {
+        data = (await response.json()) as {
+          aztec_version?: string;
+          available_versions?: string[];
+        };
+      } catch {
+        // Reachable but returned unparseable JSON — that's "error" (the host answered), NOT
+        // "offline" (which means both probes failed). Reset the cached protocol since a
+        // misbehaving responder shouldn't pin it for subsequent /prove calls.
+        this.#acceleratorProtocol = null;
+        return cacheAndReturn({
+          available: false,
+          reason: "error",
+          sdkAztecVersion,
+          protocol,
+        });
+      }
 
       const acceleratorVersion = data.aztec_version;
       const availableVersions = data.available_versions;


### PR DESCRIPTION
## Post-impl codex audit fix

The codex post-implementation audit of the quality-refactor returned **Q1/Q2/Q7 SAFE** (it confirmed the `/prove` ordering, the shared `https_bound` flag, and no dropped guards/visibility holes from the server.rs split). For Q12 it flagged one real (minor) bug:

A reachable `200` `/health` response with an **unparseable body** throws in `response.json()`, falls to the outer `catch`, and gets the new union's `reason: "offline"` — but "offline" is documented as *both probes failed*. The host answered, so it's `"error"` (and carries the `protocol`).

### Fix
Wrap the `json()` parse; on failure return the `error` variant (with protocol) and reset the cached protocol (a misbehaving responder shouldn't pin it for `/prove`). The `available:false` → WASM-fallback **outcome is unchanged** — only the new `reason` field is now accurate, and the outer catch's `"offline"` is now reserved for genuine unreachability.

### Validation
- SDK build + test:lint + **27 unit tests** (incl. a new malformed-JSON regression) + biome — all green

### Audit note
The audit's other Q12 observation (`needsDownload` omitted on unavailable variants) is the **intended, documented** breaking change — the union deliberately drops a field that's meaningless when unavailable; MIGRATION.md covers the narrow-on-`available` requirement. Not a defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)