### PR TITLE
chore(v5): fpc bridge scripts + decoupled playground deploy

### DIFF
--- a/.github/workflows/publish-testnet.yml
+++ b/.github/workflows/publish-testnet.yml
@@ -2,6 +2,12 @@ name: Publish Testnet
 
 on:
   workflow_dispatch:
+    inputs:
+      skip_sdk_publish:
+        description: "Deploy the playground only — skip re-publishing the SDK to npm"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: publish-testnet
@@ -37,11 +43,13 @@ jobs:
 
   publish-sdk:
     needs: [changes, e2e]
-    if: needs.changes.outputs.sdk == 'true' || github.event_name == 'workflow_dispatch'
+    # Skip when deploying the playground only. latest:false — while @aztec deps are rc-labeled the
+    # SDK ships on the `testnet` dist-tag, never npm `latest` (which stays on the last stable line).
+    if: (needs.changes.outputs.sdk == 'true' || github.event_name == 'workflow_dispatch') && inputs.skip_sdk_publish != true
     uses: ./.github/workflows/_publish-sdk.yml
     with:
       dist_tag: testnet
-      latest: true
+      latest: false
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/packages/playground/scripts/batch-fund-fpc.ts
+++ b/packages/playground/scripts/batch-fund-fpc.ts
@@ -49,7 +49,7 @@ const batchSizeIndex = cliArgs.indexOf("--batch-size");
 const batchSize = batchSizeIndex !== -1 ? Number(cliArgs[batchSizeIndex + 1]) : 50;
 
 // ── Environment ───────────────────────────────────────────────────────
-const nodeUrl = process.env.AZTEC_NODE_URL || "https://rpc.testnet.aztec-labs.com";
+const nodeUrl = process.env.AZTEC_NODE_URL || "https://v5.testnet.rpc.aztec-labs.com";
 const l1RpcUrl = process.env.L1_RPC_URL;
 const l1PrivateKey = process.env.L1_PRIVATE_KEY;
 
@@ -209,7 +209,8 @@ console.log(`  Bridged ${claim.claimAmount} wei to FPC, leaf: ${claim.messageLea
 // ── Step 3: Bootstrap ephemeral L2 account (for claiming) ───────────
 console.log("Step 3: Bootstrapping ephemeral L2 account...");
 
-const FEE_JUICE_ADDRESS = AztecAddress.fromBigInt(5n);
+// FeeJuice protocol contract — canonical address compacted to 0x03 in Aztec 5.0 (was 0x05)
+const FEE_JUICE_ADDRESS = AztecAddress.fromBigInt(3n);
 
 const explorerUrl = (txHash: string) => `https://testnet.aztecscan.xyz/tx-effects/${txHash}`;
 
@@ -266,7 +267,6 @@ const feeMethod = new FeeJuicePaymentMethodWithClaim(deployerAddress, {
 const { receipt: deployReceipt } = await deployMethod.send({
   from: NO_FROM,
   fee: { paymentMethod: feeMethod },
-  wait: { returnReceipt: true },
 });
 console.log(`  Account deployed in block ${deployReceipt.blockNumber}`);
 console.log(`  TX: ${explorerUrl(deployReceipt.txHash.toString())}\n`);
@@ -281,7 +281,7 @@ await waitForBlocks(2);
 const feeJuice = await FeeJuiceContract.at(FEE_JUICE_ADDRESS, wallet as any);
 const { receipt: claimReceipt } = await feeJuice.methods
   .claim(fpcInstance.address, claim.claimAmount, claim.claimSecret, claim.messageLeafIndex)
-  .send({ from: deployerAddress, wait: { returnReceipt: true } });
+  .send({ from: deployerAddress });
 console.log(
   `  Claimed! tx fee: ${claimReceipt.transactionFee}, block: ${claimReceipt.blockNumber}`,
 );

--- a/packages/playground/scripts/deploy-sponsored-fpc.ts
+++ b/packages/playground/scripts/deploy-sponsored-fpc.ts
@@ -47,7 +47,7 @@ const saltIndex = cliArgs.indexOf("--salt");
 const salt = saltIndex !== -1 ? Fr.fromHexString(cliArgs[saltIndex + 1]) : Fr.random();
 
 // ── Environment ───────────────────────────────────────────────────────
-const nodeUrl = process.env.AZTEC_NODE_URL || "https://rpc.testnet.aztec-labs.com";
+const nodeUrl = process.env.AZTEC_NODE_URL || "https://v5.testnet.rpc.aztec-labs.com";
 const l1RpcUrl = process.env.L1_RPC_URL;
 const l1PrivateKey = process.env.L1_PRIVATE_KEY;
 const bridgeAmount = process.env.BRIDGE_AMOUNT ? BigInt(process.env.BRIDGE_AMOUNT) : undefined;
@@ -107,8 +107,8 @@ const portalManager = await L1FeeJuicePortalManager.new(
 );
 console.log(`  Fee Juice token: ${portalManager.getTokenManager().tokenAddress.toString()}\n`);
 
-// FeeJuice protocol contract at canonical address 0x05
-const FEE_JUICE_ADDRESS = AztecAddress.fromBigInt(5n);
+// FeeJuice protocol contract — canonical address compacted to 0x03 in Aztec 5.0 (was 0x05)
+const FEE_JUICE_ADDRESS = AztecAddress.fromBigInt(3n);
 
 const explorerUrl = (txHash: string) => `https://testnet.aztecscan.xyz/tx-effects/${txHash}`;
 
@@ -168,7 +168,6 @@ async function bootstrapAccount(): Promise<{
   const { receipt } = await deployMethod.send({
     from: NO_FROM,
     fee: { paymentMethod: feeMethod },
-    wait: { returnReceipt: true },
   });
   console.log(`  Account deployed in block ${receipt.blockNumber}`);
   console.log(`  TX: ${explorerUrl(receipt.txHash.toString())}\n`);
@@ -188,7 +187,7 @@ async function bridgeAndClaimForFpc(wallet: EmbeddedWallet, deployerAddress: Azt
   const feeJuice = await FeeJuiceContract.at(FEE_JUICE_ADDRESS, wallet as any);
   const { receipt } = await feeJuice.methods
     .claim(fpcInstance.address, claim.claimAmount, claim.claimSecret, claim.messageLeafIndex)
-    .send({ from: deployerAddress, wait: { returnReceipt: true } });
+    .send({ from: deployerAddress });
   console.log(`  Claimed! tx fee: ${receipt.transactionFee}, block: ${receipt.blockNumber}`);
   console.log(`  TX: ${explorerUrl(receipt.txHash.toString())}\n`);
 }
@@ -214,13 +213,11 @@ if (!fundOnly) {
   if (!alreadyDeployed) {
     console.log("  Deploying SponsoredFPC (WASM proving)...");
     const startTime = Date.now();
-    const deployMethod = SponsoredFPCContract.deploy(wallet);
+    // 5.0: salt + universalDeploy move to construction-time instantiation options.
+    const deployMethod = SponsoredFPCContract.deploy(wallet, { salt, universalDeploy: true });
     console.log("  Sending deploy tx...");
     const { receipt } = await deployMethod.send({
       from: deployerAddress,
-      contractAddressSalt: salt,
-      universalDeploy: true,
-      wait: { returnReceipt: true },
     });
     const elapsed = ((Date.now() - startTime) / 1000).toFixed(0);
     console.log(`  SponsoredFPC deployed in block ${receipt.blockNumber} (${elapsed}s)`);


### PR DESCRIPTION
## v5 FPC bridge scripts + decoupled playground deploy

Follow-ups to the Aztec 5.0 bump (#363), needed to fund the v5 sponsored FPC and ship the playground.

### Script fixes (`packages/playground/scripts/`)
`deploy-sponsored-fpc.ts` + `batch-fund-fpc.ts` updated for 5.0:
- FeeJuice protocol address `0x05 → 0x03` (compacted in 5.0)
- drop the removed `wait: { returnReceipt: true }` (5.0 `send()` resolves post-inclusion)
- universal deploy → construction-time `deploy(wallet, { salt, universalDeploy: true })`
- default node URL → `v5.testnet.rpc.aztec-labs.com`

Verified end-to-end: deployed + funded the **canonical salt=0 SponsoredFPC** on v5 at `0x261366b3…7880` (1000 FJ bridged + claimed, block 1387).

### `publish-testnet.yml`
- new `skip_sdk_publish` dispatch input → deploy the playground **without** re-publishing the SDK
- `latest: true → false` — while `@aztec` deps are rc-labeled, the SDK ships on the `testnet` dist-tag, never npm `latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
