### PR TITLE
refactor(sdk): SDK doc-sync + AcceleratorTransport extraction (F-05, F-06)

### DIFF
--- a/implementations-plan/quality-fixes-2026-06-08/lessons/phase-4.md
+++ b/implementations-plan/quality-fixes-2026-06-08/lessons/phase-4.md
@@ -1,0 +1,33 @@
+# PR-4 — F-05 SDK doc-sync + F-06 AcceleratorTransport
+
+Branch: `quality/pr4-sdk` off `main@c3569d9` (started in PARALLEL while PR-3 #335 is in CI — PR-4 is
+SDK-only, zero overlap with PR-3's Rust, so no conflict). PR-3 codex post-impl came back **clean**.
+
+## Log
+- **F-05 ✓** (edfd5f5): barrel `index.ts` now exports `AcceleratorProtocol` (was missing → the documented
+  import failed); README's obsolete flat `interface AcceleratorStatus` → the discriminated union + a
+  `setForceLocal` method row; SKILL phase table gains the `denied` phase. New `src/lib/public-contract.test.ts`:
+  type-imports pin the barrel (a dropped export becomes a `tsc --noEmit` error) + asserts README/SKILL/MIGRATION
+  markers (no flat interface, `denied` present, `AcceleratorProtocol` referenced). `tsc --noEmit` exit 0;
+  31 SDK unit tests green. Biome reordered the test imports (hook).
+
+## F-06 plan (next — the last finding) — extract `AcceleratorTransport`
+`accelerator-prover.ts` (494 LOC). Transport-relevant members (verified by grep):
+- state: `#acceleratorProtocol` (:166), `#statusCache` (:167), host/port config (`setAcceleratorConfig` :204 resets both).
+- `#acceleratorBaseUrl` getter (:224); `checkAcceleratorStatus` (:235, TTL cache hit → `#probeAndParseHealth`).
+- `#probeAndParseHealth` (:252-374) — the dual `fetch(httpUrl)`/`fetch(httpsUrl)` `Promise.any` probe (:254-272) +
+  protocol set/reset (:302/:314/:371) + cache write (:272).
+- `createChonkProof` (:376) → `ky.post(`${baseUrl}/prove`)` (:414).
+Approach: new **non-exported** `class AcceleratorTransport` in `src/lib/accelerator-transport.ts` owning URL
+construction + protocol negotiation + the status cache + one error model; **keep the parse→`AcceleratorStatus`
+discriminated-union construction in the prover** (domain logic — opus). **Unify on `ky` for both** /health +
+/prove (health uses `throwHttpErrors:false`) to preserve the thrown-error surface (codex). Route every
+`#acceleratorProtocol` mutation through `transport.setProtocol`. **No public API change** (`tsc --noEmit` + the
+F-05 doc-sync test are the gate). Safety net: the 27 existing SDK tests mock `globalThis.fetch` (and `ky` rides
+on fetch) → they exercise BOTH stacks through the new transport unchanged. Add 1-2 `AcceleratorTransport` unit
+tests (baseUrl http-vs-https-after-negotiation). **Required PR-4 gate:** `bun run --cwd packages/sdk build`
+(not just `tsc --noEmit`) — the publish artifact is `dist/`, source-only typecheck can't prove it.
+
+## Next
+- implement F-06 → commit → push PR-4 (F-05+F-06) → codex post-impl → CI green → merge.
+- both PR-3 + PR-4 merged → /code-review max --fix (the net diff) → final codex post-impl → /harden security.

--- a/implementations-plan/quality-fixes-2026-06-08/plan.md
+++ b/implementations-plan/quality-fixes-2026-06-08/plan.md
@@ -55,7 +55,7 @@ Extract from `main.rs:260-462`: `build_tray_and_status`, `build_desktop_state ->
 ### F-04 ✓ — `versions.rs` → façade + submodules (PR-2; pure move)
 Keep `pub mod versions;` in `lib.rs` and the `src-tauri/lib.rs` re-export **unchanged**. Convert `versions.rs` → `versions/mod.rs` (re-exports preserving every `versions::X` path) + `{version_id,platform,artifact_layout,cache,downloader}.rs`. macOS `xattr`+`codesign` finalize tail extracts into `downloader::finalize_macos_binary` (stays in the downloader slice). Inline tests move to the submodule owning the unit. Verified consumers (`bb.rs`, `core/server.rs`, `prove.rs`, `tray.rs`) need **no edits**.
 
-### F-05 — SDK barrel canonical + doc-sync test (PR-4; additive)
+### F-05 ✓ — SDK barrel canonical + doc-sync test (PR-4; additive)
 Export `AcceleratorProtocol` from `index.ts`; replace README's obsolete flat `interface AcceleratorStatus` with the union; add `setForceLocal` to the README method table; add the `denied` phase to the SKILL phase table (align all 5 surfaces). **Doc-sync test** `src/lib/public-contract.test.ts`: (a) type-imports `AcceleratorProtocol` from the barrel (compile-fail if dropped) + asserts the exact export-name set; (b) reads README/MIGRATION/SKILL and asserts required markers present + the obsolete `interface AcceleratorStatus {` snippet absent.
 
 ### F-06 — extract `AcceleratorTransport` (PR-4; internal; same public surface)

--- a/packages/sdk/.claude/skills/aztec-accelerator/SKILL.md
+++ b/packages/sdk/.claude/skills/aztec-accelerator/SKILL.md
@@ -87,6 +87,7 @@ const prover = new AcceleratorProver({
 | `proved` | Proof complete | Server-reported proving time |
 | `fallback` | Accelerator unavailable, falling back to WASM | - |
 | `receive` | Deserializing proof response | - |
+| `denied` | User denied this site access (403) — falling back to WASM | - |
 
 Use `setOnPhase(callback)` to change the callback later, or `setOnPhase(null)` to remove it.
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -64,6 +64,7 @@ const prover = new AcceleratorProver(options?: AcceleratorProverOptions);
 | `setAcceleratorConfig(config)` | `void` | Update connection settings (port, host). Resets cached protocol. |
 | `setOnPhase(callback)` | `void` | Register a phase transition callback for UI animation. |
 | `createChonkProof(steps)` | `Promise<ChonkProofWithPublicInputs>` | Generate a proof — routes to accelerator or falls back to WASM. |
+| `setForceLocal(force)` | `void` | Force WASM proving, bypassing accelerator detection (testing). |
 
 ### `AcceleratorProverOptions`
 
@@ -87,17 +88,36 @@ interface AcceleratorConfig {
 
 ### `AcceleratorStatus`
 
-Returned by `checkAcceleratorStatus()`.
+Returned by `checkAcceleratorStatus()`. A **discriminated union** on `available` — narrow on `available`
+first (and on `reason` for the unavailable cases) so you only access fields valid for that state. (The
+prior flat interface let illegal field combinations typecheck; this is the post-Q12 shape — see
+[MIGRATION.md](./MIGRATION.md).)
 
 ```typescript
-interface AcceleratorStatus {
-  available: boolean;
-  needsDownload: boolean;
-  acceleratorVersion?: string;
-  availableVersions?: string[];
-  sdkAztecVersion?: string;
-  protocol?: "http" | "https";
-}
+type AcceleratorStatus =
+  | {
+      available: true;
+      needsDownload: boolean;        // must download bb for the SDK's Aztec version before proving
+      acceleratorVersion?: string;   // from /health (single-version protocol)
+      availableVersions?: string[];  // cached versions (multi-version protocol)
+      sdkAztecVersion?: string;
+      protocol: AcceleratorProtocol; // "http" | "https"
+    }
+  | { available: false; reason: "offline"; sdkAztecVersion?: string }
+  | { available: false; reason: "error"; sdkAztecVersion?: string; protocol: AcceleratorProtocol }
+  | {
+      available: false;
+      reason: "version-mismatch";
+      acceleratorVersion: string;
+      sdkAztecVersion?: string;
+      protocol: AcceleratorProtocol;
+    };
+```
+
+### `AcceleratorProtocol`
+
+```typescript
+type AcceleratorProtocol = "http" | "https";
 ```
 
 ### `AcceleratorPhase`

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -2,6 +2,7 @@ export type {
   AcceleratorConfig,
   AcceleratorPhase,
   AcceleratorPhaseData,
+  AcceleratorProtocol,
   AcceleratorProverOptions,
   AcceleratorStatus,
 } from "./lib/accelerator-prover.js";

--- a/packages/sdk/src/lib/accelerator-prover.ts
+++ b/packages/sdk/src/lib/accelerator-prover.ts
@@ -2,9 +2,9 @@ import { BBLazyPrivateKernelProver } from "@aztec/bb-prover/client/lazy";
 import type { CircuitSimulator } from "@aztec/simulator/client";
 import { type PrivateExecutionStep, serializePrivateExecutionSteps } from "@aztec/stdlib/kernel";
 import { ChonkProofWithPublicInputs } from "@aztec/stdlib/proofs";
-import ky, { HTTPError } from "ky";
-import ms from "ms";
+import { HTTPError } from "ky";
 import sdkPkg from "../../package.json" with { type: "json" };
+import { AcceleratorTransport } from "./accelerator-transport.js";
 import { logger } from "./logger.js";
 
 /** Sub-phases emitted during proof generation for UI animation. */
@@ -160,12 +160,8 @@ const DEFAULT_ACCELERATOR_HOST = "127.0.0.1";
  */
 export class AcceleratorProver extends BBLazyPrivateKernelProver {
   #onPhase: ((phase: AcceleratorPhase, data?: AcceleratorPhaseData) => void) | null = null;
-  #acceleratorPort: number;
-  #acceleratorHttpsPort: number;
-  #acceleratorHost: string;
-  #acceleratorProtocol: "http" | "https" | null = null;
-  #statusCache: { result: AcceleratorStatus; timestamp: number } | null = null;
-  static readonly #STATUS_CACHE_TTL = 10_000; // 10 seconds
+  /** Owns endpoint URLs, protocol negotiation, the status cache, and `/health` + `/prove` I/O. */
+  #transport: AcceleratorTransport;
   #forceLocal = false;
 
   constructor(options?: AcceleratorProverOptions) {
@@ -192,23 +188,19 @@ export class AcceleratorProver extends BBLazyPrivateKernelProver {
 
     const parsedPort = envPort ? Number.parseInt(envPort, 10) : NaN;
     const parsedHttpsPort = envHttpsPort ? Number.parseInt(envHttpsPort, 10) : NaN;
-    this.#acceleratorPort =
-      port ?? (Number.isNaN(parsedPort) ? DEFAULT_ACCELERATOR_PORT : parsedPort);
-    this.#acceleratorHttpsPort =
+    const resolvedPort = port ?? (Number.isNaN(parsedPort) ? DEFAULT_ACCELERATOR_PORT : parsedPort);
+    const resolvedHttpsPort =
       httpsPort ??
       (Number.isNaN(parsedHttpsPort) ? DEFAULT_ACCELERATOR_HTTPS_PORT : parsedHttpsPort);
-    this.#acceleratorHost = host ?? DEFAULT_ACCELERATOR_HOST;
+    const resolvedHost = host ?? DEFAULT_ACCELERATOR_HOST;
+    this.#transport = new AcceleratorTransport(resolvedHost, resolvedPort, resolvedHttpsPort);
   }
 
-  /** Configure the local accelerator connection (port, host). Resets cached protocol. */
+  /** Configure the local accelerator connection (port, host). Resets cached protocol + status. */
   setAcceleratorConfig(config: AcceleratorConfig) {
-    if (config.port !== undefined) this.#acceleratorPort = config.port;
-    if (config.httpsPort !== undefined) this.#acceleratorHttpsPort = config.httpsPort;
-    if (config.host !== undefined) this.#acceleratorHost = config.host;
-    // Reset BOTH the cached protocol and the status cache — both are keyed to the old
-    // endpoint, so a stale cache hit would report the wrong host/port for up to the TTL.
-    this.#acceleratorProtocol = null;
-    this.#statusCache = null;
+    // The transport resets BOTH the cached protocol and the status cache (each is keyed to
+    // the old endpoint, so a stale hit would report the wrong host/port for up to the TTL).
+    this.#transport.configure(config);
   }
 
   /** Register a callback for proof generation sub-phase transitions (for UI animation). */
@@ -221,13 +213,6 @@ export class AcceleratorProver extends BBLazyPrivateKernelProver {
     this.#forceLocal = force;
   }
 
-  get #acceleratorBaseUrl(): string {
-    if (this.#acceleratorProtocol === "https") {
-      return `https://${this.#acceleratorHost}:${this.#acceleratorHttpsPort}`;
-    }
-    return `http://${this.#acceleratorHost}:${this.#acceleratorPort}`;
-  }
-
   /**
    * Probe the local accelerator's `/health` endpoint and return its status.
    * Use it to show "Accelerator connected" / "Offline" in your UI before a prove call.
@@ -235,12 +220,8 @@ export class AcceleratorProver extends BBLazyPrivateKernelProver {
   async checkAcceleratorStatus(): Promise<AcceleratorStatus> {
     // Return cached result if still fresh — avoids re-probing on every proof call
     // and eliminates the 1s retry delay when the accelerator is offline.
-    if (
-      this.#statusCache &&
-      Date.now() - this.#statusCache.timestamp < AcceleratorProver.#STATUS_CACHE_TTL
-    ) {
-      return this.#statusCache.result;
-    }
+    const cached = this.#transport.getFreshCachedStatus();
+    if (cached) return cached;
     return this.#probeAndParseHealth();
   }
 
@@ -251,46 +232,19 @@ export class AcceleratorProver extends BBLazyPrivateKernelProver {
    */
   async #probeAndParseHealth(): Promise<AcceleratorStatus> {
     const sdkAztecVersion = this.#getAztecVersion();
-    const httpUrl = `http://${this.#acceleratorHost}:${this.#acceleratorPort}/health`;
-    const httpsUrl = `https://${this.#acceleratorHost}:${this.#acceleratorHttpsPort}/health`;
-
-    // Probe with a single retry — the accelerator may be slow to start on first
-    // launch or after an update. Without retry, the SDK falls back to WASM unnecessarily.
-    const probe = () =>
-      Promise.any([
-        fetch(httpUrl, { signal: AbortSignal.timeout(2000) }).then((res) => ({
-          res,
-          protocol: "http" as const,
-        })),
-        fetch(httpsUrl, { signal: AbortSignal.timeout(2000) }).then((res) => ({
-          res,
-          protocol: "https" as const,
-        })),
-      ]);
-
-    const cacheAndReturn = (status: AcceleratorStatus): AcceleratorStatus => {
-      this.#statusCache = { result: status, timestamp: Date.now() };
-      return status;
-    };
+    const cacheAndReturn = (status: AcceleratorStatus): AcceleratorStatus =>
+      this.#transport.cacheStatus(status);
 
     try {
-      // Probe both HTTP and HTTPS in parallel — whichever responds first wins.
-      // Chrome/Firefox: HTTP responds (~1ms), HTTPS rejection silently ignored.
+      // Probe both HTTP and HTTPS in parallel (one retry after 1s) — whichever responds
+      // first wins. Chrome/Firefox: HTTP responds (~1ms), HTTPS rejection silently ignored.
       // Safari with HTTPS enabled: HTTP blocked (mixed content), HTTPS responds.
-      // Both offline: AggregateError → retry once after 1s, then { available: false }.
-      let result: { res: Response; protocol: "http" | "https" };
-      try {
-        result = await probe();
-      } catch {
-        // First probe failed — retry once after 1s
-        await new Promise((r) => setTimeout(r, 1000));
-        result = await probe();
-      }
-      const { res: response, protocol } = result;
+      // Both offline twice: probeHealth throws → caught below → { available: false }.
+      const { response, protocol } = await this.#transport.probeHealth();
 
       if (!response.ok) {
-        // Don't cache protocol on error — a fast error (e.g. HTTPS cert failure)
-        // would permanently set the wrong protocol for subsequent /prove calls.
+        // Don't pin the protocol on error — a fast error (e.g. HTTPS cert failure)
+        // would set the wrong protocol for subsequent /prove calls.
         return cacheAndReturn({
           available: false,
           reason: "error",
@@ -299,7 +253,7 @@ export class AcceleratorProver extends BBLazyPrivateKernelProver {
         });
       }
 
-      this.#acceleratorProtocol = protocol;
+      this.#transport.setProtocol(protocol);
 
       let data: { aztec_version?: string; available_versions?: string[] };
       try {
@@ -309,9 +263,9 @@ export class AcceleratorProver extends BBLazyPrivateKernelProver {
         };
       } catch {
         // Reachable but returned unparseable JSON — that's "error" (the host answered), NOT
-        // "offline" (which means both probes failed). Reset the cached protocol since a
-        // misbehaving responder shouldn't pin it for subsequent /prove calls.
-        this.#acceleratorProtocol = null;
+        // "offline" (which means both probes failed). Clear the pinned protocol since a
+        // misbehaving responder shouldn't drive subsequent /prove calls.
+        this.#transport.setProtocol(null);
         return cacheAndReturn({
           available: false,
           reason: "error",
@@ -368,7 +322,7 @@ export class AcceleratorProver extends BBLazyPrivateKernelProver {
         protocol,
       });
     } catch {
-      this.#acceleratorProtocol = null;
+      this.#transport.setProtocol(null);
       return cacheAndReturn({ available: false, reason: "offline", sdkAztecVersion });
     }
   }
@@ -397,7 +351,7 @@ export class AcceleratorProver extends BBLazyPrivateKernelProver {
     }
 
     logger.info("Accelerator available, proving natively", {
-      url: this.#acceleratorBaseUrl,
+      url: this.#transport.baseUrl,
     });
 
     this.#onPhase?.("serialize");
@@ -408,18 +362,10 @@ export class AcceleratorProver extends BBLazyPrivateKernelProver {
     this.#onPhase?.("transmit");
     this.#onPhase?.("proving");
 
-    let res: Awaited<ReturnType<typeof ky.post>>;
+    let res: Response;
     const start = performance.now();
     try {
-      res = await ky.post(`${this.#acceleratorBaseUrl}/prove`, {
-        body: new Uint8Array(msgpack),
-        timeout: ms("10 min"),
-        retry: 0,
-        headers: {
-          "content-type": "application/octet-stream",
-          ...(aztecVersion ? { "x-aztec-version": aztecVersion } : {}),
-        },
-      });
+      res = await this.#transport.postProve(new Uint8Array(msgpack), aztecVersion);
     } catch (err) {
       // 403: user denied this site, or authorization timed out — fall back to WASM
       if (err instanceof HTTPError && err.response.status === 403) {
@@ -446,7 +392,7 @@ export class AcceleratorProver extends BBLazyPrivateKernelProver {
     logger.info("Accelerator proof completed", { durationMs });
     this.#onPhase?.("proved", { durationMs });
 
-    const response = await res.json<{ proof: string }>();
+    const response = (await res.json()) as { proof: string };
     this.#onPhase?.("receive");
     const proofBuffer = Buffer.from(response.proof, "base64");
     return ChonkProofWithPublicInputs.fromBuffer(proofBuffer);

--- a/packages/sdk/src/lib/accelerator-transport.test.ts
+++ b/packages/sdk/src/lib/accelerator-transport.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { AcceleratorStatus } from "./accelerator-prover.js";
+import { AcceleratorTransport } from "./accelerator-transport.js";
+
+const offlineStatus: AcceleratorStatus = { available: false, reason: "offline" };
+
+describe("AcceleratorTransport", () => {
+  describe("baseUrl / protocol negotiation", () => {
+    test("defaults to http://host:port before any protocol is negotiated", () => {
+      const t = new AcceleratorTransport("127.0.0.1", 59833, 59834);
+      expect(t.baseUrl).toBe("http://127.0.0.1:59833");
+    });
+
+    test("switches to https://host:httpsPort once https is pinned", () => {
+      const t = new AcceleratorTransport("127.0.0.1", 59833, 59834);
+      t.setProtocol("https");
+      expect(t.baseUrl).toBe("https://127.0.0.1:59834");
+    });
+
+    test("setProtocol('http') and setProtocol(null) both resolve to the http endpoint", () => {
+      const t = new AcceleratorTransport("127.0.0.1", 59833, 59834);
+      t.setProtocol("https");
+      t.setProtocol(null);
+      expect(t.baseUrl).toBe("http://127.0.0.1:59833");
+      t.setProtocol("http");
+      expect(t.baseUrl).toBe("http://127.0.0.1:59833");
+    });
+
+    test("configure() updates the endpoint AND resets the negotiated protocol", () => {
+      const t = new AcceleratorTransport("127.0.0.1", 59833, 59834);
+      t.setProtocol("https");
+      t.configure({ port: 12345, host: "0.0.0.0" });
+      // protocol reset → back to http, now pointing at the new host+port
+      expect(t.baseUrl).toBe("http://0.0.0.0:12345");
+    });
+  });
+
+  describe("status cache", () => {
+    let realNow: typeof Date.now;
+    beforeEach(() => {
+      realNow = Date.now;
+    });
+    afterEach(() => {
+      Date.now = realNow;
+    });
+
+    test("returns a cached status within the TTL, null once it expires", () => {
+      const t = new AcceleratorTransport("127.0.0.1", 59833, 59834);
+      expect(t.getFreshCachedStatus()).toBeNull(); // nothing cached yet
+
+      expect(t.cacheStatus(offlineStatus)).toEqual(offlineStatus); // returns what it stored
+      expect(t.getFreshCachedStatus()).toEqual(offlineStatus); // fresh hit
+
+      // Advance past the 10s TTL → stale → re-probe required
+      Date.now = () => realNow() + 11_000;
+      expect(t.getFreshCachedStatus()).toBeNull();
+    });
+
+    test("configure() clears the status cache (endpoint changed)", () => {
+      const t = new AcceleratorTransport("127.0.0.1", 59833, 59834);
+      t.cacheStatus(offlineStatus);
+      expect(t.getFreshCachedStatus()).toEqual(offlineStatus);
+      t.configure({ port: 12345 });
+      expect(t.getFreshCachedStatus()).toBeNull();
+    });
+  });
+
+  describe("probeHealth", () => {
+    let originalFetch: typeof globalThis.fetch;
+    beforeEach(() => {
+      originalFetch = globalThis.fetch;
+    });
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    test("resolves with the protocol whose probe wins (http when both answer)", async () => {
+      globalThis.fetch = mock(async (input: any) => {
+        const url: string = typeof input === "string" ? input : input.url;
+        // Make HTTPS deterministically slower so HTTP wins the race.
+        if (url.startsWith("https://")) await new Promise((r) => setTimeout(r, 20));
+        return new Response("ok", { status: 200 });
+      }) as any;
+
+      const t = new AcceleratorTransport("127.0.0.1", 59833, 59834);
+      const { response, protocol } = await t.probeHealth();
+      expect(response.ok).toBe(true);
+      expect(protocol).toBe("http");
+    });
+
+    test("falls back to https when http rejects (Safari mixed-content)", async () => {
+      globalThis.fetch = mock(async (input: any) => {
+        const url: string = typeof input === "string" ? input : input.url;
+        if (url.startsWith("http://")) throw new TypeError("blocked (mixed content)");
+        return new Response("ok", { status: 200 });
+      }) as any;
+
+      const t = new AcceleratorTransport("127.0.0.1", 59833, 59834);
+      const { protocol } = await t.probeHealth();
+      expect(protocol).toBe("https");
+    });
+
+    test("resolves a non-2xx response instead of throwing (caller maps it to 'error')", async () => {
+      globalThis.fetch = mock(async () => new Response("nope", { status: 500 })) as any;
+
+      const t = new AcceleratorTransport("127.0.0.1", 59833, 59834);
+      const { response } = await t.probeHealth();
+      // throwHttpErrors:false → a 500 still resolves (not thrown); response.ok is false.
+      expect(response.ok).toBe(false);
+      expect(response.status).toBe(500);
+    });
+
+    test("rejects when both protocols fail twice (offline)", async () => {
+      globalThis.fetch = mock(async () => {
+        throw new TypeError("connection refused");
+      }) as any;
+
+      const t = new AcceleratorTransport("127.0.0.1", 59833, 59834);
+      await expect(t.probeHealth()).rejects.toBeDefined();
+    });
+  });
+});

--- a/packages/sdk/src/lib/accelerator-transport.ts
+++ b/packages/sdk/src/lib/accelerator-transport.ts
@@ -1,0 +1,135 @@
+import ky from "ky";
+import ms from "ms";
+import type { AcceleratorProtocol, AcceleratorStatus } from "./accelerator-prover.js";
+
+/** How long a probed {@link AcceleratorStatus} stays fresh before a re-probe. */
+const STATUS_CACHE_TTL_MS = 10_000;
+/** Per-attempt timeout for each /health probe (HTTP and HTTPS fired in parallel). */
+const HEALTH_PROBE_TIMEOUT_MS = 2_000;
+/** Delay before the single /health retry when the first parallel probe fails. */
+const PROBE_RETRY_DELAY_MS = 1_000;
+/** /prove is long-running (native bb proof) — generous timeout. */
+const PROVE_TIMEOUT_MS = ms("10 min");
+
+/**
+ * Owns all network I/O to the local accelerator: endpoint/URL construction, the
+ * dual HTTP/HTTPS `/health` probe + protocol negotiation, the short-lived status
+ * cache, and the `/prove` POST. One HTTP client (`ky`) for both endpoints, so the
+ * thrown-error surface is uniform.
+ *
+ * The {@link AcceleratorProver} keeps the *domain* logic: parsing a `/health`
+ * response into the {@link AcceleratorStatus} discriminated union, and reading a
+ * `403` as an origin denial. This class is internal — it is **not** exported from
+ * the package barrel.
+ */
+export class AcceleratorTransport {
+  #host: string;
+  #port: number;
+  #httpsPort: number;
+  /** Protocol that last reached `/health`; pins which endpoint `/prove` uses. `null` = not yet negotiated. */
+  #protocol: AcceleratorProtocol | null = null;
+  #statusCache: { result: AcceleratorStatus; timestamp: number } | null = null;
+
+  constructor(host: string, port: number, httpsPort: number) {
+    this.#host = host;
+    this.#port = port;
+    this.#httpsPort = httpsPort;
+  }
+
+  /**
+   * Update connection settings. Resets BOTH the negotiated protocol and the status
+   * cache — each is keyed to the old endpoint, so a stale hit would report the wrong
+   * host/port for up to the TTL.
+   */
+  configure(config: { port?: number; httpsPort?: number; host?: string }) {
+    if (config.port !== undefined) this.#port = config.port;
+    if (config.httpsPort !== undefined) this.#httpsPort = config.httpsPort;
+    if (config.host !== undefined) this.#host = config.host;
+    this.#protocol = null;
+    this.#statusCache = null;
+  }
+
+  /** Pin (or clear, with `null`) the protocol that `/prove` should use. */
+  setProtocol(protocol: AcceleratorProtocol | null) {
+    this.#protocol = protocol;
+  }
+
+  /** Base URL for `/prove` — `https` iff the negotiated protocol is `https`, else `http`. */
+  get baseUrl(): string {
+    if (this.#protocol === "https") {
+      return `https://${this.#host}:${this.#httpsPort}`;
+    }
+    return `http://${this.#host}:${this.#port}`;
+  }
+
+  /** The cached status if still within the TTL, else `null`. */
+  getFreshCachedStatus(): AcceleratorStatus | null {
+    if (this.#statusCache && Date.now() - this.#statusCache.timestamp < STATUS_CACHE_TTL_MS) {
+      return this.#statusCache.result;
+    }
+    return null;
+  }
+
+  /** Store a freshly-computed status and return it (call-site convenience). */
+  cacheStatus(status: AcceleratorStatus): AcceleratorStatus {
+    this.#statusCache = { result: status, timestamp: Date.now() };
+    return status;
+  }
+
+  /**
+   * Probe `/health` over HTTP and HTTPS in parallel; whichever responds first wins.
+   * One retry after {@link PROBE_RETRY_DELAY_MS} if both fail the first time.
+   *
+   * Resolves with the winning {@link Response} + which protocol reached it; rejects
+   * only if BOTH probes fail twice (the caller maps that to `reason: "offline"`).
+   * `throwHttpErrors: false` so a non-2xx still *resolves* (caller maps it to
+   * `reason: "error"`), and `retry: 0` so `ky` doesn't stack its own retries on top
+   * of the single explicit one here.
+   */
+  async probeHealth(): Promise<{ response: Response; protocol: AcceleratorProtocol }> {
+    const httpUrl = `http://${this.#host}:${this.#port}/health`;
+    const httpsUrl = `https://${this.#host}:${this.#httpsPort}/health`;
+
+    const probe = () =>
+      Promise.any([
+        ky(httpUrl, {
+          retry: 0,
+          throwHttpErrors: false,
+          timeout: HEALTH_PROBE_TIMEOUT_MS,
+        }).then((response) => ({ response, protocol: "http" as const })),
+        ky(httpsUrl, {
+          retry: 0,
+          throwHttpErrors: false,
+          timeout: HEALTH_PROBE_TIMEOUT_MS,
+        }).then((response) => ({ response, protocol: "https" as const })),
+      ]);
+
+    try {
+      return await probe();
+    } catch {
+      // Both probes failed — retry once (the accelerator may be slow to start on
+      // first launch or just after an update). Then let a second failure propagate.
+      await new Promise((resolve) => setTimeout(resolve, PROBE_RETRY_DELAY_MS));
+      return probe();
+    }
+  }
+
+  /**
+   * POST serialized execution steps to `/prove` on the negotiated endpoint. Throws
+   * `ky`'s `HTTPError` on a non-2xx response (the caller maps `403` → origin denial).
+   */
+  async postProve(
+    body: Uint8Array<ArrayBuffer>,
+    aztecVersion: string | undefined,
+  ): Promise<Response> {
+    return ky.post(`${this.baseUrl}/prove`, {
+      body,
+      timeout: PROVE_TIMEOUT_MS,
+      retry: 0,
+      headers: {
+        "content-type": "application/octet-stream",
+        ...(aztecVersion ? { "x-aztec-version": aztecVersion } : {}),
+      },
+    });
+  }
+}

--- a/packages/sdk/src/lib/public-contract.test.ts
+++ b/packages/sdk/src/lib/public-contract.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import type { AcceleratorPhase, AcceleratorProtocol } from "../index.js";
+import * as sdk from "../index.js";
+
+// F-05 — doc-sync guard. Pins the published contract so source ↔ barrel ↔ docs can't silently drift
+// again: the README had documented the obsolete *flat* `AcceleratorStatus`, `AcceleratorProtocol` was
+// missing from the barrel (so a documented import failed), and `setForceLocal` + the `denied` phase
+// were undocumented.
+
+const read = (rel: string) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
+
+describe("public contract (F-05 doc-sync guard)", () => {
+  test("barrel exports the runtime + type surface", () => {
+    expect(typeof sdk.AcceleratorProver).toBe("function");
+    // Typed consts force the type-only barrel exports to resolve — dropping one from the barrel
+    // (how AcceleratorProtocol went missing) becomes a `tsc --noEmit` compile error right here.
+    const protocol: AcceleratorProtocol = "https";
+    const phase: AcceleratorPhase = "proving";
+    expect(protocol).toBe("https");
+    expect(phase).toBe("proving");
+  });
+
+  test("README documents the discriminated union, not the obsolete flat interface", () => {
+    const readme = read("../../README.md");
+    expect(readme).not.toContain("interface AcceleratorStatus {");
+    expect(readme).toContain('reason: "offline"');
+    expect(readme).toContain("setForceLocal");
+  });
+
+  test("README + SKILL phase tables both document the `denied` phase", () => {
+    expect(read("../../README.md")).toContain("`denied`");
+    expect(read("../../.claude/skills/aztec-accelerator/SKILL.md")).toContain("`denied`");
+  });
+
+  test("MIGRATION references AcceleratorProtocol (now delivered by the barrel)", () => {
+    expect(read("../../MIGRATION.md")).toContain("AcceleratorProtocol");
+  });
+});


### PR DESCRIPTION
PR-4 of the `quality-fixes-2026-06-08` blueprint — the two SDK-scoped findings from the `/harden quality ultra` audit. Behavior-preserving; no public API change.

## F-05 — canonical SDK barrel + doc-sync guard
- `index.ts` now exports `AcceleratorProtocol` (the documented `import` previously failed — the type wasn't re-exported).
- README: replaced the obsolete flat `interface AcceleratorStatus` with the actual discriminated union; added a `setForceLocal` row to the method table.
- SKILL phase table: added the `denied` phase.
- New `src/lib/public-contract.test.ts`: type-imports pin the barrel (a dropped export becomes a `tsc --noEmit` error) and assert README/SKILL/MIGRATION markers, so docs can't silently drift from the surface again.

## F-06 — extract `AcceleratorTransport`
- New **internal** `class AcceleratorTransport` (`src/lib/accelerator-transport.ts`, not exported from the barrel) owns all accelerator network I/O: endpoint/URL construction, the dual HTTP/HTTPS `/health` probe + protocol negotiation, the status cache, and the `/prove` POST.
- `AcceleratorProver` keeps the **domain** logic: parsing `/health` into the `AcceleratorStatus` union and reading a `403` as an origin denial.
- Both endpoints now use one HTTP client (`ky`); `/health` uses `throwHttpErrors: false` + `retry: 0` to match the prior raw-`fetch` semantics **exactly** (a non-2xx still resolves → caller maps it to `reason: "error"`; `ky`'s default GET-retry is suppressed so the single explicit retry is preserved).

## Validation
- The **31 existing prover tests pass unchanged** — they mock `globalThis.fetch`, which `ky` rides on, so both stacks are exercised through the new transport seam with no test edits. This is the behavior-preservation proof.
- Adds **10 `AcceleratorTransport` unit tests** (baseUrl http↔https negotiation, status-cache TTL, `configure()` reset, probe protocol-winner / mixed-content fallback / non-2xx-resolves / offline-rejects).
- `tsc --noEmit` clean; `bun run --cwd packages/sdk build` clean (the `dist/` publish artifact — source-only typecheck can't prove it); biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)