### PR TITLE
docs(accelerator): fix stale resolve_version doc ref (code-review)

### DIFF
--- a/packages/accelerator/src-tauri/src/versions.rs
+++ b/packages/accelerator/src-tauri/src/versions.rs
@@ -325,7 +325,7 @@ async fn fetch_github_asset_digest(
 /// Flow: check cache → GET tarball → verify digest → extract to temp dir → atomic rename → chmod.
 /// Returns the path to the cached `bb` binary.
 /// Validate a version string before it is used to build cache paths or download URLs. THE single
-/// source of truth for both the HTTP ingress (`server.rs::resolve_version`) and the `download_bb`
+/// source of truth for both the HTTP ingress (`server::prove::resolve_version`) and the `download_bb`
 /// sink. Rejects path-traversal + injection: non-empty, `<= 128` chars, ASCII alnum/`.`/`-`/`_`,
 /// no leading dot, no `..` sequence.
 pub fn is_valid_version(version: &str) -> bool {


### PR DESCRIPTION
## /code-review max on the prove-core split (#313)

Ran an Anthropic-family `/code-review max` pass on the riskiest architectural change — the Q2 prove-core extraction (#313). The line-by-line semantic comparison verified the `/prove` ordering (auth → body → semaphore → resolve/download → bb::prove), every error path (400/413/500/503), `StatusGuard`, `resolve_version`'s lifetime, and the no-lost-`await`/`?` invariant — **all verbatim, compiles clean. No correctness findings.**

The single nit: the `is_valid_version` doc in `versions.rs` still referenced `server.rs::resolve_version`, which moved to `server::prove::resolve_version`. Doc-only fix.

Combined with the codex post-impl audit (whole implementation → Q1/Q2/Q7 SAFE, one Q12 edge-case bug fixed in #319), the refactor is reviewed clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)