### PR TITLE
refactor(accelerator): PR-3 — CertPaths + spawn_https + /prove status ownership (F-07, F-09, F-08)

### DIFF
--- a/implementations-plan/quality-fixes-2026-06-08/lessons/phase-3.md
+++ b/implementations-plan/quality-fixes-2026-06-08/lessons/phase-3.md
@@ -1,0 +1,31 @@
+# PR-3 — F-07 CertPaths + F-09 spawn_https + F-08 status ownership
+
+Branch: `quality/pr3-local-refactors` off `main@c3569d9` (PR-2 merged). Order: F-07 → F-09 → F-08.
+
+## Log
+- **F-07 ✓** (d729ee5): `CertPaths { ca_cert, leaf_cert, leaf_key }` + `live()`/`staged(dir)`/`exists()`/
+  `swap_into(live)`/`remove()`. `write_new_cert_set(&CertPaths)`; `rotate()` → `staged.swap_into(&CertPaths::live())`
+  (renames stay ca→leaf→key). REMOVED the 3 served-path accessors (`ca_cert_path`/`leaf_cert_path`/`leaf_key_path`);
+  `ca_key_path` kept standalone (legacy-migration target). Updated ALL callers incl. the macOS trust fns
+  (`install_ca_trust`/`is_ca_trusted` → `CertPaths::live().ca_cert`) + `load_rustls_config` + `leaf_cert_days_remaining`
+  + the `generation_writes_no_ca_key` test. src-tauri 19 + clippy green.
+- **F-09 ✓** (d50f9df): `server::spawn_https(state, tls_config)` wrapper in `src-tauri/src/server.rs`; both
+  `try_start_https` (launch) + `enable_safari_support` (settings) call it. The divergent TLS-load/failure
+  preamble stays upstream (intentional — not unified, per plan). default + webdriver clippy green.
+- **F-08 ✓** (6c0bb5c): `resolve_version` → **pure sync** `ResolvedVersion { version, to_download }` (no status,
+  no download). `prove()` owns the whole `Proving→(Downloading→Proving)→Idle` machine; the **redundant leading
+  Proving is preserved** so the download arm stays `[Proving, Downloading, Proving, Idle]` (opus H2). New tests:
+  `resolve_version_flags_uncached_for_download` + `resolve_version_no_download_for_bundled`. The full 4-element
+  download-arm sequence is NOT unit-testable (`download_bb` needs the network) → covered by the no-download
+  char test (`prove_success_path_and_status_sequence`, still `[Proving, Idle]`) + the structural reorder +
+  the `to_download` flag test. `ResolvedVersion` needs `#[derive(Debug)]` (test `unwrap_err`) + `pub(crate)`
+  (a `pub(crate)` fn can't return a private type). core 120 + clippy green.
+
+## Infra note
+- **GPG signing via 1Password failed mid-run** ("failed to fill whole buffer" — agent hiccup). Per the standing
+  AFK rule, committed F-07/F-08/F-09 **unsigned** via `git -c commit.gpgsign=false` (never touched git config).
+  Signatures are backfillable later (`git rebase --exec 'git commit --amend --no-edit -S' <base>`).
+
+## Next
+- push PR-3 → codex post-impl → CI green → merge → PR-4 (F-05 + F-06, SDK). PR-3 does NOT move the Windows
+  AddrInUse arm (that was F-03/PR-2) → normal `accelerator.yml` gate, no Windows-E2E precondition.

--- a/implementations-plan/quality-fixes-2026-06-08/plan.md
+++ b/implementations-plan/quality-fixes-2026-06-08/plan.md
@@ -61,17 +61,17 @@ Export `AcceleratorProtocol` from `index.ts`; replace README's obsolete flat `in
 ### F-06 — extract `AcceleratorTransport` (PR-4; internal; same public surface)
 New non-exported `AcceleratorTransport` in `src/lib/accelerator-transport.ts` owning URL construction, the dual http/https probe + protocol negotiation, the status cache, and one error model. **Keep `ky` for BOTH** health and prove (health uses `throwHttpErrors: false`) — preserves the thrown-error surface (the main risk; the team is break-sensitive). The **parse → `AcceleratorStatus`** discriminated-union construction stays in the prover (domain). Route every `#acceleratorProtocol` mutation through `transport.setProtocol` (the "doesn't cache protocol on non-ok" + "detected protocol used for subsequent /prove" tests pin exactly-when).
 
-### F-07 — `CertPaths` parameter object (PR-3; pure)
+### F-07 ✓ — `CertPaths` parameter object (PR-3; pure)
 ```rust
 struct CertPaths { ca_cert, leaf_cert, leaf_key: PathBuf }
 impl CertPaths { fn live()->Self; fn staged(dir:&Path)->Self; fn exists(&self)->bool; fn swap_into(&self, live:&CertPaths)->io::Result<()> }
 ```
 `write_new_cert_set(&CertPaths)`, `load_rustls_config_from(&CertPaths)`; public no-arg wrappers delegate to `CertPaths::live()`. **Keep `ca_key_path` standalone** (legacy-migration target, not part of the served triple). `certs_exist` keeps its **leaf-validity** check (not just `.exists()`). `swap_into` preserves rename order **ca→leaf→key**.
 
-### F-08 — `/prove` status ownership (PR-3; behavior-preserving)
+### F-08 ✓ — `/prove` status ownership (PR-3; behavior-preserving)
 `resolve_version` → `pub(crate) fn resolve_version(state, requested) -> Result<ResolvedVersion>` where `ResolvedVersion { version: Option<…>, needs_download: bool }` (no callbacks). `prove()` owns the sequence: emit `Proving` **before** the `needs_download` check → if `needs_download` { `Downloading`; `download_bb`; spawn cleanup; `Proving` } → `bb::prove` → `StatusGuard` drops to `Idle`. Update the 3 `resolve_version_*` tests (`server.rs:1046-1074`). **Preserve the redundant leading `Proving`** (today's download arm is `[Proving, Downloading, Proving, Idle]`) — do NOT "clean it up" (that'd be a tests-only behavior change on an uncovered path). `server.rs:626` pins only the no-download arm → the new download-arm test asserts the full **4-element** sequence.
 
-### F-09 — shared `spawn_https()` (PR-3; pure)
+### F-09 ✓ — shared `spawn_https()` (PR-3; pure)
 `pub fn spawn_https(state: AppState, tls: Arc<rustls::ServerConfig>)` in `src-tauri/src/server.rs` (spawn + error-log only). `main.rs::try_start_https` + `commands.rs::enable_safari_support` keep their distinct preambles and both call it. Do NOT unify the divergent TLS-load-failure policies (main resets Safari support; commands propagates the error — intentional).
 
 ---

--- a/packages/accelerator/core/src/server.rs
+++ b/packages/accelerator/core/src/server.rs
@@ -1103,35 +1103,54 @@ mod tests {
         assert_eq!(compute_threads(&state), None);
     }
 
-    #[tokio::test]
-    async fn resolve_version_passes_valid_version() {
+    #[test]
+    fn resolve_version_flags_uncached_for_download() {
+        // F-08: resolve_version is now pure (sync, no download, no status). A valid, non-bundled,
+        // uncached version resolves Ok with `to_download` set — prove() then owns the download+status
+        // (Proving→Downloading→Proving). The full 4-element download-arm sequence can't be unit-tested
+        // (download_bb needs the network); the no-download arm is pinned by
+        // `prove_success_path_and_status_sequence`, and prove() emits Downloading/Proving structurally
+        // around this flag.
         let state = AppState::default();
         let version = Some("5.0.0-rc.1".to_string());
-        let result = resolve_version(&state, &version).await;
-        // May fail on download (no network in test) but should not reject the version
-        assert!(result.is_ok() || result.is_err());
-        // The key assertion: valid version string is not rejected as BAD_REQUEST
-        if let Err((status, _)) = &result {
-            assert_ne!(*status, StatusCode::BAD_REQUEST);
-        }
+        let resolved = resolve_version(&state, &version).expect("valid version resolves");
+        assert_eq!(resolved.version, Some("5.0.0-rc.1"));
+        assert!(
+            resolved.to_download.is_some(),
+            "uncached non-bundled version must be flagged for download"
+        );
     }
 
-    #[tokio::test]
-    async fn resolve_version_rejects_invalid_version() {
+    #[test]
+    fn resolve_version_no_download_for_bundled() {
+        // The bundled version is always present → never flagged for download (no Downloading status).
+        let core = HeadlessState::headless("1.0.0", Some("0.99.0".to_string()), None, None);
+        let state = AppState::headless(core);
+        let requested = Some("0.99.0".to_string());
+        let resolved = resolve_version(&state, &requested).expect("bundled resolves");
+        assert_eq!(resolved.version, Some("0.99.0"));
+        assert!(
+            resolved.to_download.is_none(),
+            "bundled version must NOT download"
+        );
+    }
+
+    #[test]
+    fn resolve_version_rejects_invalid_version() {
         let state = AppState::default();
         let version = Some("../../../etc/passwd".to_string());
-        let result = resolve_version(&state, &version).await;
+        let result = resolve_version(&state, &version);
         assert!(result.is_err());
         let (status, _) = result.unwrap_err();
         assert_eq!(status, StatusCode::BAD_REQUEST);
     }
 
-    #[tokio::test]
-    async fn resolve_version_returns_none_without_header() {
+    #[test]
+    fn resolve_version_returns_none_without_header() {
         let state = AppState::default();
-        let result = resolve_version(&state, &None).await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), None);
+        let resolved = resolve_version(&state, &None).expect("no header resolves");
+        assert_eq!(resolved.version, None);
+        assert!(resolved.to_download.is_none());
     }
 
     // ── Failure-path tests ──

--- a/packages/accelerator/core/src/server/prove.rs
+++ b/packages/accelerator/core/src/server/prove.rs
@@ -30,13 +30,28 @@ impl Drop for StatusGuard {
 }
 
 /// Validate and resolve the requested Aztec version. Downloads the bb binary if needed.
-pub(crate) async fn resolve_version<'a>(
+/// Outcome of version resolution: the version string for `bb::prove` (`None` = bundled default) and,
+/// when the requested version isn't cached + isn't the bundled one, the parsed version `prove()` must
+/// download first. **Pure** — no status emission, no download. (F-08: `prove` owns the whole
+/// Proving→Downloading→Proving status sequence so it lives in one place.)
+#[derive(Debug)]
+pub(crate) struct ResolvedVersion<'a> {
+    pub(crate) version: Option<&'a str>,
+    pub(crate) to_download: Option<versions::AztecVersion>,
+}
+
+pub(crate) fn resolve_version<'a>(
     state: &AppState,
     requested: &'a Option<String>,
-) -> Result<Option<&'a str>, ProveError> {
+) -> Result<ResolvedVersion<'a>, ProveError> {
     let v = match requested {
         Some(v) => v,
-        None => return Ok(None),
+        None => {
+            return Ok(ResolvedVersion {
+                version: None,
+                to_download: None,
+            })
+        }
     };
 
     // Construct the validated value object ONCE at the ingress boundary (Q3). Parse failure returns
@@ -61,42 +76,17 @@ pub(crate) async fn resolve_version<'a>(
         .as_deref()
         .unwrap_or(super::DEFAULT_BB_VERSION);
 
-    if v != bundled && !versions::version_bb_path(&version).exists() {
-        tracing::info!(version = %version, "Version not cached, downloading");
-        if let Some(ref cb) = state.on_status {
-            cb(ServerStatus::Downloading);
-        }
+    let to_download = if v != bundled && !versions::version_bb_path(&version).exists() {
+        tracing::info!(version = %version, "Version not cached, will download");
+        Some(version)
+    } else {
+        None
+    };
 
-        match versions::download_bb(&version).await {
-            Ok(_) => {
-                tracing::info!(version = %v, "Download complete");
-                let bundled_owned = bundled.to_string();
-                let on_versions_changed = state.on_versions_changed.clone();
-                tokio::spawn(async move {
-                    versions::cleanup_old_versions(&bundled_owned).await;
-                    if let Some(cb) = on_versions_changed {
-                        cb();
-                    }
-                });
-            }
-            Err(e) => {
-                tracing::error!(version = %v, error = %e, "Failed to download bb");
-                return Err((
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    json_error(
-                        "download_failed",
-                        &format!("Failed to download bb v{v}: {e}"),
-                    ),
-                ));
-            }
-        }
-
-        if let Some(ref cb) = state.on_status {
-            cb(ServerStatus::Proving);
-        }
-    }
-
-    Ok(Some(v.as_str()))
+    Ok(ResolvedVersion {
+        version: Some(v.as_str()),
+        to_download,
+    })
 }
 
 /// Read the speed setting from config and convert to thread count.
@@ -160,7 +150,50 @@ pub(crate) async fn prove(
         cb: state.on_status.clone(),
     };
 
-    let version_for_prove = resolve_version(&state, &requested_version).await?;
+    // Resolve (pure: parse + cache check), then OWN the status sequence here (F-08): the whole
+    // Proving→(Downloading→Proving)→Idle machine lives in one function. `resolve_version` no longer
+    // emits status or downloads.
+    let ResolvedVersion {
+        version: version_for_prove,
+        to_download,
+    } = resolve_version(&state, &requested_version)?;
+    if let Some(version) = to_download {
+        if let Some(ref cb) = state.on_status {
+            cb(ServerStatus::Downloading);
+        }
+        match versions::download_bb(&version).await {
+            Ok(_) => {
+                tracing::info!(version = %version, "Download complete");
+                let bundled_owned = state
+                    .bundled_version
+                    .as_deref()
+                    .unwrap_or(super::DEFAULT_BB_VERSION)
+                    .to_string();
+                let on_versions_changed = state.on_versions_changed.clone();
+                tokio::spawn(async move {
+                    versions::cleanup_old_versions(&bundled_owned).await;
+                    if let Some(cb) = on_versions_changed {
+                        cb();
+                    }
+                });
+            }
+            Err(e) => {
+                tracing::error!(version = %version, error = %e, "Failed to download bb");
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    json_error(
+                        "download_failed",
+                        &format!("Failed to download bb v{version}: {e}"),
+                    ),
+                ));
+            }
+        }
+        // Re-emit Proving after the Downloading interlude — preserves the redundant leading Proving so
+        // the download-arm sequence stays [Proving, Downloading, Proving, Idle]. (F-08 / opus H2)
+        if let Some(ref cb) = state.on_status {
+            cb(ServerStatus::Proving);
+        }
+    }
     let threads = compute_threads(&state);
 
     let start = std::time::Instant::now();

--- a/packages/accelerator/src-tauri/src/certs.rs
+++ b/packages/accelerator/src-tauri/src/certs.rs
@@ -17,20 +17,60 @@ pub fn certs_dir() -> PathBuf {
         .join("certs")
 }
 
-fn ca_cert_path() -> PathBuf {
-    certs_dir().join("ca.pem")
-}
-
+/// The legacy on-disk CA private key path. NOT part of [`CertPaths`] — the keyless-CA design never
+/// writes it; this exists only so `migrate_legacy_ca_key` can delete one left by older installs.
 fn ca_key_path() -> PathBuf {
     certs_dir().join("ca.key")
 }
 
-fn leaf_cert_path() -> PathBuf {
-    certs_dir().join("localhost.pem")
+/// The trio of TLS artifact paths that always travel together: CA cert, leaf cert, leaf key. Bundling
+/// them kills the 3×`&Path` arg-swap foot-gun (all the same type) + the basenames that were
+/// duplicated across the accessors, the staging set, and the swap. (F-07)
+struct CertPaths {
+    ca_cert: PathBuf,
+    leaf_cert: PathBuf,
+    leaf_key: PathBuf,
 }
 
-fn leaf_key_path() -> PathBuf {
-    certs_dir().join("localhost.key")
+impl CertPaths {
+    /// The live served set under `certs_dir()` (`ca.pem` / `localhost.pem` / `localhost.key`).
+    fn live() -> Self {
+        let dir = certs_dir();
+        Self {
+            ca_cert: dir.join("ca.pem"),
+            leaf_cert: dir.join("localhost.pem"),
+            leaf_key: dir.join("localhost.key"),
+        }
+    }
+
+    /// The staged set (`*.new`) under `dir`, written + (macOS) trusted before the atomic swap.
+    fn staged(dir: &std::path::Path) -> Self {
+        Self {
+            ca_cert: dir.join("ca.pem.new"),
+            leaf_cert: dir.join("localhost.pem.new"),
+            leaf_key: dir.join("localhost.key.new"),
+        }
+    }
+
+    /// True iff all three files exist (presence only — validity is checked by the caller).
+    fn exists(&self) -> bool {
+        self.ca_cert.exists() && self.leaf_cert.exists() && self.leaf_key.exists()
+    }
+
+    /// Best-effort remove all three (used to discard a failed staging).
+    fn remove(&self) {
+        let _ = std::fs::remove_file(&self.ca_cert);
+        let _ = std::fs::remove_file(&self.leaf_cert);
+        let _ = std::fs::remove_file(&self.leaf_key);
+    }
+
+    /// Atomically rename this (staged) set over `live`, preserving order ca → leaf → key.
+    fn swap_into(&self, live: &CertPaths) -> std::io::Result<()> {
+        std::fs::rename(&self.ca_cert, &live.ca_cert)?;
+        std::fs::rename(&self.leaf_cert, &live.leaf_cert)?;
+        std::fs::rename(&self.leaf_key, &live.leaf_key)?;
+        Ok(())
+    }
 }
 
 /// 824 days — one day under Apple's inclusive 825-day TLS-server-cert cap (applies even to
@@ -88,30 +128,23 @@ fn leaf_params(
 /// triggers regeneration instead of being skipped forever. Note: `ca.key` is intentionally NOT
 /// required — it is never written.
 pub fn certs_exist() -> bool {
-    ca_cert_path().exists()
-        && leaf_cert_path().exists()
-        && leaf_key_path().exists()
-        && leaf_cert_days_remaining().map(|d| d > 0).unwrap_or(false)
+    CertPaths::live().exists() && leaf_cert_days_remaining().map(|d| d > 0).unwrap_or(false)
 }
 
 /// Generate a CA + leaf and write the CA cert + leaf cert + leaf key to the three given paths.
 /// The CA private key is generated in memory, signs the leaf, and is dropped at function end —
 /// **never written to disk.** Writing to caller-chosen paths lets rotation stage a new set
 /// (`*.new`) and atomically swap it in only after the new anchor is trusted.
-fn write_new_cert_set(
-    ca_cert_dst: &std::path::Path,
-    leaf_cert_dst: &std::path::Path,
-    leaf_key_dst: &std::path::Path,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+fn write_new_cert_set(paths: &CertPaths) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let now = OffsetDateTime::now_utc();
     let ca_key = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256)?;
     let ca_cert = ca_params(now).self_signed(&ca_key)?;
     let leaf_key = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256)?;
     let leaf_cert = leaf_params(now)?.signed_by(&leaf_key, &ca_cert, &ca_key)?;
 
-    write_pem_file(ca_cert_dst, &ca_cert.pem())?;
-    write_pem_file(leaf_cert_dst, &leaf_cert.pem())?;
-    write_pem_file(leaf_key_dst, &leaf_key.serialize_pem())?;
+    write_pem_file(&paths.ca_cert, &ca_cert.pem())?;
+    write_pem_file(&paths.leaf_cert, &leaf_cert.pem())?;
+    write_pem_file(&paths.leaf_key, &leaf_key.serialize_pem())?;
     // `ca_key` drops here — the only copy of the CA signing key is gone.
     Ok(())
 }
@@ -125,7 +158,7 @@ fn generate_certs() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700))?;
     }
-    write_new_cert_set(&ca_cert_path(), &leaf_cert_path(), &leaf_key_path())?;
+    write_new_cert_set(&CertPaths::live())?;
     tracing::info!(dir = %dir.display(), "Generated CA + leaf (CA signing key discarded, not written)");
     Ok(())
 }
@@ -201,8 +234,9 @@ fn write_pem_file(
 /// Load the leaf cert + key from PEM files and build a rustls ServerConfig.
 pub fn load_rustls_config(
 ) -> Result<Arc<rustls::ServerConfig>, Box<dyn std::error::Error + Send + Sync>> {
-    let cert_pem = std::fs::read(leaf_cert_path())?;
-    let key_pem = std::fs::read(leaf_key_path())?;
+    let live = CertPaths::live();
+    let cert_pem = std::fs::read(&live.leaf_cert)?;
+    let key_pem = std::fs::read(&live.leaf_key)?;
 
     let certs: Vec<_> =
         rustls_pemfile::certs(&mut BufReader::new(&cert_pem[..])).collect::<Result<Vec<_>, _>>()?;
@@ -222,7 +256,7 @@ pub fn load_rustls_config(
 /// Uses the actual X.509 certificate, not file mtime (which can be wrong if
 /// the file is copied, restored from backup, or touched).
 pub fn leaf_cert_days_remaining() -> Result<i64, Box<dyn std::error::Error + Send + Sync>> {
-    let pem_bytes = std::fs::read(leaf_cert_path())?;
+    let pem_bytes = std::fs::read(CertPaths::live().leaf_cert)?;
     let (_, pem) = x509_parser::pem::parse_x509_pem(&pem_bytes)?;
     let (_, cert) = x509_parser::parse_x509_certificate(&pem.contents)?;
     let not_after = cert.validity().not_after.timestamp();
@@ -261,11 +295,9 @@ pub fn regenerate_leaf_if_expiring() -> Result<(), Box<dyn std::error::Error + S
 fn rotate() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let dir = certs_dir();
     std::fs::create_dir_all(&dir)?;
-    let staged_ca = dir.join("ca.pem.new");
-    let staged_leaf = dir.join("localhost.pem.new");
-    let staged_key = dir.join("localhost.key.new");
+    let staged = CertPaths::staged(&dir);
 
-    write_new_cert_set(&staged_ca, &staged_leaf, &staged_key)?;
+    write_new_cert_set(&staged)?;
 
     // Capture the OLD anchor's SHA-1 before touching the keychain, for removal after the swap.
     #[cfg(target_os = "macos")]
@@ -273,17 +305,13 @@ fn rotate() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     // macOS: trust + verify the NEW anchor BEFORE swapping. Fail-closed — discard staging, keep live.
     #[cfg(target_os = "macos")]
-    if add_trusted_cert(&staged_ca).is_err() || !verify_cert_trusted(&staged_ca) {
-        let _ = std::fs::remove_file(&staged_ca);
-        let _ = std::fs::remove_file(&staged_leaf);
-        let _ = std::fs::remove_file(&staged_key);
+    if add_trusted_cert(&staged.ca_cert).is_err() || !verify_cert_trusted(&staged.ca_cert) {
+        staged.remove();
         return Err("new CA cert could not be trusted — kept the existing certs".into());
     }
 
     // Atomic swap: the new set replaces the live certs. Trust is content-keyed, so rename keeps it.
-    std::fs::rename(&staged_ca, ca_cert_path())?;
-    std::fs::rename(&staged_leaf, leaf_cert_path())?;
-    std::fs::rename(&staged_key, leaf_key_path())?;
+    staged.swap_into(&CertPaths::live())?;
 
     // Remove the OLD anchor now that the NEW one is live + trusted (no keyless-anchor accumulation).
     #[cfg(target_os = "macos")]
@@ -375,13 +403,13 @@ fn remove_trusted_cert_by_sha1(sha1: &str) {
 /// Install the live CA cert (`ca.pem`) as a trusted root. Public entry for the initial Safari-enable.
 #[cfg(target_os = "macos")]
 pub fn install_ca_trust() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    add_trusted_cert(&ca_cert_path())
+    add_trusted_cert(&CertPaths::live().ca_cert)
 }
 
 /// Whether the live CA cert is still trusted in the macOS Keychain.
 #[cfg(target_os = "macos")]
 pub fn is_ca_trusted() -> bool {
-    verify_cert_trusted(&ca_cert_path())
+    verify_cert_trusted(&CertPaths::live().ca_cert)
 }
 
 // Non-macOS stubs — trust management is macOS-only.
@@ -504,7 +532,12 @@ mod tests {
         let leaf = tmp.path().join("localhost.pem");
         let key = tmp.path().join("localhost.key");
 
-        write_new_cert_set(&ca, &leaf, &key).unwrap();
+        write_new_cert_set(&CertPaths {
+            ca_cert: ca.clone(),
+            leaf_cert: leaf.clone(),
+            leaf_key: key.clone(),
+        })
+        .unwrap();
 
         assert!(ca.exists(), "ca.pem (anchor) should be written");
         assert!(

--- a/packages/accelerator/src-tauri/src/certs.rs
+++ b/packages/accelerator/src-tauri/src/certs.rs
@@ -58,6 +58,9 @@ impl CertPaths {
     }
 
     /// Best-effort remove all three (used to discard a failed staging).
+    /// Only the macOS trust-failure path discards a staged set, so this is
+    /// macOS-only — gating it keeps Linux/Windows clippy `-D warnings` clean.
+    #[cfg(target_os = "macos")]
     fn remove(&self) {
         let _ = std::fs::remove_file(&self.ca_cert);
         let _ = std::fs::remove_file(&self.leaf_cert);

--- a/packages/accelerator/src-tauri/src/commands.rs
+++ b/packages/accelerator/src-tauri/src/commands.rs
@@ -172,12 +172,7 @@ pub async fn enable_safari_support(
         certs::load_rustls_config().map_err(|e| format!("Failed to load TLS config: {e}"))?;
     // The clone shares the Arc'd https_bound flag with the managed state, so start_https flipping it
     // after a successful bind is visible to /health — no https_port propagation needed. (Q7)
-    let state = (**shared_state).clone();
-    tauri::async_runtime::spawn(async move {
-        if let Err(e) = crate::server::start_https(state, tls_config).await {
-            tracing::error!("HTTPS server error: {e}");
-        }
-    });
+    crate::server::spawn_https((**shared_state).clone(), tls_config);
 
     tracing::info!("Safari Support enabled via Settings");
     Ok(())

--- a/packages/accelerator/src-tauri/src/main.rs
+++ b/packages/accelerator/src-tauri/src/main.rs
@@ -81,12 +81,7 @@ fn try_start_https(state: &AppState) {
         }
     };
 
-    let state_for_https = state.clone();
-    tauri::async_runtime::spawn(async move {
-        if let Err(e) = aztec_accelerator::server::start_https(state_for_https, tls_config).await {
-            tracing::error!("HTTPS server error: {e}");
-        }
-    });
+    aztec_accelerator::server::spawn_https(state.clone(), tls_config);
 
     // Pre-expiry auto-renewal runs OFF the startup path (a background thread) so the macOS trust
     // prompt can never block/hang launch. The running server keeps its already-loaded config; a

--- a/packages/accelerator/src-tauri/src/server.rs
+++ b/packages/accelerator/src-tauri/src/server.rs
@@ -7,3 +7,18 @@ pub use accelerator_core::server::*;
 
 mod tls;
 pub use tls::start_https;
+
+/// Spawn the GUI-side HTTPS server with `tls_config`, logging any error. Shared by the two callers
+/// (launch-time `try_start_https` + settings-time `enable_safari_support`) — only the identical
+/// spawn+error-log wrapper is unified; each caller keeps its own (intentionally divergent) TLS-load
+/// and failure-handling preamble upstream. (F-09)
+pub fn spawn_https(
+    state: AppState,
+    tls_config: std::sync::Arc<tokio_rustls::rustls::ServerConfig>,
+) {
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = start_https(state, tls_config).await {
+            tracing::error!("HTTPS server error: {e}");
+        }
+    });
+}


### PR DESCRIPTION
PR-3 of 4 from the `/blueprint deep` quality-fixes plan (F-07 + F-09 + F-08; behavior-preserving).

## F-07 — `CertPaths` parameter object
Bundle the always-together TLS paths (CA cert / leaf cert / leaf key) into `CertPaths` with `live()`/`staged()`/`exists()`/`swap_into()`/`remove()`. Kills the 3×`&Path` arg-swap foot-gun + duplicated basenames. `ca_key_path` stays standalone (legacy-migration target).

## F-09 — shared `spawn_https()`
Dedupe the identical `spawn(start_https)`+error-log block from `try_start_https` (launch) and `enable_safari_support` (settings) into `server::spawn_https`. Divergent TLS-load/failure preambles stay upstream (intentional).

## F-08 — `/prove` status ownership (behavior-preserving)
`resolve_version` is now pure (sync, no status/download) returning `{version, to_download}`; `prove()` owns the full `Proving→(Downloading→Proving)→Idle` sequence — the **redundant leading `Proving` is preserved** so the download arm stays `[Proving, Downloading, Proving, Idle]` (opus H2).

## Validation
- core **120** + server **5** + src-tauri **19** tests; `clippy -D warnings` clean on all 3 crates (default + `webdriver`). Behavior-preserving.

> Note: commits in this PR are unsigned — the local 1Password signing agent hit a transient buffer error mid-run, so per the standing rule they were committed with signing skipped (git config untouched); backfillable.

Plan + lessons: `implementations-plan/quality-fixes-2026-06-08/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)