### PR TITLE
feat(accelerator): per-request opaque auth id (SEC-06, PR-3)

### DIFF
--- a/packages/accelerator/core/Cargo.lock
+++ b/packages/accelerator/core/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "url",
+ "uuid",
  "which",
 ]
 
@@ -1685,6 +1686,17 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "vcpkg"

--- a/packages/accelerator/core/Cargo.toml
+++ b/packages/accelerator/core/Cargo.toml
@@ -34,6 +34,7 @@ hex = "0.4"
 sha2 = "0.11"
 url = "2"
 time = "0.3"
+uuid = { version = "1.20.0", features = ["v4"] }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/packages/accelerator/core/src/authorization.rs
+++ b/packages/accelerator/core/src/authorization.rs
@@ -161,8 +161,23 @@ pub enum AuthDecision {
 /// Prevents popup/memory spam from a malicious site generating many subdomains.
 const MAX_PENDING_ORIGINS: usize = 10;
 
+/// A pending authorization awaiting the user's decision: its origin (for display + cleanup) and the
+/// receivers of every request piggybacking on it.
+struct PendingRequest {
+    origin: String,
+    senders: Vec<oneshot::Sender<AuthDecision>>,
+}
+
+#[derive(Default)]
+struct PendingState {
+    /// origin → its current pending `request_id` (so repeat requests from one origin piggyback).
+    by_origin: HashMap<String, String>,
+    /// `request_id` → the pending request. Decisions resolve by **id**, not origin (SEC-06).
+    by_request: HashMap<String, PendingRequest>,
+}
+
 pub struct AuthorizationManager {
-    pending: Mutex<HashMap<String, Vec<oneshot::Sender<AuthDecision>>>>,
+    state: Mutex<PendingState>,
 }
 
 impl Default for AuthorizationManager {
@@ -174,36 +189,57 @@ impl Default for AuthorizationManager {
 impl AuthorizationManager {
     pub fn new() -> Self {
         Self {
-            pending: Mutex::new(HashMap::new()),
+            state: Mutex::new(PendingState::default()),
         }
     }
 
     /// Register a pending authorization request for `origin`.
     ///
-    /// Returns `Ok((receiver, is_first))`. If `is_first` is true, the caller should
-    /// show the authorization popup. Otherwise, a popup is already showing and
-    /// this request will piggyback on that decision.
+    /// Returns `Ok((receiver, request_id, is_first))`. If `is_first` is true, the caller should show
+    /// the authorization popup carrying `request_id`. Otherwise a popup is already showing for this
+    /// origin and this request piggybacks on it (sharing the same `request_id` + decision).
     ///
-    /// Returns `Err` if the maximum number of pending origins is exceeded (DoS protection).
+    /// `request_id` is an **opaque, unguessable** UUID (SEC-06) — decisions are addressed by it, not
+    /// by origin string, so a caller that knows only an origin cannot resolve a concurrent request.
+    ///
+    /// Returns `Err` if the maximum number of pending requests is exceeded (DoS protection).
     pub fn request(
         &self,
         origin: &str,
-    ) -> Result<(oneshot::Receiver<AuthDecision>, bool), &'static str> {
+    ) -> Result<(oneshot::Receiver<AuthDecision>, String, bool), &'static str> {
         let (tx, rx) = oneshot::channel();
-        let mut pending = self.pending.lock();
-        let is_first = !pending.contains_key(origin);
-        if is_first && pending.len() >= MAX_PENDING_ORIGINS {
+        let mut st = self.state.lock();
+        // Piggyback on an existing pending request for this origin.
+        if let Some(request_id) = st.by_origin.get(origin).cloned() {
+            if let Some(req) = st.by_request.get_mut(&request_id) {
+                req.senders.push(tx);
+                return Ok((rx, request_id, false));
+            }
+        }
+        // New request.
+        if st.by_request.len() >= MAX_PENDING_ORIGINS {
             return Err("too many pending authorization requests");
         }
-        pending.entry(origin.to_string()).or_default().push(tx);
-        Ok((rx, is_first))
+        let request_id = uuid::Uuid::new_v4().to_string();
+        st.by_origin.insert(origin.to_string(), request_id.clone());
+        st.by_request.insert(
+            request_id.clone(),
+            PendingRequest {
+                origin: origin.to_string(),
+                senders: vec![tx],
+            },
+        );
+        Ok((rx, request_id, true))
     }
 
-    /// Resolve all pending requests for `origin` with the given decision.
-    pub fn resolve(&self, origin: &str, decision: AuthDecision) {
-        let mut pending = self.pending.lock();
-        if let Some(senders) = pending.remove(origin) {
-            for tx in senders {
+    /// Resolve the pending request identified by `request_id` with `decision`. Sends to every
+    /// piggybacking receiver and clears both maps. A no-op for an unknown/stale id (already resolved,
+    /// or a tampered/guessed id that matches nothing).
+    pub fn resolve(&self, request_id: &str, decision: AuthDecision) {
+        let mut st = self.state.lock();
+        if let Some(req) = st.by_request.remove(request_id) {
+            st.by_origin.remove(&req.origin);
+            for tx in req.senders {
                 let _ = tx.send(decision);
             }
         }
@@ -310,16 +346,15 @@ mod tests {
     #[tokio::test]
     async fn request_and_resolve() {
         let mgr = AuthorizationManager::new();
-        let (rx1, is_first1) = mgr.request("https://example.com").unwrap();
+        let (rx1, id1, is_first1) = mgr.request("https://example.com").unwrap();
         assert!(is_first1);
 
-        let (rx2, is_first2) = mgr.request("https://example.com").unwrap();
+        // A second request for the SAME origin piggybacks on the same request_id.
+        let (rx2, id2, is_first2) = mgr.request("https://example.com").unwrap();
         assert!(!is_first2);
+        assert_eq!(id1, id2, "same origin must share one request_id");
 
-        mgr.resolve(
-            "https://example.com",
-            AuthDecision::Allow { remember: true },
-        );
+        mgr.resolve(&id1, AuthDecision::Allow { remember: true });
 
         assert_eq!(rx1.await.unwrap(), AuthDecision::Allow { remember: true });
         assert_eq!(rx2.await.unwrap(), AuthDecision::Allow { remember: true });
@@ -328,8 +363,25 @@ mod tests {
     #[tokio::test]
     async fn resolve_deny() {
         let mgr = AuthorizationManager::new();
-        let (rx, _) = mgr.request("https://evil.com").unwrap();
-        mgr.resolve("https://evil.com", AuthDecision::Deny);
+        let (rx, id, _) = mgr.request("https://evil.com").unwrap();
+        mgr.resolve(&id, AuthDecision::Deny);
+        assert_eq!(rx.await.unwrap(), AuthDecision::Deny);
+    }
+
+    /// SEC-06: a decision addressed to a WRONG/unknown `request_id` must NOT resolve a pending
+    /// request. The old origin-keyed resolve let any caller that knew an origin resolve it; now the
+    /// opaque id is required, so a guessed/tampered id is a no-op.
+    #[tokio::test]
+    async fn resolve_ignores_wrong_request_id() {
+        let mgr = AuthorizationManager::new();
+        let (mut rx, id, _) = mgr.request("https://example.com").unwrap();
+        mgr.resolve("not-the-real-id", AuthDecision::Allow { remember: true });
+        assert!(
+            rx.try_recv().is_err(),
+            "a wrong request_id must not resolve the request"
+        );
+        // The correct id resolves it.
+        mgr.resolve(&id, AuthDecision::Deny);
         assert_eq!(rx.await.unwrap(), AuthDecision::Deny);
     }
 

--- a/packages/accelerator/core/src/server.rs
+++ b/packages/accelerator/core/src/server.rs
@@ -75,8 +75,9 @@ impl ServerStatus {
 pub type StatusCallback = Arc<dyn Fn(ServerStatus) + Send + Sync>;
 pub type VersionsChangedCallback = Arc<dyn Fn() + Send + Sync>;
 
-/// Callback to show the authorization popup window. Takes the origin string.
-pub type ShowAuthPopupCallback = Arc<dyn Fn(&str) + Send + Sync>;
+/// Callback to show the authorization popup window. Takes the origin + the opaque `request_id`
+/// (SEC-06) the popup must echo back to `respond_auth` so decisions resolve by id, not origin.
+pub type ShowAuthPopupCallback = Arc<dyn Fn(&str, &str) + Send + Sync>;
 
 /// The server-side core state — everything the headless `accelerator-server` needs, with no GUI
 /// coupling. Lives behind an `Arc` in [`AppState`] so cloning the state is cheap (fixes the main.rs
@@ -723,12 +724,15 @@ mod tests {
         .await;
 
         // origin_denied (403) — auth + deny
-        let (popup_tx, _popup_rx) = std::sync::mpsc::channel();
+        let (popup_tx, popup_rx) = std::sync::mpsc::channel();
         let (state, auth) = auth_state_with_popup(popup_tx);
         let auth_clone = auth.clone();
         tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(50)).await;
-            auth_clone.resolve("https://evil.com", crate::authorization::AuthDecision::Deny);
+            let (_origin, request_id) =
+                tokio::task::spawn_blocking(move || popup_rx.recv().unwrap())
+                    .await
+                    .unwrap();
+            auth_clone.resolve(&request_id, crate::authorization::AuthDecision::Deny);
         });
         assert_error(
             router(state),
@@ -913,9 +917,10 @@ mod tests {
         );
     }
 
-    /// Helper: build an AppState with auth enabled and a mock popup callback.
+    /// Helper: build an AppState with auth enabled and a mock popup callback. The callback forwards
+    /// `(origin, request_id)` so tests can assert the origin AND resolve by the opaque id (SEC-06).
     fn auth_state_with_popup(
-        popup_tx: std::sync::mpsc::Sender<String>,
+        popup_tx: std::sync::mpsc::Sender<(String, String)>,
     ) -> (AppState, Arc<crate::authorization::AuthorizationManager>) {
         let auth = Arc::new(crate::authorization::AuthorizationManager::new());
         let auth_for_state = auth.clone();
@@ -926,8 +931,8 @@ mod tests {
                 config: Some(Arc::new(RwLock::new(cfg))),
                 ..Default::default()
             }),
-            show_auth_popup: Some(Arc::new(move |origin: &str| {
-                let _ = popup_tx.send(origin.to_string());
+            show_auth_popup: Some(Arc::new(move |origin: &str, request_id: &str| {
+                let _ = popup_tx.send((origin.to_string(), request_id.to_string()));
             })),
             ..Default::default()
         };
@@ -983,12 +988,13 @@ mod tests {
         let auth_clone = auth.clone();
         let (popup_seen_tx, popup_seen_rx) = tokio::sync::oneshot::channel::<String>();
         tokio::spawn(async move {
-            let origin = tokio::task::spawn_blocking(move || popup_rx.recv().unwrap())
-                .await
-                .unwrap();
-            let _ = popup_seen_tx.send(origin.clone());
+            let (origin, request_id) =
+                tokio::task::spawn_blocking(move || popup_rx.recv().unwrap())
+                    .await
+                    .unwrap();
+            let _ = popup_seen_tx.send(origin);
             auth_clone.resolve(
-                &origin,
+                &request_id,
                 crate::authorization::AuthDecision::Allow { remember: false },
             );
         });
@@ -1015,15 +1021,18 @@ mod tests {
 
     #[tokio::test]
     async fn prove_returns_403_when_origin_denied() {
-        let (popup_tx, _popup_rx) = std::sync::mpsc::channel();
+        let (popup_tx, popup_rx) = std::sync::mpsc::channel();
         let (state, auth) = auth_state_with_popup(popup_tx);
         let app = router(state);
 
-        // Auto-deny after popup fires
+        // Auto-deny by request_id once the popup fires (SEC-06: resolve by opaque id, not origin).
         let auth_clone = auth.clone();
         tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(50)).await;
-            auth_clone.resolve("https://evil.com", crate::authorization::AuthDecision::Deny);
+            let (_origin, request_id) =
+                tokio::task::spawn_blocking(move || popup_rx.recv().unwrap())
+                    .await
+                    .unwrap();
+            auth_clone.resolve(&request_id, crate::authorization::AuthDecision::Deny);
         });
 
         let response: axum::http::Response<_> = app

--- a/packages/accelerator/core/src/server/auth.rs
+++ b/packages/accelerator/core/src/server/auth.rs
@@ -74,7 +74,7 @@ pub(crate) async fn authorize_origin(
     }
 
     tracing::info!(origin = %origin, "Origin not approved, requesting authorization");
-    let (rx, is_first) = auth_manager.request(origin.as_str()).map_err(|_| {
+    let (rx, request_id, is_first) = auth_manager.request(origin.as_str()).map_err(|_| {
         tracing::warn!(origin = %origin, "Too many pending authorization requests");
         (
             StatusCode::TOO_MANY_REQUESTS,
@@ -87,7 +87,7 @@ pub(crate) async fn authorize_origin(
 
     if is_first {
         if let Some(ref show_popup) = state.show_auth_popup {
-            show_popup(origin.as_str());
+            show_popup(origin.as_str(), &request_id);
         }
     }
 
@@ -95,7 +95,7 @@ pub(crate) async fn authorize_origin(
         .await
         .map_err(|_| {
             tracing::warn!(origin = %origin, "Authorization timed out");
-            auth_manager.resolve(origin.as_str(), AuthDecision::Deny);
+            auth_manager.resolve(&request_id, AuthDecision::Deny);
             (
                 StatusCode::FORBIDDEN,
                 json_error("authorization_timeout", "Authorization request timed out"),

--- a/packages/accelerator/e2e/authorize.spec.ts
+++ b/packages/accelerator/e2e/authorize.spec.ts
@@ -28,14 +28,16 @@ test("shows decoded origin from URL params", async ({ page }) => {
 });
 
 test("allow calls respond_auth with correct args", async ({ page }) => {
-  await page.goto("/authorize.html?origin=https%3A%2F%2Fexample.com");
+  await page.goto("/authorize.html?origin=https%3A%2F%2Fexample.com&requestId=req-abc");
 
   await page.getByRole("button", { name: "Allow" }).click();
 
   const calls = await callsFor(page, "respond_auth");
   expect(calls.length).toBe(1);
+  // SEC-06: the opaque requestId from the URL is echoed back so the server resolves by id.
   // "Remember this site" checkbox defaults to checked
   expect(calls[0].args).toEqual({
+    requestId: "req-abc",
     origin: "https://example.com",
     allowed: true,
     remember: true,
@@ -43,7 +45,7 @@ test("allow calls respond_auth with correct args", async ({ page }) => {
 });
 
 test("deny calls respond_auth with correct args", async ({ page }) => {
-  await page.goto("/authorize.html?origin=https%3A%2F%2Fexample.com");
+  await page.goto("/authorize.html?origin=https%3A%2F%2Fexample.com&requestId=req-abc");
 
   await page.getByRole("button", { name: "Deny" }).click();
 
@@ -51,6 +53,7 @@ test("deny calls respond_auth with correct args", async ({ page }) => {
   expect(calls.length).toBe(1);
   // "Remember this site" checkbox defaults to checked — deny still sends remember: true
   expect(calls[0].args).toEqual({
+    requestId: "req-abc",
     origin: "https://example.com",
     allowed: false,
     remember: true,
@@ -69,7 +72,7 @@ test("buttons disabled after invoke prevents double-click", async ({ page }) => 
 });
 
 test("uncheck remember changes allow args", async ({ page }) => {
-  await page.goto("/authorize.html?origin=https%3A%2F%2Ftest.com");
+  await page.goto("/authorize.html?origin=https%3A%2F%2Ftest.com&requestId=req-xyz");
 
   // Uncheck "Remember this site"
   await page.locator("#remember").uncheck();
@@ -77,6 +80,7 @@ test("uncheck remember changes allow args", async ({ page }) => {
 
   const calls = await callsFor(page, "respond_auth");
   expect(calls[0].args).toEqual({
+    requestId: "req-xyz",
     origin: "https://test.com",
     allowed: true,
     remember: false,

--- a/packages/accelerator/src-tauri/Cargo.lock
+++ b/packages/accelerator/src-tauri/Cargo.lock
@@ -24,6 +24,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "url",
+ "uuid",
  "which",
 ]
 

--- a/packages/accelerator/src-tauri/frontend/authorize.html
+++ b/packages/accelerator/src-tauri/frontend/authorize.html
@@ -32,6 +32,9 @@
   <script>
     const params = new URLSearchParams(window.location.search);
     const origin = params.get("origin") || "unknown";
+    // SEC-06: the opaque request id the server issued for this popup. Echoed back to respond_auth so
+    // the decision resolves by id (not origin) — a stale/forged popup can't resolve another request.
+    const requestId = params.get("requestId") || "";
     document.getElementById("origin").textContent = origin;
 
     // Fetch recognition info; render badge if the origin is on the curated list.
@@ -47,7 +50,7 @@
 
     function respond(allowed) {
       const remember = document.getElementById("remember").checked;
-      return invoke("respond_auth", { origin, allowed, remember });
+      return invoke("respond_auth", { requestId, origin, allowed, remember });
     }
 
     wireButton("allow", {

--- a/packages/accelerator/src-tauri/src/commands.rs
+++ b/packages/accelerator/src-tauri/src/commands.rs
@@ -1,4 +1,4 @@
-use crate::authorization::{AuthDecision, AuthorizationManager, CanonicalOrigin};
+use crate::authorization::{AuthDecision, AuthorizationManager};
 use crate::config::{self, AcceleratorConfig};
 use crate::verified_sites::VerifiedSitesRegistry;
 use parking_lot::RwLock;
@@ -108,31 +108,24 @@ pub fn get_verified_info(
 pub fn respond_auth(
     app: tauri::AppHandle,
     auth: tauri::State<'_, AuthState>,
+    request_id: String,
     origin: String,
     allowed: bool,
     remember: bool,
 ) {
-    match CanonicalOrigin::parse(&origin) {
-        Some(canonical) => {
-            let decision = if allowed {
-                AuthDecision::Allow { remember }
-            } else {
-                AuthDecision::Deny
-            };
-            auth.resolve(canonical.as_str(), decision);
-        }
-        None => {
-            // F-02: a non-canonical origin can't match any pending request (keys are canonical), so a
-            // tampered popup payload is never honored as Allow. This `resolve` is a no-op on the real
-            // (canonical-keyed) request, which then denies via its 60s timeout. Immediate deny would
-            // need a server-issued opaque request id (or a typed pending map) — deferred; the pending
-            // map typing was scoped out of F-02. (codex post-impl PR-1, Low)
-            tracing::warn!(origin = %origin, "respond_auth received a non-canonical origin; denying");
-            auth.resolve(&origin, AuthDecision::Deny);
-        }
-    }
+    let decision = if allowed {
+        AuthDecision::Allow { remember }
+    } else {
+        AuthDecision::Deny
+    };
+    // SEC-06: resolve by the opaque `request_id`, NOT the origin. A tampered/guessed payload with a
+    // wrong id is a harmless no-op (it can't resolve a *different* concurrent request, and the old
+    // origin-keyed resolve could); the real request then denies via its 60s timeout. The `origin` is
+    // used only to close the matching popup window (and, server-side in the `/prove` handler, to
+    // persist an `Allow { remember }`).
+    auth.resolve(&request_id, decision);
 
-    // Close the authorization popup window
+    // Close the authorization popup window (labelled by origin, matching windows.rs).
     let label = format!("auth-{}", sanitize_window_label(&origin));
     if let Some(window) = app.get_webview_window(&label) {
         let _ = window.close();

--- a/packages/accelerator/src-tauri/src/main.rs
+++ b/packages/accelerator/src-tauri/src/main.rs
@@ -387,10 +387,11 @@ fn main() {
             let app_handle_for_auth = app.handle().clone();
             let auth_manager_for_timeout = auth_manager.clone();
             let show_auth_popup: aztec_accelerator::server::ShowAuthPopupCallback =
-                Arc::new(move |origin: &str| {
+                Arc::new(move |origin: &str, request_id: &str| {
                     windows::show_auth_popup_window(
                         &app_handle_for_auth,
                         origin,
+                        request_id,
                         &auth_manager_for_timeout,
                     );
                 });

--- a/packages/accelerator/src-tauri/src/windows.rs
+++ b/packages/accelerator/src-tauri/src/windows.rs
@@ -77,10 +77,16 @@ pub fn open_settings_window(app: &AppHandle) {
 pub fn show_auth_popup_window(
     app: &AppHandle,
     origin: &str,
+    request_id: &str,
     auth_manager: &Arc<AuthorizationManager>,
 ) {
     let label = format!("auth-{}", commands::sanitize_window_label(origin));
-    let url = format!("authorize.html?origin={}", urlencoding::encode(origin));
+    // SEC-06: carry the opaque request_id so the popup echoes it back to respond_auth.
+    let url = format!(
+        "authorize.html?origin={}&requestId={}",
+        urlencoding::encode(origin),
+        urlencoding::encode(request_id)
+    );
     if open_or_focus_window(
         app,
         WindowConfig {
@@ -103,6 +109,7 @@ pub fn show_auth_popup_window(
     // origin was already resolved by respond_auth (senders already consumed).
     let app_handle = app.clone();
     let origin_owned = origin.to_string();
+    let request_id_owned = request_id.to_string();
     let auth_manager = auth_manager.clone();
     tauri::async_runtime::spawn(async move {
         tokio::time::sleep(aztec_accelerator::server::AUTH_DECISION_TIMEOUT).await;
@@ -110,8 +117,8 @@ pub fn show_auth_popup_window(
         if let Some(window) = app_handle.get_webview_window(&label) {
             let _ = window.close();
         }
-        // Always try to resolve — no-op if already resolved by user click
-        auth_manager.resolve(&origin_owned, AuthDecision::Deny);
+        // SEC-06: resolve by request_id — no-op if respond_auth already consumed it.
+        auth_manager.resolve(&request_id_owned, AuthDecision::Deny);
         tracing::debug!(origin = %origin_owned, "Authorization timeout cleanup");
     });
 }


### PR DESCRIPTION
PR-3 of `security-hardening-2026-06-09`. **SEC-06** — addresses the Medium where auth decisions resolved by origin string (a malformed-origin Deny silently missed, and two same-origin requests shared one decision channel).

## What
`AuthorizationManager` now resolves by an **opaque, unguessable UUID** per request — a dual map (`origin→request_id` for piggyback, `request_id→{origin,senders}` for resolution). A tampered/guessed popup payload with a wrong id is a harmless no-op; it can't resolve a *different* concurrent request.

Cross-package, one cohesive change:
- `request()` → `(rx, request_id, is_first)`; `resolve(request_id, …)`.
- `ShowAuthPopupCallback` gains `request_id`; the `/prove` gate (auth.rs) + the `windows.rs` 60s timeout + the desktop wiring all resolve by id.
- `show_auth_popup_window` + `authorize.html` thread `requestId` through the popup URL; `respond_auth(request_id, origin, allowed, remember)` resolves by id and drops the now-moot F-02 non-canonical-origin workaround.

## Tests
- `resolve_ignores_wrong_request_id` (SEC-06 core) — a wrong id does NOT resolve a pending request; piggyback shares one id.
- The popup-resolving server tests capture the id from the popup callback and resolve by it.
- Playwright asserts the popup echoes `requestId` back to `respond_auth`.
- Local: **core 129 + src-tauri 19 pass, clippy `-D warnings` clean, Playwright 12 pass.** The WebDriver auth-flow E2E exercises the real end-to-end popup→id→resolve path.

Adds `uuid` v1 (cargo dep; the npm min-age gate doesn't apply to cargo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)