### PR TITLE
fix(ci): scope N-1 resolution to accelerator tags; SDK releases never repo-Latest

### DIFF
--- a/.github/workflows/_e2e-updater-linux.yml
+++ b/.github/workflows/_e2e-updater-linux.yml
@@ -96,7 +96,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           N_VERSION: ${{ inputs.n-version }}
         run: |
-          N1_TAG=$(gh release list --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName')
+          N1_TAG=$(gh release list --exclude-pre-releases --limit 20 --json tagName --jq '[.[].tagName | select(startswith("accelerator-v"))][0]')
           if [ -z "$N1_TAG" ]; then
             echo "::error::no stable release found to use as N-1"
             exit 1

--- a/.github/workflows/_e2e-updater.yml
+++ b/.github/workflows/_e2e-updater.yml
@@ -65,7 +65,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           N_VERSION: ${{ inputs.n-version }}
         run: |
-          N1_TAG=$(gh release list --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName')
+          N1_TAG=$(gh release list --exclude-pre-releases --limit 20 --json tagName --jq '[.[].tagName | select(startswith("accelerator-v"))][0]')
           if [ -z "$N1_TAG" ]; then
             echo "::error::no stable release found to use as N-1"
             exit 1

--- a/.github/workflows/_publish-sdk.yml
+++ b/.github/workflows/_publish-sdk.yml
@@ -126,7 +126,11 @@ jobs:
             NOTES="SDK revision for Aztec ${{ inputs.dist_tag }} version \`${AZTEC_VERSION}\`."
           fi
 
+          # ALWAYS --latest=false: `inputs.latest` governs the npm dist-tag only. The repo's GitHub
+          # "Latest" badge belongs to accelerator releases — the 4.2.0-revision.2 SDK release stole
+          # it from accelerator-v1.0.5 (2026-06-11), breaking the updater smokes' N-1 resolution
+          # and the releases/latest URL.
           gh release create "$TAG" \
             --title "$TAG" \
             --notes "$NOTES" \
-            ${{ inputs.latest && '--latest' || '--latest=false' }}
+            --latest=false


### PR DESCRIPTION
The SDK publish's GitHub release (metadata-only) stole the repo Latest badge and became the updater smokes' N-1, failing 4/6 smokes on the 1.0.6-rc.1 cut. Resolvers now filter `accelerator-v*`; `_publish-sdk` always creates releases with `--latest=false` (the `latest` input keeps its npm dist-tag meaning). State already repaired live. `bun run lint:actions` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)