### PR TITLE
feat(accelerator): origin-gate hardening — deny-default, /health tier, localhost prompt-once (SEC-01b/c, SEC-04, SEC-05, PR-2)

### DIFF
--- a/packages/accelerator/README.md
+++ b/packages/accelerator/README.md
@@ -120,8 +120,9 @@ For the headless server binary (CI/testing), set `ALLOWED_ORIGINS=origin1,origin
 >
 > **Security caveats — read before deploying:**
 >
-> - The server listens on `127.0.0.1` only. On a single-tenant CI runner (GitHub-hosted) this is the auth boundary.
-> - `ALLOWED_ORIGINS` only gates **browser-driven** callers via the `Origin` header. Non-browser callers (curl, another process on the same host) can omit the header and bypass the check. This is acceptable for single-tenant CI but **unsafe for shared/self-hosted runners or any production environment**.
+> - The server listens on `127.0.0.1` only, AND (SEC-01a) every request must carry a loopback `Host`/`:authority` (`127.0.0.1` / `localhost` / `[::1]`) on the listener port — this closes the DNS-rebinding vector where a remote web page rebinds its domain to loopback. A forged/non-loopback `Host` is rejected with `403 invalid_host` before any route logic.
+> - **Deny-by-default (SEC-01c):** with `ALLOWED_ORIGINS` unset the server now **gates** browser origins and **denies any non-localhost origin** (localhost/`127.0.0.1`/`[::1]` stay auto-approved). Set `ALLOWED_ORIGINS=a,b` to pre-approve specific origins, or pass `--allow-all` / `ACCEL_ALLOW_ALL=1` to opt back into approving every origin (mutually exclusive with `ALLOWED_ORIGINS` → fails loud). Unset no longer means "approve everyone".
+> - Non-browser callers on the **same host** (curl, another local process) can still reach `/prove` (loopback `Host`, no `Origin`) — inherent to a localhost service. Acceptable for single-tenant CI but **unsafe for shared/self-hosted runners or any production environment**.
 > - The tarball is shipped with a SHA-256 sidecar only, not a cryptographic signature. Verify the checksum before extracting.
 > - Do not run this as a service. Do not expose it on a public interface. Do not use on a multi-tenant host.
 
@@ -165,7 +166,8 @@ The accelerator will download the matching `bb` binary on the first prove reques
 
 | Env var | Effect |
 |---|---|
-| `ALLOWED_ORIGINS` | Comma-separated list of origins pre-approved for browser-driven `/prove` calls. If unset, all browser origins are auto-approved on the headless server. |
+| `ALLOWED_ORIGINS` | Comma-separated browser origins pre-approved for `/prove`. **Unset = deny-by-default** (non-localhost denied; localhost auto-approved). Mutually exclusive with `--allow-all` / `ACCEL_ALLOW_ALL`. |
+| `ACCEL_ALLOW_ALL` | `1` or `true` → approve **all** browser origins (the pre-SEC-01 behavior). Opt-in; mutually exclusive with `ALLOWED_ORIGINS`. Prefer `ALLOWED_ORIGINS` for an explicit allowlist. (`--allow-all` CLI flag is equivalent.) |
 | `BB_BINARY_PATH` | Path to a pre-installed `bb` binary, bypassing the auto-download. |
 | `RUST_LOG` | Standard `tracing-subscriber` filter (e.g. `info`, `debug`). |
 

--- a/packages/accelerator/core/src/authorization.rs
+++ b/packages/accelerator/core/src/authorization.rs
@@ -222,12 +222,21 @@ impl AuthorizationManager {
             .is_some_and(|h| matches!(h.trim_end_matches('.'), "localhost" | "127.0.0.1" | "[::1]"))
     }
 
-    /// Returns true if the origin is approved (auto-approved or in the approved list).
+    /// Returns true if the origin is approved: in the persisted allowlist, OR — only when
+    /// `auto_approve_localhost` is set — an auto-approved localhost origin (SEC-04). With the flag
+    /// `false` (the desktop default) a localhost page is NOT silently trusted; it falls through to
+    /// the approval prompt (then, if remembered, joins `approved_origins`). The headless binary
+    /// passes `true` (no popup).
     ///
-    /// Both `origin` and `approved_origins` are [`CanonicalOrigin`], so canonicality is
-    /// guaranteed by the type — no comment-only precondition, no bypassable ingress.
-    pub fn is_approved(origin: &CanonicalOrigin, approved_origins: &[CanonicalOrigin]) -> bool {
-        Self::is_auto_approved(origin) || approved_origins.iter().any(|o| o == origin)
+    /// Both `origin` and `approved_origins` are [`CanonicalOrigin`], so canonicality is guaranteed by
+    /// the type — no comment-only precondition, no bypassable ingress.
+    pub fn is_approved(
+        origin: &CanonicalOrigin,
+        approved_origins: &[CanonicalOrigin],
+        auto_approve_localhost: bool,
+    ) -> bool {
+        (auto_approve_localhost && Self::is_auto_approved(origin))
+            || approved_origins.iter().any(|o| o == origin)
     }
 }
 
@@ -271,17 +280,30 @@ mod tests {
     #[test]
     fn is_approved_checks_both() {
         let approved = vec![co("https://playground.aztec-accelerator.dev")];
+        // auto_approve_localhost = true → localhost auto-approved.
         assert!(AuthorizationManager::is_approved(
             &co("http://localhost:5173"),
-            &approved
+            &approved,
+            true
         ));
+        // An explicitly-approved origin is approved regardless of the localhost flag.
         assert!(AuthorizationManager::is_approved(
             &co("https://playground.aztec-accelerator.dev"),
-            &approved
+            &approved,
+            false
         ));
+        // Unapproved non-localhost → denied.
         assert!(!AuthorizationManager::is_approved(
             &co("https://evil.com"),
-            &approved
+            &approved,
+            true
+        ));
+        // SEC-04: with the flag off (desktop default), localhost is NOT silently auto-approved —
+        // it must be prompted/remembered. This closes the silent local-page hole.
+        assert!(!AuthorizationManager::is_approved(
+            &co("http://localhost:5173"),
+            &approved,
+            false
         ));
     }
 

--- a/packages/accelerator/core/src/config.rs
+++ b/packages/accelerator/core/src/config.rs
@@ -53,6 +53,12 @@ pub struct AcceleratorConfig {
     /// None = never asked, Some(true) = auto-update, Some(false) = manual
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auto_update: Option<bool>,
+    /// SEC-04: when `true`, any `localhost`/`127.0.0.1`/`[::1]` origin is auto-approved with no
+    /// prompt. Defaults to **`false`** on desktop (a localhost page gets one remembered approval
+    /// prompt instead — closes the silent local-page hole); the headless binary sets it `true` (it
+    /// has no popup). Existing on-disk configs lacking the field deserialize to `false` (secure).
+    #[serde(default)]
+    pub auto_approve_localhost: bool,
 }
 
 impl Default for AcceleratorConfig {
@@ -63,6 +69,7 @@ impl Default for AcceleratorConfig {
             approved_origins: Vec::new(),
             speed: Speed::default(),
             auto_update: None,
+            auto_approve_localhost: false,
         }
     }
 }

--- a/packages/accelerator/core/src/server.rs
+++ b/packages/accelerator/core/src/server.rs
@@ -227,7 +227,39 @@ pub fn router_for_port(state: AppState, expected_port: u16) -> Router {
         .with_state(state)
 }
 
-async fn health(State(state): State<AppState>) -> impl IntoResponse {
+/// SEC-05: whether `/health` returns the detailed body (version / cached versions / `bb_available` /
+/// `https_port`) or a minimal liveness body. Detailed only for an ABSENT Origin (local non-browser
+/// callers: curl / Node / CI) or an APPROVED Origin (`is_approved` covers auto-approved localhost). A
+/// present-but-unapproved cross-origin caller gets the minimal body — so a random website learns at
+/// most "an accelerator exists", not its version or cached set. After SEC-01a every caller already
+/// has a loopback Host, so the Origin (not the Host) is the right discriminant here.
+fn health_is_detailed(state: &AppState, headers: &axum::http::HeaderMap) -> bool {
+    let Some(raw) = headers
+        .get(http::header::ORIGIN)
+        .and_then(|v| v.to_str().ok())
+    else {
+        return true; // no Origin → local, non-browser caller
+    };
+    let Some(origin) = crate::authorization::CanonicalOrigin::parse(raw) else {
+        return false; // malformed Origin → treat as untrusted → minimal
+    };
+    match state.config.as_ref() {
+        // Gated: detailed only for approved origins (is_approved includes auto-approved localhost).
+        Some(cfg) => AuthorizationManager::is_approved(&origin, &cfg.read().approved_origins),
+        // No gating config (headless --allow-all) → no fingerprint concern → serve detailed.
+        None => true,
+    }
+}
+
+async fn health(
+    State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
+) -> impl IntoResponse {
+    // SEC-05: starve cross-site fingerprinting — an unapproved cross-origin probe gets liveness only.
+    if !health_is_detailed(&state, &headers) {
+        return axum::Json(json!({ "status": "ok", "api_version": 1 }));
+    }
+
     let bundled = state
         .bundled_version
         .as_deref()
@@ -806,6 +838,70 @@ mod tests {
         assert!(versions
             .iter()
             .any(|v| v.as_str() == Some("5.0.0-nightly.20260307")));
+    }
+
+    /// SEC-05: a present-but-unapproved cross-origin `/health` probe gets a minimal liveness body
+    /// (no version/cache fingerprint); an auto-approved localhost origin gets the detailed body. The
+    /// no-Origin case (local tools, CI, `connectivity.test.ts`) stays detailed — covered above.
+    #[tokio::test]
+    async fn health_minimal_for_unapproved_cross_origin() {
+        let state = AppState {
+            core: Arc::new(HeadlessState {
+                bundled_version: Some("5.0.0-nightly.20260307".into()),
+                // Gated (config present, empty allowlist) → the Origin predicate applies.
+                config: Some(Arc::new(RwLock::new(
+                    crate::config::AcceleratorConfig::default(),
+                ))),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let app = router(state);
+
+        // Unapproved, non-localhost Origin → minimal body.
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .header("host", "127.0.0.1:59833")
+                    .header("origin", "https://evil.example")
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["status"], "ok");
+        assert!(
+            json.get("available_versions").is_none() && json.get("aztec_version").is_none(),
+            "must not leak version/cache to an unapproved origin (got: {json})"
+        );
+
+        // An auto-approved localhost Origin → detailed body.
+        let response2 = app
+            .oneshot(
+                Request::builder()
+                    .header("host", "127.0.0.1:59833")
+                    .header("origin", "http://localhost:5173")
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body2 = axum::body::to_bytes(response2.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json2: serde_json::Value = serde_json::from_slice(&body2).unwrap();
+        assert!(
+            json2.get("available_versions").is_some(),
+            "approved/localhost origin must get the detailed body (got: {json2})"
+        );
     }
 
     /// Helper: build an AppState with auth enabled and a mock popup callback.

--- a/packages/accelerator/core/src/server.rs
+++ b/packages/accelerator/core/src/server.rs
@@ -939,7 +939,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn prove_skips_auth_when_no_origin_header() {
+    async fn prove_allows_no_origin_only_with_trusted_loopback_host() {
         let (popup_tx, popup_rx) = std::sync::mpsc::channel();
         let (state, _auth) = auth_state_with_popup(popup_tx);
         let app = router(state);
@@ -957,7 +957,11 @@ mod tests {
             .await
             .unwrap();
 
-        // No Origin header = auto-approved (curl, same-origin)
+        // SEC-01b: a no-Origin request is allowed ONLY because it carries a trusted loopback Host
+        // (the SEC-01a guard vouched for it) — this is the legit curl/Node/local-script case. The
+        // DNS-rebinding no-Origin variant is 403'd at the Host guard (Host=evil.com), pinned by
+        // `prove_rejects_forged_host_dns_rebinding`. So the Host guard, not the Origin header, is the
+        // boundary for non-browser callers — the old "Origin omission = bypass" footgun is closed.
         assert_ne!(response.status(), StatusCode::FORBIDDEN);
         assert!(
             popup_rx.try_recv().is_err(),

--- a/packages/accelerator/core/src/server.rs
+++ b/packages/accelerator/core/src/server.rs
@@ -244,8 +244,15 @@ fn health_is_detailed(state: &AppState, headers: &axum::http::HeaderMap) -> bool
         return false; // malformed Origin → treat as untrusted → minimal
     };
     match state.config.as_ref() {
-        // Gated: detailed only for approved origins (is_approved includes auto-approved localhost).
-        Some(cfg) => AuthorizationManager::is_approved(&origin, &cfg.read().approved_origins),
+        // Gated: detailed only for approved origins (incl. auto-approved localhost when enabled).
+        Some(cfg) => {
+            let cfg = cfg.read();
+            AuthorizationManager::is_approved(
+                &origin,
+                &cfg.approved_origins,
+                cfg.auto_approve_localhost,
+            )
+        }
         // No gating config (headless --allow-all) → no fingerprint concern → serve detailed.
         None => true,
     }
@@ -848,10 +855,12 @@ mod tests {
         let state = AppState {
             core: Arc::new(HeadlessState {
                 bundled_version: Some("5.0.0-nightly.20260307".into()),
-                // Gated (config present, empty allowlist) → the Origin predicate applies.
-                config: Some(Arc::new(RwLock::new(
-                    crate::config::AcceleratorConfig::default(),
-                ))),
+                // Gated, with localhost auto-approve ON so the localhost probe below is "approved"
+                // and exercises the detailed tier (SEC-04 defaults this off; tested separately).
+                config: Some(Arc::new(RwLock::new(crate::config::AcceleratorConfig {
+                    auto_approve_localhost: true,
+                    ..Default::default()
+                }))),
                 ..Default::default()
             }),
             ..Default::default()
@@ -929,6 +938,15 @@ mod tests {
     async fn prove_auto_approves_localhost_origin() {
         let (popup_tx, popup_rx) = std::sync::mpsc::channel();
         let (state, _auth) = auth_state_with_popup(popup_tx);
+        // SEC-04: localhost auto-approve is now opt-in (desktop default is prompt-once). Enable it
+        // here to exercise the auto-approve path; the flag-OFF deny is pinned by
+        // `authorization::tests::is_approved_checks_both`.
+        state
+            .config
+            .as_ref()
+            .unwrap()
+            .write()
+            .auto_approve_localhost = true;
         let app = router(state);
 
         let response: axum::http::Response<_> = app

--- a/packages/accelerator/core/src/server/auth.rs
+++ b/packages/accelerator/core/src/server/auth.rs
@@ -48,7 +48,11 @@ pub(crate) async fn authorize_origin(
 
     let approved = state.config.as_ref().is_some_and(|cfg| {
         let cfg = cfg.read();
-        AuthorizationManager::is_approved(&origin, &cfg.approved_origins)
+        AuthorizationManager::is_approved(
+            &origin,
+            &cfg.approved_origins,
+            cfg.auto_approve_localhost,
+        )
     });
 
     if approved {

--- a/packages/accelerator/core/src/server/auth.rs
+++ b/packages/accelerator/core/src/server/auth.rs
@@ -1,8 +1,10 @@
 //! `/prove` origin authorization.
 //!
-//! Auto-approves localhost + persisted origins; otherwise popup-gates the request with a 60s
-//! auto-deny (`AUTH_DECISION_TIMEOUT`). Headless mode (no popup callback) denies unknown origins.
-//! Extracted from server.rs (Q2).
+//! Approves persisted origins (and localhost only when `auto_approve_localhost` is set — desktop
+//! default is prompt-once, SEC-04); otherwise popup-gates the request with a 60s auto-deny
+//! (`AUTH_DECISION_TIMEOUT`). Headless mode (no popup callback) denies unapproved origins. All
+//! requests are first constrained to a loopback `Host` (SEC-01a, `super::host`). Extracted from
+//! server.rs (Q2).
 
 use crate::authorization::{AuthDecision, AuthorizationManager, CanonicalOrigin};
 use crate::config;

--- a/packages/accelerator/server/src/main.rs
+++ b/packages/accelerator/server/src/main.rs
@@ -73,6 +73,9 @@ async fn main() {
             );
             let cfg = AcceleratorConfig {
                 approved_origins: origins,
+                // Headless has no approval popup → keep localhost auto-approved (SEC-04/R13). The
+                // prompt-once default is desktop-only; operators scope localhost via ALLOWED_ORIGINS.
+                auto_approve_localhost: true,
                 ..Default::default()
             };
             (

--- a/packages/accelerator/server/src/main.rs
+++ b/packages/accelerator/server/src/main.rs
@@ -3,8 +3,13 @@
 //! Runs the same Axum HTTP server as the Tauri app but without any display
 //! context. Used in CI for e2e testing against the native `bb` binary.
 //!
-//! Set `ALLOWED_ORIGINS=origin1,origin2` to restrict which origins can call `/prove`.
-//! When unset, all origins are auto-approved (no auth_manager).
+//! Origin gating (SEC-01c — deny-by-default):
+//!   • `ALLOWED_ORIGINS=a,b` — gate; pre-approve those origins.
+//!   • unset (default)       — gate with an empty allowlist: **deny every non-localhost origin**
+//!     (localhost/127.0.0.1/[::1] stay auto-approved). Unset no longer means "approve everyone".
+//!   • `--allow-all` / `ACCEL_ALLOW_ALL=1` — opt back into no gating (all origins). Mutually
+//!     exclusive with `ALLOWED_ORIGINS`.
+//! All requests are additionally constrained to a loopback `Host` (SEC-01a, see `core::server::host`).
 
 use accelerator_core::authorization::{AuthorizationManager, CanonicalOrigin};
 use accelerator_core::config::AcceleratorConfig;
@@ -38,31 +43,43 @@ async fn main() {
 
     tracing::info!("Starting headless accelerator server");
 
-    // If ALLOWED_ORIGINS is set, enforce origin gating with those origins pre-approved.
-    // Without it, auth_manager is None and all origins are auto-approved.
-    let (auth_manager, config) = if let Ok(origins_str) = std::env::var("ALLOWED_ORIGINS") {
-        // PRESENCE semantics (F-02): the var being SET enables gating even if it parses to an
-        // empty list — exactly as before. An empty list denies every NON-localhost browser origin;
-        // localhost/127.0.0.1/[::1] stay auto-approved via `AuthorizationManager::is_auto_approved`.
-        // Only an invalid NON-empty entry is fatal (operator security input → fail loud, don't drop).
-        let origins = match parse_allowed_origins_env(&origins_str) {
-            Ok(o) => o,
-            Err(e) => {
-                tracing::error!(error = %e, "Invalid ALLOWED_ORIGINS; refusing to start");
-                std::process::exit(1);
-            }
-        };
-        tracing::info!(origins = ?origins, "Restricting to allowed origins");
-        let cfg = AcceleratorConfig {
-            approved_origins: origins,
-            ..Default::default()
-        };
-        (
-            Some(Arc::new(AuthorizationManager::new())),
-            Some(Arc::new(RwLock::new(cfg))),
-        )
-    } else {
-        (None, None)
+    // Origin gating, three explicit modes (SEC-01c — deny-by-default):
+    //   • allow-all  (`--allow-all` or `ACCEL_ALLOW_ALL=1`)  → NO gating (auth_manager None). Opt-in.
+    //   • allowlist  (`ALLOWED_ORIGINS=a,b`)                  → gate; pre-approve those origins.
+    //   • default    (neither)                                → gate with an EMPTY allowlist: deny every
+    //     non-localhost origin (localhost/127.0.0.1/[::1] stay auto-approved). **Unset no longer means
+    //     "approve everyone"** — that was the SEC-01 headless fail-open.
+    // `--allow-all` and `ALLOWED_ORIGINS` express conflicting intent → mutually exclusive, fail loud.
+    let allow_all = std::env::args().skip(1).any(|a| a == "--allow-all")
+        || std::env::var("ACCEL_ALLOW_ALL").is_ok_and(|v| v == "1" || v == "true");
+    let allowed_origins_env = std::env::var("ALLOWED_ORIGINS").ok();
+
+    let (auth_manager, config) = match resolve_gating(allow_all, allowed_origins_env.as_deref()) {
+        Err(e) => {
+            tracing::error!(error = %e, "Invalid origin-gating configuration; refusing to start");
+            std::process::exit(1);
+        }
+        Ok(Gating::AllowAll) => {
+            tracing::warn!(
+                "Running with --allow-all: ALL browser origins can reach /prove without approval. \
+                 Prefer ALLOWED_ORIGINS to restrict, or leave both unset for localhost-only gating."
+            );
+            (None, None)
+        }
+        Ok(Gating::Gated(origins)) => {
+            tracing::info!(
+                origins = ?origins,
+                "Origin gating enabled (deny-by-default): localhost auto-approved; non-localhost must be in ALLOWED_ORIGINS"
+            );
+            let cfg = AcceleratorConfig {
+                approved_origins: origins,
+                ..Default::default()
+            };
+            (
+                Some(Arc::new(AuthorizationManager::new())),
+                Some(Arc::new(RwLock::new(cfg))),
+            )
+        }
     };
 
     let state = AppState::headless(HeadlessState::headless(
@@ -105,12 +122,76 @@ fn parse_allowed_origins_env(raw: &str) -> Result<Vec<CanonicalOrigin>, String> 
     Ok(out)
 }
 
+/// Resolved origin-gating mode (SEC-01c). Pure decision over the env inputs so it is unit-testable;
+/// the side effects (process exit / warn / state construction) stay in `main`.
+enum Gating {
+    /// `--allow-all` / `ACCEL_ALLOW_ALL` — no auth_manager, every origin reaches `/prove`.
+    AllowAll,
+    /// Gated with this (possibly empty) allowlist. Empty ⇒ deny non-localhost (localhost auto-approved).
+    Gated(Vec<CanonicalOrigin>),
+}
+
+/// Decide the gating mode. `--allow-all` and `ALLOWED_ORIGINS` are mutually exclusive (conflicting
+/// intent → `Err`). Unset+not-allow-all ⇒ `Gated([])` (deny-by-default). An invalid non-empty
+/// `ALLOWED_ORIGINS` entry ⇒ `Err`.
+fn resolve_gating(allow_all: bool, allowed_origins: Option<&str>) -> Result<Gating, String> {
+    match (allow_all, allowed_origins) {
+        (true, Some(_)) => Err(
+            "--allow-all / ACCEL_ALLOW_ALL is mutually exclusive with ALLOWED_ORIGINS".to_string(),
+        ),
+        (true, None) => Ok(Gating::AllowAll),
+        (false, Some(raw)) => Ok(Gating::Gated(parse_allowed_origins_env(raw)?)),
+        (false, None) => Ok(Gating::Gated(Vec::new())),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn co(s: &str) -> CanonicalOrigin {
         CanonicalOrigin::parse(s).unwrap()
+    }
+
+    #[test]
+    fn gating_allow_all_no_origins() {
+        assert!(matches!(resolve_gating(true, None), Ok(Gating::AllowAll)));
+    }
+
+    #[test]
+    fn gating_allow_all_conflicts_with_allowlist() {
+        assert!(resolve_gating(true, Some("https://a.com")).is_err());
+        assert!(resolve_gating(true, Some("")).is_err()); // even an empty allowlist is a conflict
+    }
+
+    #[test]
+    fn gating_default_is_deny_by_default_empty_allowlist() {
+        // The SEC-01c fix: neither flag → gated with an EMPTY allowlist (deny non-localhost).
+        match resolve_gating(false, None) {
+            Ok(Gating::Gated(v)) => assert!(v.is_empty()),
+            other => panic!("expected Gated([]), got {:?}", other.is_ok()),
+        }
+    }
+
+    #[test]
+    fn gating_allowlist_parses_origins() {
+        match resolve_gating(false, Some("https://a.com, http://b.com")) {
+            Ok(Gating::Gated(v)) => assert_eq!(v, vec![co("https://a.com"), co("http://b.com")]),
+            _ => panic!("expected Gated(origins)"),
+        }
+    }
+
+    #[test]
+    fn gating_present_but_empty_allowlist_still_gates() {
+        match resolve_gating(false, Some("")) {
+            Ok(Gating::Gated(v)) => assert!(v.is_empty()),
+            _ => panic!("present-but-empty must still gate (deny non-localhost)"),
+        }
+    }
+
+    #[test]
+    fn gating_invalid_origin_errs() {
+        assert!(resolve_gating(false, Some("not-a-url")).is_err());
     }
 
     #[test]


### PR DESCRIPTION
PR-2 of `security-hardening-2026-06-09`, layered on PR-1's Host guard (#338). Four findings.

- **SEC-01c — headless deny-by-default.** `resolve_gating()` → 3 modes: `allow-all` (`--allow-all`/`ACCEL_ALLOW_ALL`, opt-in, WARN), `allowlist` (`ALLOWED_ORIGINS`), default **gated with an empty allowlist** (deny non-localhost). Unset no longer means "approve everyone". `--allow-all` ⊥ `ALLOWED_ORIGINS` (fail loud). 6 unit tests on the pure `resolve_gating`.
- **SEC-01b — no-Origin contract.** Renamed/re-commented `prove_allows_no_origin_only_with_trusted_loopback_host`: a no-Origin `/prove` is allowed only because PR-1's Host guard already vouched for the loopback Host (legit curl/Node); the rebinding no-Origin variant is 403'd at the guard.
- **SEC-05 — two-tier `/health`.** Detailed body (version/cache/`bb_available`/`https_port`) only for an **absent** Origin (curl/Node/CI) or an **approved** Origin; a present-but-unapproved cross-origin probe gets minimal `{status, api_version}`. Cuts cross-site fingerprinting while keeping the no-Origin CI probes (`connectivity.test`, curl smoke) on the full body. Test: unapproved→minimal, localhost→detailed.
- **SEC-04 — localhost prompt-once (audit C1, the Critical).** `is_approved()` now takes `auto_approve_localhost`; localhost is auto-approved **only when set**. New config field defaults **false** on desktop (a localhost page gets one remembered approval prompt instead of silent access; existing on-disk configs deserialize to false). Headless sets it **true** (no popup). `is_approved_checks_both` pins flag-off-denies-localhost.

**Docs:** README headless section rewritten for deny-by-default + `--allow-all` + the Host guard; corrected the stale "all origins auto-approved" / "Origin omission bypasses" claims; auth.rs module doc fixed.

All Rust green locally: core 128, server 11, clippy `-D warnings` clean. Behavior-preserving except the three intentional security changes (deny-default, localhost prompt-once, /health minimal-for-unapproved). Audited across two reject rounds before approval (R1–R13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)