### PR TITLE
feat(accelerator): loopback Host-allowlist guard (SEC-01a, PR-1)

### DIFF
--- a/packages/accelerator/core/src/server.rs
+++ b/packages/accelerator/core/src/server.rs
@@ -24,6 +24,7 @@ pub use bind::bind_with_retry;
 mod probe;
 pub use probe::healthy_aztec_on_port;
 mod auth;
+mod host;
 mod prove;
 
 const PORT: u16 = 59833;
@@ -190,7 +191,16 @@ pub async fn start(state: AppState) -> Result<(), Box<dyn std::error::Error + Se
     Ok(())
 }
 
+/// Build the router for the HTTP listener (port [`PORT`]). Thin shim over [`router_for_port`].
 pub fn router(state: AppState) -> Router {
+    router_for_port(state, PORT)
+}
+
+/// Build the router, gating every request on a trusted loopback `Host`/`:authority` for
+/// `expected_port` (SEC-01a — the DNS-rebinding keystone, see [`host`]). Each listener passes its
+/// own port (HTTP [`PORT`], HTTPS [`HTTPS_PORT`]) so a `:59834` authority can't pass on the `:59833`
+/// listener. The guard is the OUTERMOST layer → it runs before CORS and the routes.
+pub fn router_for_port(state: AppState, expected_port: u16) -> Router {
     let cors = CorsLayer::new()
         .allow_origin(Any)
         .allow_methods([Method::GET, Method::POST])
@@ -209,6 +219,11 @@ pub fn router(state: AppState) -> Router {
             http::header::HeaderName::from_static("cross-origin-resource-policy"),
             HeaderValue::from_static("cross-origin"),
         ))
+        // Outermost layer (added last → runs first): reject any non-loopback / wrong-port Host
+        // before route or CORS logic. Behaviour-preserving for real loopback clients.
+        .layer(axum::middleware::from_fn(move |req, next| {
+            host::guard(expected_port, req, next)
+        }))
         .with_state(state)
 }
 
@@ -287,6 +302,7 @@ mod tests {
         let response: axum::http::Response<_> = app
             .oneshot(
                 Request::builder()
+                    .header("host", "127.0.0.1:59833")
                     .uri("/health")
                     .body(Body::empty())
                     .unwrap(),
@@ -336,6 +352,7 @@ mod tests {
         let response = router(state)
             .oneshot(
                 Request::builder()
+                    .header("host", "127.0.0.1:59833")
                     .uri("/health")
                     .body(Body::empty())
                     .unwrap(),
@@ -364,6 +381,7 @@ mod tests {
         let response: axum::http::Response<_> = app
             .oneshot(
                 Request::builder()
+                    .header("host", "127.0.0.1:59833")
                     .uri("/health")
                     .body(Body::empty())
                     .unwrap(),
@@ -399,6 +417,7 @@ mod tests {
         let response: axum::http::Response<_> = app
             .oneshot(
                 Request::builder()
+                    .header("host", "127.0.0.1:59833")
                     .uri("/health")
                     .body(Body::empty())
                     .unwrap(),
@@ -422,6 +441,7 @@ mod tests {
         let response: axum::http::Response<_> = app
             .oneshot(
                 Request::builder()
+                    .header("host", "127.0.0.1:59833")
                     .method("OPTIONS")
                     .uri("/prove")
                     .header("origin", "http://localhost:5173")
@@ -455,6 +475,7 @@ mod tests {
         let response: axum::http::Response<_> = app
             .oneshot(
                 Request::builder()
+                    .header("host", "127.0.0.1:59833")
                     .method("OPTIONS")
                     .uri("/prove")
                     .header("origin", "http://localhost:5173")
@@ -485,6 +506,7 @@ mod tests {
         let response: axum::http::Response<_> = app
             .oneshot(
                 Request::builder()
+                    .header("host", "127.0.0.1:59833")
                     .uri("/health")
                     .header("origin", "http://localhost:5173")
                     .body(Body::empty())
@@ -517,6 +539,7 @@ mod tests {
         let response: axum::http::Response<_> = app
             .oneshot(
                 Request::builder()
+                    .header("host", "127.0.0.1:59833")
                     .method("POST")
                     .uri("/prove")
                     .header("content-type", "application/octet-stream")
@@ -536,6 +559,7 @@ mod tests {
         let response: axum::http::Response<_> = app
             .oneshot(
                 Request::builder()
+                    .header("host", "127.0.0.1:59833")
                     .uri("/health")
                     .body(Body::empty())
                     .unwrap(),
@@ -567,6 +591,7 @@ mod tests {
         let response: axum::http::Response<_> = app
             .oneshot(
                 Request::builder()
+                    .header("host", "127.0.0.1:59833")
                     .method("POST")
                     .uri("/prove")
                     .header("content-type", "application/octet-stream")
@@ -628,6 +653,7 @@ mod tests {
         assert_error(
             router(AppState::default()),
             Request::builder()
+                .header("host", "127.0.0.1:59833")
                 .method("POST")
                 .uri("/prove")
                 .header("content-type", "application/octet-stream")
@@ -645,6 +671,7 @@ mod tests {
         assert_error(
             router(state),
             Request::builder()
+                .header("host", "127.0.0.1:59833")
                 .method("POST")
                 .uri("/prove")
                 .header("content-type", "application/octet-stream")
@@ -667,6 +694,7 @@ mod tests {
         assert_error(
             router(state),
             Request::builder()
+                .header("host", "127.0.0.1:59833")
                 .method("POST")
                 .uri("/prove")
                 .header("content-type", "application/octet-stream")
@@ -714,6 +742,7 @@ mod tests {
         let response = router(state)
             .oneshot(
                 Request::builder()
+                    .header("host", "127.0.0.1:59833")
                     .method("POST")
                     .uri("/prove")
                     .header("content-type", "application/octet-stream")
@@ -759,6 +788,7 @@ mod tests {
         let response: axum::http::Response<_> = app
             .oneshot(
                 Request::builder()
+                    .header("host", "127.0.0.1:59833")
                     .uri("/health")
                     .body(Body::empty())
                     .unwrap(),
@@ -808,6 +838,7 @@ mod tests {
         let response: axum::http::Response<_> = app
             .oneshot(
                 Request::builder()
+                    .header("host", "127.0.0.1:59833")
                     .method("POST")
                     .uri("/prove")
                     .header("content-type", "application/octet-stream")
@@ -851,6 +882,7 @@ mod tests {
         let response: axum::http::Response<_> = app
             .oneshot(
                 Request::builder()
+                    .header("host", "127.0.0.1:59833")
                     .method("POST")
                     .uri("/prove")
                     .header("content-type", "application/octet-stream")
@@ -883,6 +915,7 @@ mod tests {
         let response: axum::http::Response<_> = app
             .oneshot(
                 Request::builder()
+                    .header("host", "127.0.0.1:59833")
                     .method("POST")
                     .uri("/prove")
                     .header("content-type", "application/octet-stream")
@@ -914,6 +947,7 @@ mod tests {
         let response: axum::http::Response<_> = app
             .oneshot(
                 Request::builder()
+                    .header("host", "127.0.0.1:59833")
                     .method("POST")
                     .uri("/prove")
                     .header("content-type", "application/octet-stream")
@@ -928,6 +962,44 @@ mod tests {
         assert!(
             popup_rx.try_recv().is_err(),
             "popup should not fire without Origin"
+        );
+    }
+
+    /// SEC-01a: the DNS-rebinding attack shape — a rebound page makes a same-origin (no-Origin)
+    /// request whose `Host` is the attacker's domain, not loopback. The loopback-Host guard must
+    /// 403 it BEFORE the Origin gate (which would otherwise auto-approve the missing Origin), and
+    /// the popup must never fire.
+    #[tokio::test]
+    async fn prove_rejects_forged_host_dns_rebinding() {
+        let (popup_tx, popup_rx) = std::sync::mpsc::channel();
+        let (state, _auth) = auth_state_with_popup(popup_tx);
+        let app = router(state);
+
+        let response: axum::http::Response<_> = app
+            .oneshot(
+                Request::builder()
+                    .header("host", "evil.com:59833") // rebound attacker domain, not loopback
+                    .method("POST")
+                    .uri("/prove")
+                    .header("content-type", "application/octet-stream")
+                    .body(Body::from(vec![0u8; 10]))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body = String::from_utf8_lossy(&body);
+        assert!(
+            body.contains("invalid_host"),
+            "rebinding must be rejected by the Host guard (got: {body})"
+        );
+        assert!(
+            popup_rx.try_recv().is_err(),
+            "popup must not fire for a forged-Host request"
         );
     }
 
@@ -947,6 +1019,7 @@ mod tests {
         let response: axum::http::Response<_> = app
             .oneshot(
                 Request::builder()
+                    .header("host", "127.0.0.1:59833")
                     .method("POST")
                     .uri("/prove")
                     .header("content-type", "application/octet-stream")
@@ -983,6 +1056,7 @@ mod tests {
         let response: axum::http::Response<_> = app
             .oneshot(
                 Request::builder()
+                    .header("host", "127.0.0.1:59833")
                     .method("POST")
                     .uri("/prove")
                     .header("content-type", "application/octet-stream")
@@ -1013,6 +1087,7 @@ mod tests {
         let response: axum::http::Response<_> = app
             .oneshot(
                 Request::builder()
+                    .header("host", "127.0.0.1:59833")
                     .method("POST")
                     .uri("/prove")
                     .header("content-type", "application/octet-stream")
@@ -1044,6 +1119,7 @@ mod tests {
         let response: axum::http::Response<_> = app
             .oneshot(
                 Request::builder()
+                    .header("host", "127.0.0.1:59833")
                     .method("POST")
                     .uri("/prove")
                     .header("content-type", "application/octet-stream")
@@ -1167,6 +1243,7 @@ mod tests {
         let response = app
             .oneshot(
                 Request::builder()
+                    .header("host", "127.0.0.1:59833")
                     .method("POST")
                     .uri("/prove")
                     .body(Body::from(vec![0u8; 10]))
@@ -1184,6 +1261,7 @@ mod tests {
         let response = app
             .oneshot(
                 Request::builder()
+                    .header("host", "127.0.0.1:59833")
                     .method("POST")
                     .uri("/prove")
                     .body(Body::empty())

--- a/packages/accelerator/core/src/server/host.rs
+++ b/packages/accelerator/core/src/server/host.rs
@@ -1,0 +1,135 @@
+//! Loopback `Host`/`:authority` allowlist (SEC-01a) — the DNS-rebinding keystone.
+//!
+//! Every request must carry a `Host` (HTTP/1.1) or `:authority` (HTTP/2) whose host-component is an
+//! exact loopback literal (`127.0.0.1` / `localhost` / `[::1]`) on the listener's expected port. A
+//! DNS-rebinding page's `Host` is the attacker's domain (`evil.com:59833`), not a loopback literal,
+//! so it is rejected here — *before* the Origin gate runs, and regardless of whether an Origin is
+//! present. This is behaviour-preserving: every real client (the SDK over HTTP `127.0.0.1:59833` and
+//! Safari HTTPS `127.0.0.1:59834`, curl/Node/CI) already sends a loopback Host on the right port.
+
+use axum::extract::Request;
+use axum::http::StatusCode;
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+
+/// True iff `authority` is exactly a loopback host on `expected_port`, with no userinfo.
+///
+/// Parsed via [`axum::http::uri::Authority`] (canonical authority grammar) rather than ad-hoc
+/// `split(':')`, so malformed/duplicate/IPv6 forms are handled correctly. Exact-port match is
+/// required (real clients always send the explicit port). Rejects userinfo (`user@host` could
+/// smuggle a host past a naive parser), non-loopback hosts, and all alternate numeric forms
+/// (`0.0.0.0`, decimal/hex IPs, `[::ffff:127.0.0.1]`).
+pub(crate) fn host_is_trusted(authority: &str, expected_port: u16) -> bool {
+    // Userinfo is never legitimate for a localhost service and is a classic host-smuggle vector.
+    if authority.contains('@') {
+        return false;
+    }
+    let Ok(parsed) = authority.parse::<axum::http::uri::Authority>() else {
+        return false;
+    };
+    // Exact port required — no "port absent" loophole (drops the weaker invariant; real clients
+    // send `127.0.0.1:59833`/`:59834`), and no wrong-port (`:59834` on the HTTP listener).
+    if parsed.port_u16() != Some(expected_port) {
+        return false;
+    }
+    // Normalise: lowercase, strip one trailing dot (`localhost.`), strip IPv6 brackets (`[::1]`→`::1`).
+    let host = parsed.host().trim_end_matches('.').to_ascii_lowercase();
+    let host = host
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host.as_str());
+    matches!(host, "127.0.0.1" | "localhost" | "::1")
+}
+
+/// Axum middleware gating every request on a trusted loopback `Host`/`:authority` for `expected_port`.
+///
+/// Reads the HTTP/1.1 `Host` header AND the HTTP/2 `:authority` (`req.uri().authority()`); if both
+/// are present and disagree it fails closed (can't tell which the peer meant); if neither is present
+/// it fails closed (HTTP/1.1 mandates `Host` and HTTP/2 mandates `:authority` — no real client omits
+/// both). Replies `403 invalid_host` with a minimal body that does not echo the offending host.
+pub(crate) async fn guard(expected_port: u16, req: Request, next: Next) -> Response {
+    let host_header = req
+        .headers()
+        .get(axum::http::header::HOST)
+        .and_then(|v| v.to_str().ok());
+    let authority = req.uri().authority().map(|a| a.as_str());
+
+    let value = match (host_header, authority) {
+        // Both present and disagreeing → fail closed.
+        (Some(h), Some(a)) if h != a => None,
+        (Some(h), _) => Some(h),
+        (None, Some(a)) => Some(a),
+        // Neither present → fail closed.
+        (None, None) => None,
+    };
+
+    match value {
+        Some(v) if host_is_trusted(v, expected_port) => next.run(req).await,
+        _ => (
+            StatusCode::FORBIDDEN,
+            axum::Json(serde_json::json!({ "error": "invalid_host" })),
+        )
+            .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::host_is_trusted;
+
+    const HTTP: u16 = 59833;
+    const HTTPS: u16 = 59834;
+
+    #[test]
+    fn accepts_real_client_authorities() {
+        // The exact forms the SDK + Safari emit (transport.ts: `127.0.0.1:{59833,59834}`).
+        assert!(host_is_trusted("127.0.0.1:59833", HTTP));
+        assert!(host_is_trusted("127.0.0.1:59834", HTTPS));
+        // Configurable host + IPv6 loopback the cert also covers.
+        assert!(host_is_trusted("localhost:59833", HTTP));
+        assert!(host_is_trusted("[::1]:59834", HTTPS));
+        // Case-insensitive + trailing dot.
+        assert!(host_is_trusted("LocalHost:59833", HTTP));
+        assert!(host_is_trusted("localhost.:59833", HTTP));
+    }
+
+    #[test]
+    fn rejects_dns_rebinding_and_external_hosts() {
+        assert!(!host_is_trusted("evil.com:59833", HTTP));
+        assert!(!host_is_trusted("attacker.localhost.com:59833", HTTP));
+    }
+
+    #[test]
+    fn rejects_wrong_port() {
+        // HTTPS authority on the HTTP listener and vice-versa.
+        assert!(!host_is_trusted("127.0.0.1:59834", HTTP));
+        assert!(!host_is_trusted("127.0.0.1:59833", HTTPS));
+        // No port at all → reject (no "port absent" loophole).
+        assert!(!host_is_trusted("127.0.0.1", HTTP));
+        assert!(!host_is_trusted("localhost", HTTP));
+    }
+
+    #[test]
+    fn rejects_alternate_numeric_and_mapped_forms() {
+        assert!(!host_is_trusted("0.0.0.0:59833", HTTP));
+        assert!(!host_is_trusted("2130706433:59833", HTTP)); // decimal 127.0.0.1
+        assert!(!host_is_trusted("[::ffff:127.0.0.1]:59833", HTTP)); // IPv4-mapped IPv6
+        assert!(!host_is_trusted("[::ffff:7f00:1]:59833", HTTP));
+    }
+
+    #[test]
+    fn rejects_userinfo_smuggling() {
+        // A naive `split(':')`/suffix parser could read the host as 127.0.0.1 here.
+        assert!(!host_is_trusted("evil.com@127.0.0.1:59833", HTTP));
+        assert!(!host_is_trusted("127.0.0.1@evil.com:59833", HTTP));
+        assert!(!host_is_trusted("user@localhost:59833", HTTP));
+    }
+
+    #[test]
+    fn rejects_malformed_authorities() {
+        assert!(!host_is_trusted("", HTTP));
+        assert!(!host_is_trusted(":59833", HTTP));
+        assert!(!host_is_trusted("127.0.0.1:notaport", HTTP));
+        assert!(!host_is_trusted("127.0.0.1:59833:extra", HTTP));
+    }
+}

--- a/packages/accelerator/src-tauri/src/server/tls.rs
+++ b/packages/accelerator/src-tauri/src/server/tls.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use tokio_rustls::TlsAcceptor;
 
-use accelerator_core::server::{bind_with_retry, router, AppState, HTTPS_PORT};
+use accelerator_core::server::{bind_with_retry, router_for_port, AppState, HTTPS_PORT};
 
 /// Start an HTTPS listener using the provided TLS config.
 /// Runs independently from HTTP — errors are logged but never crash the app.
@@ -16,9 +16,11 @@ pub async fn start_https(
     state: AppState,
     tls_config: Arc<tokio_rustls::rustls::ServerConfig>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    // Capture the shared bind-state flag before `router` consumes `state`.
+    // Capture the shared bind-state flag before `router_for_port` consumes `state`.
     let https_bound = state.https_bound.clone();
-    let app = router(state);
+    // Pass HTTPS_PORT so the loopback-Host guard accepts `127.0.0.1:59834` (Safari) and rejects a
+    // `:59833` authority replayed onto the HTTPS listener.
+    let app = router_for_port(state, HTTPS_PORT);
     let addr = SocketAddr::from(([127, 0, 0, 1], HTTPS_PORT));
     // Same restart race as the HTTP listener: an in-place update relaunches while
     // the old process still holds 59834. Retry first; only fall back to HTTP-only


### PR DESCRIPTION
PR-1 of `security-hardening-2026-06-09` — the DNS-rebinding keystone. **Behavior-preserving.**

## What
A fail-closed ingress guard (`core/src/server/host.rs`) rejects any request whose `Host` (HTTP/1.1) or `:authority` (HTTP/2) is not an exact loopback literal (`127.0.0.1`/`localhost`/`[::1]`) on the listener's **expected port**, *before* the Origin gate runs. `router(state)` → `router_for_port(state, expected_port)`; the HTTP listener passes `PORT` (59833), HTTPS passes `HTTPS_PORT` (59834).

## Why it's the keystone
DNS rebinding works because the server only ever checked `Origin`. A rebound `evil.com→127.0.0.1` page sends `Host: evil.com:59833` — not loopback — so it's now 403'd **regardless of Origin** (including the no-Origin same-origin case). This closes SEC-01's remote-web vector at the network boundary.

## Why behavior-preserving
Every real client already sends a loopback Host on the right port — verified the SDK emits `127.0.0.1:{59833,59834}` (transport), and curl/Node/CI callers target loopback. The existing 25 server request-tests get a default loopback Host (a one-time `req()`-style cleanup) and stay green.

## Tests
- `host.rs` bypass-rejection matrix: accepts the real SDK/Safari forms; rejects `evil.com`, wrong-port (`:59834` on the HTTP listener), `0.0.0.0`, decimal IP (`2130706433`), IPv4-mapped IPv6 (`[::ffff:127.0.0.1]`), **userinfo smuggling** (`evil.com@127.0.0.1`), absent/malformed.
- `prove_rejects_forged_host_dns_rebinding`: the attack shape (forged Host + no Origin) → 403 `invalid_host`, popup never fires.
- 127 core tests pass; clippy `-D warnings` clean (core + src-tauri).

Audited: PR-1's exact-port + RFC-authority-parser + h2-`:authority` contract was hardened across two reject rounds (codex + opus) before approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)