### PR TITLE
fix(accelerator): close the BB_BINARY_PATH test race behind the Rust Tests CI flake

### DIFF
--- a/packages/accelerator/core/src/server.rs
+++ b/packages/accelerator/core/src/server.rs
@@ -566,6 +566,11 @@ mod tests {
     }
 
     #[tokio::test]
+    // `#[serial]`: this test is a READER of the process-global `BB_BINARY_PATH` (via `find_bb` in
+    // both the skip-guard and the handler). `#[serial]` only excludes other `#[serial]` tests, so an
+    // unmarked reader still overlaps the serial writer (`prove_success_path_and_status_sequence`) —
+    // its fake exit-0 bb then turns this 500-assertion into a 200 (the CI flake on #346/#347).
+    #[serial]
     async fn prove_returns_error_when_bb_not_found() {
         // This test exercises the "bb not found" error path. When bb IS installed
         // on the dev machine, find_bb() succeeds and the real bb binary runs with
@@ -770,7 +775,16 @@ mod tests {
         )
         .unwrap();
         std::fs::set_permissions(&fake_bb, std::fs::Permissions::from_mode(0o755)).unwrap();
+        // RAII: unset `BB_BINARY_PATH` even if the request below panics — a leaked var would poison
+        // every later `find_bb`-reading test in this process (they'd all see the fake bb).
+        struct EnvGuard;
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                std::env::remove_var("BB_BINARY_PATH");
+            }
+        }
         std::env::set_var("BB_BINARY_PATH", &fake_bb);
+        let _guard = EnvGuard;
 
         let recorded = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
         let rec = recorded.clone();
@@ -794,7 +808,6 @@ mod tests {
             )
             .await
             .unwrap();
-        std::env::remove_var("BB_BINARY_PATH");
 
         assert_eq!(response.status(), StatusCode::OK);
         assert!(
@@ -1383,6 +1396,10 @@ mod tests {
     }
 
     #[tokio::test]
+    // `#[serial]`: same `BB_BINARY_PATH` reader race as `prove_returns_error_when_bb_not_found` —
+    // garbage bodies DO reach bb (no deserialization gate before the spawn), so the serial writer's
+    // fake exit-0 bb can turn this not-2xx assertion into a 200.
+    #[serial]
     async fn prove_handles_empty_body() {
         let app = router(AppState::default());
         let response = app


### PR DESCRIPTION
`server::tests::prove_returns_error_when_bb_not_found` failed twice in 2 days (on the #346 and #347 gates) with `200 != 500`. Root cause, not runner noise:

- `find_bb` step 0 reads the **process-global `BB_BINARY_PATH`** env var.
- The success-path test (`prove_success_path_and_status_sequence`, correctly `#[serial]`) sets that var to a **fake exit-0 bb**.
- `#[serial]` only serializes against *other `#[serial]` tests* — and the bb-not-found test (a reader of the same global, via its skip-guard *and* its handler) was unmarked, so it overlapped the writer, found a "working" bb, and `/prove` returned **200**.
- It never reproduces locally: with bb installed, the test self-skips — it only genuinely runs on CI runners.

Fix (test-only):
- `#[serial]` on `prove_returns_error_when_bb_not_found` (the flake).
- `#[serial]` on `prove_handles_empty_body` — same exposure: garbage bodies reach bb (no deserialization gate before the spawn), so the fake bb can flip its not-2xx assertion to 200.
- RAII guard on the writer's env cleanup, so a panic mid-request can't leak the var process-wide.

The auth-flow `/prove` tests assert `assert_ne!(403)`, which holds whether bb runs (200) or is missing (500) — race-immune, left parallel.

Validation: `cargo fmt --check` · `cargo clippy --all-targets -- -D warnings` · core **132/132**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)