### PR TITLE
docs: fix post-impl codex findings + close out FPC-salt plan

### DIFF
--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -80,7 +80,7 @@ gh workflow run publish-testnet.yml -f skip_sdk_publish=true
 
 ### Pre-flight (SDK)
 
-- [ ] `bun run --cwd packages/sdk test` green (lint + typecheck + unit)
+- [ ] `bun run --cwd packages/sdk test:lint` (typecheck) + `bun run --cwd packages/sdk test:unit` green; `bun run lint` clean (biome)
 - [ ] SDK version in `packages/sdk/package.json` bumped (the rc / `testnet` line)
 - [ ] `@aztec/*` deps resolve to the intended version; `bun.lock` committed (`bun install --frozen-lockfile` passes)
 

--- a/implementations-plan/fpc-salt-removal-docs-2026-06-18/lessons/phase-4.md
+++ b/implementations-plan/fpc-salt-removal-docs-2026-06-18/lessons/phase-4.md
@@ -1,0 +1,18 @@
+# Phase 4 — Land the PR (2026-06-19)
+
+**PR #366** → squash-merged to `main` as `ba3aec0`. All gates green (lint, typecheck, unit, **salt-less** SDK+App local-network e2e, WebDriver macos/linux/windows, Rust, Clippy, actionlint, smokes). The salt-less e2e passing is the live proof the removal is a true no-op for CI.
+
+## Gotchas caught during P4 (the real work of this phase)
+
+- **Scope contamination:** my P2 commit used `git add -A`, which swept the untracked `audit/security/**` (8 files, ~900 lines, unrelated security-audit reports from session start) into the commit. Caught it pre-push via `git diff --stat`. Excised cleanly with `reset --hard <base>` + `cherry-pick P1`, `cherry-pick P2 → git rm -r --cached audit/security/ → commit --amend` (P2 was HEAD at that moment, so the amend was exact), `cherry-pick P3`. Result: 3 clean commits, net 24 files / +274−65, no `audit/`. **Lesson: never `git add -A` with untracked unrelated dirs present — stage by path.**
+- **Stale `origin/main` ref:** the local `origin/main` tracking ref was 3 commits behind real main (still at #363). Root cause (again): `git fetch <URL> main` updates **`FETCH_HEAD` only**, NOT `refs/remotes/origin/main`. Verified real main via `git ls-remote` + `gh pr view 364/365 --json state` (both MERGED). The branch base was actually correct (built on real main `0fc6ffd`); the alarm was purely the stale ref. Fixed with `git update-ref refs/remotes/origin/main <FETCH_HEAD>`. **Lesson: after `fetch <URL> <branch>`, the truth is `FETCH_HEAD`; `ls-remote` is the authoritative cross-check.**
+
+## Post-impl review
+- `/code-review max --fix` on the #366 diff: **clean, no findings.** Reviewed all angles directly (diff is ~9 lines of logic + YAML deletions + docs — disproportionate to fan out 10 agents): explicit `new Fr(0)` (no falsy-zero), `Fr`/`salt` still used everywhere, `execSync` removed cleanly, reusable-workflow `secrets:` removed symmetrically (decl + callers), no `/Users/` paths in docs.
+- Codex post-impl audit (xhigh, adversarial) — verdict "safe for currently verified targets":
+  - **Med (fixed):** `RELEASE_RUNBOOK` pre-flight said `bun run --cwd packages/sdk test`, but `packages/sdk` has no `test` script (only `test:lint`/`test:unit`) → would hard-fail. Corrected to the real scripts.
+  - **Low (fixed):** `packages/sdk/README.md` bare `npm install` gave no hint that the 5.0 line is on the `testnet` dist-tag → added a one-line note (root README already had it).
+  - **Med (accepted, NOT reverted):** removing the salt override means a *future* custom `AZTEC_NODE_URL` without a funded salt=0 FPC would fail sponsored txs with no escape hatch. This is the **approved scope** ("always salt=0" — every targeted network has salt=0 funded). Per the standing rule, codex is advisory and can't override approved plan scope; surfaced + documented, not actioned. If a non-salt=0 network is ever targeted, re-introduce a config knob then.
+  - **Confirmed fine by codex:** no dangling workflow/secret breakage (symmetric removal); security posture improved (smaller trust surface); the headless README "no Tauri/WebKit" claim verified against `server/Cargo.toml` → `accelerator-core`.
+
+LESSONS_FILE=implementations-plan/fpc-salt-removal-docs-2026-06-18/lessons/phase-4.md

--- a/implementations-plan/fpc-salt-removal-docs-2026-06-18/plan.md
+++ b/implementations-plan/fpc-salt-removal-docs-2026-06-18/plan.md
@@ -49,7 +49,7 @@ Apply the doc changes listed above. No full local paths in committed files (use 
 
 **Validation gate:** manual review — each of the 5 docs reflects current reality (salt-less, 5.0, headless slimmed, version-model note present); the playground README no longer lists `SPONSORED_FPC_SALT`; no absolute local paths; relative links resolve. (Markdown isn't lint-gated in this repo — review is the gate.) Layers: manual-review.
 
-### P4 — Land the PR
+### P4 — Land the PR ✓ (PR #366, squash `ba3aec0`)
 Branch (`chore/remove-fpc-salt` or similar) → PR → CI green → auto-merge. `main` is branch-protected (branch + PR + auto-merge; unsigned commits via `git -c commit.gpgsign=false`). The e2e now runs salt-less (salt=0 canonical) — confirm the local-sandbox e2e stays green.
 
 **Validation gate:** `sdk.yml` + `app.yml` + `accelerator.yml` + `actionlint.yml` green (incl. the salt-less e2e); PR auto-merges. Layers: lint · typecheck · unit · e2e (local sandbox). *(Known infra flake: the Playwright `install-deps` timeout — re-run the failed job, it's not the change.)*

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -15,6 +15,8 @@ npm install @alejoamiras/aztec-accelerator
 bun add @alejoamiras/aztec-accelerator
 ```
 
+> The bare install resolves npm `latest`, which tracks the last **stable** Aztec line. For the current **Aztec 5.0** line (`5.0.0-rc.x`), install the `testnet` dist-tag: `npm install @alejoamiras/aztec-accelerator@testnet`.
+
 Peer dependency: your project must already have `@aztec/aztec.js` (or the individual `@aztec/stdlib`, `@aztec/bb-prover` packages) installed.
 
 ## Quick Start


### PR DESCRIPTION
## What

Post-implementation close-out of the `SPONSORED_FPC_SALT` removal (follow-up to #366). Fixes the two real doc bugs the codex post-impl audit found, plus plan/lessons bookkeeping.

## Codex post-impl findings addressed

- **[Med — fixed]** `docs/RELEASE_RUNBOOK.md` SDK pre-flight ran `bun run --cwd packages/sdk test`, but `packages/sdk` defines no `test` script (only `test:lint` / `test:unit`) — anyone following it literally hit a hard failure. Corrected to the real scripts.
- **[Low — fixed]** `packages/sdk/README.md` bare `npm install` gave no hint that the active **Aztec 5.0** line is on the `testnet` dist-tag. Added a one-line note (the root README already had one).
- **[Med — accepted, not reverted]** removing the salt override means a *future* custom `AZTEC_NODE_URL` without a funded salt=0 FPC would fail sponsored txs with no escape hatch. This is the **approved scope** of #366 ("always salt=0" — every targeted network has salt=0 funded). Documented in the phase-4 lesson; re-introduce a config knob only if a non-salt=0 network is ever targeted.

## Bookkeeping

Marks **P4 ✓** and files `lessons/phase-4.md` (the #366 merge; the `audit/security/` `git add -A` contamination caught + excised pre-push; the recurring stale-`origin/main`-ref trap). `/code-review max --fix` on #366 was clean.

## Not in this PR (held for human dispatch)

- **P5** — re-deploy the playground to v5 + live smoke.
- **P6** — delete the `SPONSORED_FPC_SALT` repo secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
