### PR TITLE
core-extraction P3: CI tripwire + bb-version hook (slimming deferred)

### DIFF
--- a/.github/workflows/accelerator.yml
+++ b/.github/workflows/accelerator.yml
@@ -144,8 +144,25 @@ jobs:
         # `accelerator-server` lives in a sibling crate at `../server/`
         # — see Cargo.toml docs.
         run: cargo build --manifest-path ../server/Cargo.toml
+      - name: Assert headless tree has no GUI/TLS-serving deps (core-extraction regression guard)
+        # Tripwire: if a future change (or an accidental [workspace]) ever pulls the Tauri / webview /
+        # TLS-serving / cert-gen tree back into the headless binary, fail loudly. Protects the ~56%
+        # dependency-surface reduction from the accelerator-core extraction.
+        run: |
+          TREE=$(cargo tree --manifest-path ../server/Cargo.toml -p accelerator-server --edges normal --prefix none | sort -u)
+          if echo "$TREE" | grep -iqE '^(tauri|tao |wry|rcgen|tokio-rustls|x509-parser|rustls-pemfile)'; then
+            echo "::error::headless dep tree regressed — a GUI/TLS-serving crate leaked back in:"
+            echo "$TREE" | grep -iE '^(tauri|tao |wry|rcgen|tokio-rustls|x509-parser|rustls-pemfile)'
+            exit 1
+          fi
+          echo "headless tree clean: $(echo "$TREE" | wc -l) packages, no tauri/rcgen/tokio-rustls"
       - name: Launch and health check
         run: |
+          # bb-version hook: surface the prebuild's resolved @aztec/bb.js version (written to AZTEC_VERSION
+          # by copy-bb.ts) to /health via the runtime env — core is build.rs-free, so the server reads
+          # AZTEC_BB_VERSION at construct-time. Without this, /health.aztec_version would be "unknown".
+          AZTEC_BB_VERSION="$(cat AZTEC_VERSION 2>/dev/null || echo unknown)"
+          export AZTEC_BB_VERSION
           ../server/target/debug/accelerator-server &
           SERVER_PID=$!
 
@@ -176,6 +193,8 @@ jobs:
           fi
 
           echo "$HEALTH" | jq -e '.status == "ok"' > /dev/null
+          # bb-version hook worked → /health.aztec_version reflects the injected version, not "unknown".
+          echo "$HEALTH" | jq -e '.aztec_version != "unknown"' > /dev/null
           echo "Smoke test passed"
           kill $SERVER_PID 2>/dev/null || true
 

--- a/implementations-plan/core-extraction-2026-06-07/lessons/phase-3.md
+++ b/implementations-plan/core-extraction-2026-06-07/lessons/phase-3.md
@@ -1,0 +1,31 @@
+# Phase 3 — CI: guard the win + bb-version hook (safe parts done; setup-slimming deferred → owner)
+
+Base: `feat/core-extraction-phase-3` off `38e5720` (#326).
+
+## Done (safe, additive, validated)
+1. **cargo-tree regression tripwire** (Smoke job): asserts the headless tree has NO
+   tauri/tao/wry/rcgen/tokio-rustls/x509-parser/rustls-pemfile. Protects the −56% reduction against a future
+   regression (e.g. an accidental `[workspace]` re-unifying features) — fails the PR gate loudly if a GUI/TLS
+   crate leaks back into the headless binary.
+2. **bb-version hook** (Smoke job): `AZTEC_BB_VERSION="$(cat AZTEC_VERSION …)"; export …` before launching the
+   server — surfaces the prebuild's resolved `@aztec/bb.js` version to `/health` via the runtime env (core is
+   `build.rs`-free; the server reads `AZTEC_BB_VERSION` at construct-time). Closes the `"unknown"` gap from Phase 1/2.
+3. **/health assertion extended**: `.aztec_version != "unknown"` — validates the hook end-to-end.
+4. actionlint clean (fixed SC2155: split declare/assign for the export).
+
+## Measurement (final)
+- Headless dep tree: **446 → 194 packages (−56%)**; zero tauri/rcgen/tokio-rustls (Phase 2). The tripwire now
+  guards this in CI on every PR.
+
+## DEFERRED → owner review (Phase 3b — release-pipeline change; "CI speed is not the most important thing")
+The plan's headless-setup slimming (drop `libwebkit2gtk`/GTK + the `copy-bb.ts` prebuild from the headless CI
+legs via `install-tauri-system-deps`/`run-prebuild` composite inputs) is a **release-critical** change: the
+`setup-accelerator` composite is shared by desktop + headless + e2e + release-smoke, and `copy-bb.ts` ALSO
+**copies the bb binary the e2e needs** (not just the version). Slimming it safely needs per-job input flags +
+an alternative bb source for the e2e, AND it touches the release pipeline the owner just hardened. Given AFK +
+the owner's stated priority, I did NOT do this unsupervised — recommended as an owner-reviewed follow-up (a
+`setup-accelerator-headless` variant, or boolean inputs defaulting to current behavior). Its build-time win is
+incremental on top of the already-realized −56% dependency-surface drop, which is the headline result.
+
+## Attempts
+- GREEN. Safe parts only; SC2155 fixed on the first actionlint pass.

--- a/implementations-plan/core-extraction-2026-06-07/plan.md
+++ b/implementations-plan/core-extraction-2026-06-07/plan.md
@@ -127,7 +127,7 @@ GUI crate. GUI callbacks (`on_status`, `show_auth_popup`) are already injected v
   in); the tripwire targets the GUI/serving subtree, NOT "all TLS." Record NEW build-time + package count;
   compute delta. → `lessons/phase-2.md`.
 
-**Phase 3 — CI restructure + measurement (Q3). [scope widened + claims corrected by final codex]**
+**Phase 3 — ✓ core done (tripwire + bb-version hook + measurement); setup-slimming DEFERRED → owner (release-pipeline risk; see lessons/phase-3.md) — CI restructure + measurement (Q3). [scope widened + claims corrected by final codex]**
 - Headless setup drops WebKit/GTK + the Tauri Bun-prebuild — but is **NOT** "Rust-only": `reqwest` still needs
   `libssl-dev` (native-tls) unless we deliberately switch reqwest to `rustls-tls` (a dep choice — note it, don't
   silently assume). The desktop-only setup to strip lives in **THREE places**, not just `build-headless`:


### PR DESCRIPTION
**Phase 3 of the `accelerator-core` extraction — guard the win + close the bb-version gap** (the safe parts; the release-pipeline slimming is deferred for owner review — see below).

**Adds to the Smoke job:**
- A **`cargo tree` regression tripwire** — fails if the headless tree ever regains tauri/tao/wry/rcgen/tokio-rustls (protects the −56% reduction; guards against a future `[workspace]` re-unifying features).
- The **bb-version hook** — exports `AZTEC_BB_VERSION` (from the prebuild's `AZTEC_VERSION`) so `/health.aztec_version` reflects the real `@aztec/bb.js` version instead of `"unknown"`. Asserted via `.aztec_version != "unknown"`.

**Deferred → owner review:** the headless-setup slimming (drop WebKit/GTK + the `copy-bb.ts` prebuild from the headless CI legs) is a release-critical change — the `setup-accelerator` composite is shared across desktop/headless/e2e/release-smoke, and `copy-bb.ts` also copies the bb binary the e2e needs. Given AFK + "CI speed is not the most important thing," I didn't do that unsupervised. The −56% dep-surface drop (the headline win) is already realized + now CI-guarded.

> Commits unsigned (1Password agent down).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
