### PR TITLE
docs(sdk): narrow on `available` in accelerator skill status example

### DIFF
--- a/packages/sdk/.claude/skills/aztec-accelerator/SKILL.md
+++ b/packages/sdk/.claude/skills/aztec-accelerator/SKILL.md
@@ -92,11 +92,18 @@ Use `setOnPhase(callback)` to change the callback later, or `setOnPhase(null)` t
 
 ### 6. Health check for status UI
 
+`checkAcceleratorStatus()` returns a **discriminated union on `available`** — narrow before reading
+state-specific fields (see `MIGRATION.md`):
+
 ```typescript
 const status = await prover.checkAcceleratorStatus();
-// status.available       — accelerator is reachable and compatible
-// status.needsDownload   — accelerator needs to download bb for this version
-// status.protocol        — "http" or "https" (which succeeded)
+if (status.available) {
+  // status.needsDownload      — accelerator needs to download bb for this version
+  // status.protocol           — "http" or "https" (which succeeded)
+  // status.acceleratorVersion — also available here
+} else {
+  // status.reason — "offline" | "error" | "version-mismatch"
+}
 ```
 
 ### 7. Force WASM mode (testing/benchmarking)


### PR DESCRIPTION
Section 6 ("Health check for status UI") of the in-repo SDK integration skill (`packages/sdk/.claude/skills/aztec-accelerator/SKILL.md`) still showed the **pre-union flat access** — `status.needsDownload` / `status.protocol` read without narrowing on `status.available`. After the Q12 `AcceleratorStatus` discriminated-union break, that snippet no longer type-checks (TS2339 on the `available: false` arm).

**Fix:** narrow on `available` first, mirroring `MIGRATION.md`. Doc-only — no code or wire change. The rest of the skill (onPhase, EmbeddedWallet wiring, ports, Safari, Vite) was already current; `onPhase` was never broken (that union was cut).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
