### PR TITLE
fix(accelerator): propagate save error in respond_update_prompt (Q9 / Ask B)

### DIFF
--- a/packages/accelerator/src-tauri/src/commands.rs
+++ b/packages/accelerator/src-tauri/src/commands.rs
@@ -213,12 +213,11 @@ pub fn respond_update_prompt(
         "update" => {
             // Save auto-update preference from the checkbox
             {
-                // NOTE (Q9 / Ask B): this site intentionally SWALLOWS the save error (logs + continues)
-                // — preserved here for behavior parity. Making it propagate is a deliberate behavior
-                // change shipped as a separate, owner-surfaced PR.
-                if let Err(e) = mutate_config(&config, |cfg| cfg.auto_update = Some(auto_update)) {
-                    tracing::warn!("Failed to save auto-update preference: {e}");
-                }
+                // Q9 / Ask B (ship the fix): propagate the save error instead of swallowing it, so a
+                // failed auto-update-preference write surfaces to the user rather than the update
+                // silently proceeding on a stale preference. Rare (disk-write failure); the pending
+                // update is left untaken on the early return, so a retry re-saves and updates.
+                mutate_config(&config, |cfg| cfg.auto_update = Some(auto_update))?;
             }
 
             // Take the stored Update object — no redundant network re-check


### PR DESCRIPTION
## Q9 — the last Ask-B disguised-behavior fix

Ask B (owner-approved: *ship the 3 fixes, communicating each*) covered Q9, Q14, Q7. Q7 shipped as the Option-B health fix (#314); Q14 turned out behavior-identical (#307, no fix needed). **Q9 still swallowed** the auto-update-preference save error — the refactor preserved it for parity, deferring the fix. This ships it.

`respond_update_prompt`'s `update` action previously logged + continued on a failed preference save; now it propagates via `mutate_config(...)?`.

## ⚠️ Behavior change (auto-updated — flagging per Ask B)

A failed auto-update-preference write (rare — disk full / permissions) now **returns an error from the Update-Now action** instead of silently proceeding on a stale preference. The pending update is left untaken on the early return, so a retry re-saves and updates. If you'd rather keep the swallow (proceed-with-update on a secondary failure), this is a one-line revert.

## Validation
- `cargo clippy --lib --bins -- -D warnings` clean; headless `cargo check` clean
- (No unit test: `respond_update_prompt` is a Tauri command with `State`/`AppHandle` injection — not unit-testable without framework mocks, same as the prior swallow.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)