### PR TITLE
feat(accelerator): tarball decomp cap + fail-closed legacy ca.key + SEC-02 note (SEC-07, SEC-08, PR-5)

### DIFF
--- a/packages/accelerator/core/src/versions/downloader.rs
+++ b/packages/accelerator/core/src/versions/downloader.rs
@@ -213,15 +213,61 @@ pub(crate) fn install_version_dir(
 
 /// Extract the `bb` binary from a gzipped tarball.
 ///
+/// Hard ceiling on the DECOMPRESSED tarball size (SEC-07). The compressed download is already capped
+/// at 64 MB (`MAX_DOWNLOAD_BYTES`); 512 MB decompressed is ~8x that — well above any legit `bb` (a
+/// ≤64 MB-compressed binary inflates to at most a few hundred MB) yet far below a gzip bomb's
+/// potential (64 MB of zeros → tens of GB). Without it, `entry.unpack` would stream a bomb to disk.
+const MAX_DECOMPRESSED_BYTES: u64 = 512 * 1024 * 1024;
+
+/// A reader that errors once more than `cap` bytes have passed through it — the real backstop against
+/// a decompression bomb (the per-entry `header().size()` is attacker-controlled, so it is necessary
+/// but not sufficient on its own).
+struct CappedReader<R> {
+    inner: R,
+    read: u64,
+    cap: u64,
+}
+
+impl<R: std::io::Read> std::io::Read for CappedReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        self.read = self.read.saturating_add(n as u64);
+        if self.read > self.cap {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "decompressed tarball exceeds {} byte cap (decompression bomb?)",
+                    self.cap
+                ),
+            ));
+        }
+        Ok(n)
+    }
+}
+
 /// Looks for an entry named `bb` (at any nesting level) in the archive.
 pub(crate) fn extract_bb_from_tarball(
     data: &[u8],
     dest: &std::path::Path,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    extract_bb_from_tarball_capped(data, dest, MAX_DECOMPRESSED_BYTES)
+}
+
+/// Inner, cap-parameterized for testing (a real 512 MB bomb is impractical to build in a unit test).
+fn extract_bb_from_tarball_capped(
+    data: &[u8],
+    dest: &std::path::Path,
+    cap: u64,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
     use flate2::read::GzDecoder;
     use tar::Archive;
 
-    let decoder = GzDecoder::new(data);
+    // SEC-07: cap cumulative decompressed bytes so a gzip bomb can't fill the disk via `unpack`.
+    let decoder = CappedReader {
+        inner: GzDecoder::new(data),
+        read: 0,
+        cap,
+    };
     let mut archive = Archive::new(decoder);
 
     for entry in archive.entries()? {
@@ -237,10 +283,81 @@ pub(crate) fn extract_bb_from_tarball(
                 )
                 .into());
             }
+            // Cheap pre-check: reject a header DECLARING more than the cap. The CappedReader is the
+            // real backstop against a lying header that under-declares then over-streams.
+            let declared = entry.header().size()?;
+            if declared > cap {
+                return Err(
+                    format!("bb entry declares {declared} bytes, exceeds {cap} byte cap").into(),
+                );
+            }
             entry.unpack(dest.join(bb_binary_name()))?;
             return Ok(());
         }
     }
 
     Err("bb binary not found in tarball".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Build a gzipped tar with the given entries: `(path, size, byte)`.
+    fn make_targz(entries: &[(&str, usize, u8)]) -> Vec<u8> {
+        let mut tar_buf = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut tar_buf);
+            for (path, size, byte) in entries {
+                let data = vec![*byte; *size];
+                let mut header = tar::Header::new_gnu();
+                header.set_size(*size as u64);
+                header.set_entry_type(tar::EntryType::Regular);
+                header.set_mode(0o755);
+                header.set_cksum();
+                builder.append_data(&mut header, path, &data[..]).unwrap();
+            }
+            builder.finish().unwrap();
+        }
+        let mut gz = Vec::new();
+        let mut enc = flate2::write::GzEncoder::new(&mut gz, flate2::Compression::default());
+        enc.write_all(&tar_buf).unwrap();
+        enc.finish().unwrap();
+        gz
+    }
+
+    #[test]
+    fn extracts_bb_within_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let entry = format!("barretenberg/{}", bb_binary_name());
+        let gz = make_targz(&[(&entry, 4096, 0)]);
+        extract_bb_from_tarball_capped(&gz, dir.path(), 1024 * 1024).unwrap();
+        let out = dir.path().join(bb_binary_name());
+        assert_eq!(std::fs::metadata(&out).unwrap().len(), 4096);
+    }
+
+    #[test]
+    fn rejects_bb_entry_declaring_over_cap() {
+        // The per-entry declared-size pre-check: a 2 MB bb against a 1 MB cap is rejected before unpack.
+        let dir = tempfile::tempdir().unwrap();
+        let entry = format!("barretenberg/{}", bb_binary_name());
+        let gz = make_targz(&[(&entry, 2 * 1024 * 1024, 0)]);
+        let err = extract_bb_from_tarball_capped(&gz, dir.path(), 1024 * 1024).unwrap_err();
+        assert!(err.to_string().contains("cap"), "got: {err}");
+        assert!(!dir.path().join(bb_binary_name()).exists());
+    }
+
+    #[test]
+    fn capped_reader_trips_on_cumulative_decompressed_bytes() {
+        // The real bomb backstop: a junk entry BEFORE bb whose data alone exceeds the cap → the
+        // CappedReader aborts as the archive advances past it (proves the running counter, not just
+        // the per-entry declared size, is enforced).
+        let dir = tempfile::tempdir().unwrap();
+        let bb = format!("x/{}", bb_binary_name());
+        let gz = make_targz(&[("junk.bin", 2 * 1024 * 1024, 7), (&bb, 16, 0)]);
+        let err = extract_bb_from_tarball_capped(&gz, dir.path(), 1024 * 1024).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("cap") || msg.contains("bomb"), "got: {msg}");
+    }
 }

--- a/packages/accelerator/core/src/versions/mod.rs
+++ b/packages/accelerator/core/src/versions/mod.rs
@@ -281,11 +281,19 @@ pub(crate) fn sha256_hex(data: &[u8]) -> String {
 
 /// Fetch the expected SHA-256 digest for a release asset from the GitHub API.
 ///
-/// GitHub stores a `digest` field (e.g. `"sha256:abcd..."`) on every release asset.
-/// This doesn't protect against a compromised GitHub account (attacker can re-upload),
-/// but catches download corruption and CDN issues.
+/// GitHub stores a `digest` field (e.g. `"sha256:abcd..."`) on every release asset. This catches
+/// download corruption and CDN issues.
 ///
-/// TODO: Verify against upstream signatures when Aztec starts signing releases.
+/// SECURITY (SEC-02, deferred — circular trust): the digest is fetched from the SAME GitHub control
+/// plane (`api.github.com`) that serves the binary, so an attacker who compromises the upstream
+/// release (account/CI) — or MITMs both endpoints — can serve a malicious `bb` tarball AND a matching
+/// digest; the check passes and the binary is installed + executed. A pure network MITM is blocked
+/// (both hops are HTTPS), but supply-chain compromise is NOT. The real fix is verifying an UPSTREAM
+/// PUBLISHER SIGNATURE pinned in the shipped app (minisign/cosign/TUF), the way our own auto-updater
+/// already does — but Aztec does not yet sign `bb` releases. Pinning known-good digests in the app is
+/// NOT a workaround: barretenberg nightlies ship EVERY night, so a pinned-digest manifest would be
+/// perpetually stale. Revisit once Aztec signs `bb`.
+/// Tracking: `implementations-plan/security-hardening-2026-06-09` (SEC-02) + a GitHub issue.
 pub(crate) async fn fetch_github_asset_digest(
     version: &str,
     asset_name: &str,

--- a/packages/accelerator/src-tauri/src/certs.rs
+++ b/packages/accelerator/src-tauri/src/certs.rs
@@ -178,23 +178,42 @@ pub fn generate_and_save() -> Result<(), Box<dyn std::error::Error + Send + Sync
 /// Delete a legacy on-disk CA private key (`ca.key`) left by older installs — it is the readable
 /// mint-any-cert primitive (audit HIGH). The CA *cert* anchor stays trusted but, with no key, can
 /// sign nothing. Idempotent; safe on installs that never had one.
-pub fn migrate_legacy_ca_key() {
-    migrate_legacy_ca_key_at(&ca_key_path());
+pub fn migrate_legacy_ca_key() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    migrate_legacy_ca_key_at(&ca_key_path())
 }
 
-/// Inner, path-parameterized for testability.
-fn migrate_legacy_ca_key_at(ca_key: &std::path::Path) {
-    if ca_key.exists() {
+/// Inner, path-parameterized for testability. **SEC-08, fail-closed:** returns `Err` if `ca.key`
+/// still exists after the removal attempt (retried once for a transient lock/AV scan). The caller
+/// MUST treat that as a security failure and NOT bring up Safari HTTPS — a live HTTPS server next to
+/// a readable mint-any-cert key + its still-trusted anchor is the exact exposure we're closing.
+fn migrate_legacy_ca_key_at(
+    ca_key: &std::path::Path,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    if !ca_key.exists() {
+        return Ok(()); // never had one / already gone — the common path
+    }
+    for attempt in 0..2 {
         match std::fs::remove_file(ca_key) {
-            Ok(_) => tracing::warn!(
-                "Removed legacy on-disk CA key (ca.key) — the mint-any-cert primitive is gone. The \
-                 legacy keychain CA anchor (now keyless) remains; use Settings to fully remove it."
-            ),
-            Err(e) => {
-                tracing::error!(error = %e, "Failed to delete legacy ca.key — the readable minting key persists")
+            Ok(_) => break,
+            Err(e) if attempt == 1 => {
+                tracing::error!(error = %e, "Failed to delete legacy ca.key after retry");
             }
+            Err(_) => std::thread::sleep(std::time::Duration::from_millis(50)),
         }
     }
+    // Re-check: fail closed if it persists (a failed remove_file, an immutable flag, a perms issue).
+    if ca_key.exists() {
+        return Err(
+            "legacy ca.key persists after removal attempt — the readable mint-any-cert key is still \
+             on disk; refusing to proceed"
+                .into(),
+        );
+    }
+    tracing::warn!(
+        "Removed legacy on-disk CA key (ca.key) — the mint-any-cert primitive is gone. The legacy \
+         keychain CA anchor (now keyless) remains; use Settings to fully remove it."
+    );
+    Ok(())
 }
 
 /// Write a PEM file **atomically** with `0o600` perms: write a temp sibling (owner-only), fsync, then
@@ -577,12 +596,37 @@ mod tests {
         std::fs::write(&ca_key, "legacy key").unwrap();
         std::fs::write(&leaf, "leaf cert").unwrap();
 
-        migrate_legacy_ca_key_at(&ca_key);
+        migrate_legacy_ca_key_at(&ca_key)
+            .expect("removal of an existing legacy key should succeed");
 
         assert!(!ca_key.exists(), "legacy ca.key must be deleted");
         assert!(leaf.exists(), "the served leaf must be untouched");
 
-        // Idempotent: a second call on an absent key is a no-op (no panic).
-        migrate_legacy_ca_key_at(&ca_key);
+        // Idempotent: a second call on an absent key is Ok (no panic, no error).
+        migrate_legacy_ca_key_at(&ca_key).expect("absent key is Ok");
+    }
+
+    /// SEC-08: if the legacy key cannot be removed, migration FAILS (so the caller skips Safari HTTPS)
+    /// rather than proceeding with the readable mint-any-cert key still on disk.
+    #[cfg(unix)]
+    #[test]
+    fn migrate_fails_closed_when_key_cannot_be_removed() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("locked");
+        std::fs::create_dir(&dir).unwrap();
+        let ca_key = dir.join("ca.key");
+        std::fs::write(&ca_key, "legacy key").unwrap();
+        // Read+execute only on the PARENT dir → `remove_file` inside it fails (needs dir-write).
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o500)).unwrap();
+
+        let result = migrate_legacy_ca_key_at(&ca_key);
+
+        // Restore perms so the tempdir can clean up.
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        assert!(
+            result.is_err(),
+            "must fail closed when the legacy key can't be removed"
+        );
     }
 }

--- a/packages/accelerator/src-tauri/src/main.rs
+++ b/packages/accelerator/src-tauri/src/main.rs
@@ -417,10 +417,14 @@ fn main() {
 
             // ── HTTPS startup ──
             // One-time migration: delete any legacy on-disk CA private key (older installs) — it was
-            // a readable mint-any-cert primitive. Runs regardless of Safari Support; the keyless CA
-            // anchor that remains can't sign anything. Idempotent.
-            certs::migrate_legacy_ca_key();
-            try_start_https(&state);
+            // a readable mint-any-cert primitive. SEC-08 fail-closed: if it CANNOT be removed, do NOT
+            // bring up Safari HTTPS — a live HTTPS server next to a readable mint-any-cert key + its
+            // still-trusted anchor is the exposure we're closing. HTTP is unaffected. Idempotent.
+            match certs::migrate_legacy_ca_key() {
+                Ok(()) => try_start_https(&state),
+                Err(e) => tracing::error!(error = %e,
+                    "SECURITY: legacy ca.key could not be removed — Safari HTTPS NOT started (HTTP unaffected)"),
+            }
 
             // Manage the shared state for Tauri commands (e.g. enable_safari_support). It shares the
             // Arc'd https_bound flag with the HTTP server's state, so start_https flipping it after a


### PR DESCRIPTION
PR-5 of `security-hardening-2026-06-09`. Three of the four PR-5 items; **SEC-09 deferred** (see below).

## SEC-07 — tarball decompression cap
`extract_bb_from_tarball` wraps the `GzDecoder` in a `CappedReader` that aborts once cumulative decompressed bytes exceed **512 MB** (~8× the 64 MB compressed download cap; well above a legit `bb`, far below a gzip bomb's tens-of-GB) + a cheap per-entry declared-size pre-check. The running counter is the real backstop (the header size is attacker-controlled). 3 tests incl. the cumulative-bomb case (junk entry before `bb`).

## SEC-08 — fail-closed legacy `ca.key` removal
`migrate_legacy_ca_key` → `Result`: retry the delete once, re-check, return `Err` if `ca.key` persists. The startup gate now **skips Safari HTTPS on `Err`** — a live HTTPS server next to a readable mint-any-cert key + its still-trusted anchor is the exposure we're closing. HTTP unaffected. Tests: delete-succeeds + fail-closed (read-only parent dir → `Err`).

## SEC-02 — deferral note (per your nightlies call)
Strengthened the digest-fetch doc: the online digest is circular (same GitHub control plane as the binary), so a release/account compromise installs malicious `bb`; the real fix is an upstream publisher signature (Aztec doesn't sign `bb` yet); in-app digest pinning is impractical (nightlies ship daily). Tracking note added.

## ⚠️ SEC-09 deferred — needs a macOS manual smoke
The cert-rotation chain-check (`verify-cert -c leaf -r ca`) + atomic-swap rewrite are **macOS-only** and the audit (R5) mandates a *negative* macOS manual smoke to confirm the `-r` binding actually holds (its semantics are underdocumented) — which CI can't run. Implementing it blind risks silently breaking Safari HTTPS. Deferred to a Mac-validated follow-up (as with `safari-tls-ca-removal`). The pre-existing mid-swap window is narrow + macOS-only.

Local: core 131 + src-tauri 20 pass, clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)