### PR TITLE
docs: document Chrome 142+ Local Network Access prompt; fix leaf validity (824d)

### DIFF
--- a/docs/PLATFORM_SUPPORT.md
+++ b/docs/PLATFORM_SUPPORT.md
@@ -38,6 +38,14 @@ The app uses GTK via WebKitGTK. Tray icon support depends on the compositor:
 - KDE Plasma: works out of the box
 - Sway/wlroots: requires `waybar` or similar with tray support
 
+## Browser Notes
+
+### Chrome Local Network Access (Chrome 142+)
+
+Chrome 142 (October 2025) began gating requests from public websites to loopback addresses behind a user permission prompt (Local Network Access); Chrome 145 splits it into `local-network` and `loopback-network` permissions. A dApp probing the accelerator from a public origin triggers the prompt on first use. If the user blocks it, the SDK sees the accelerator as offline and falls back to WASM proving — re-allowing requires resetting the permission in Chrome's site settings. The prompt is keyed on the destination address space, not the scheme: the accelerator's HTTPS mode does not exempt it.
+
+Firefox and Safari have no equivalent gate as of mid-2026. Requests from `localhost`-served pages (local dev) are same-address-space and do not trigger the prompt.
+
 ## Security Model
 
 ### Localhost Authorization

--- a/packages/accelerator/README.md
+++ b/packages/accelerator/README.md
@@ -256,7 +256,7 @@ The SDK automatically probes both HTTP (59833) and HTTPS (59834) in parallel via
 
 **Certificate details:**
 - CA: ECDSA P-256, 10-year validity, Name Constraints (localhost only)
-- Leaf: ECDSA P-256, 825-day validity (Apple TLS maximum), auto-renewed
+- Leaf: ECDSA P-256, 824-day validity (one day under Apple's inclusive 825-day TLS cap), auto-renewed
 - Storage: `~/.aztec-accelerator/certs/`
 
 ## Version Compatibility

--- a/packages/sdk/.claude/skills/aztec-accelerator/SKILL.md
+++ b/packages/sdk/.claude/skills/aztec-accelerator/SKILL.md
@@ -138,6 +138,10 @@ Safari blocks HTTP fetch from HTTPS pages (mixed-content). The SDK handles this 
 
 No code changes needed in the dApp — the SDK handles protocol negotiation.
 
+## Chrome Local Network Access (Chrome 142+)
+
+Chrome 142+ gates requests from public sites to loopback behind a permission prompt (Chrome 145+ uses a dedicated `loopback-network` permission). If the user blocks it, the SDK's probe fails and proving falls back to WASM (`fallback` phase) — indistinguishable from the accelerator not running. When a user reports "accelerator installed but not detected" on Chrome, have them check the Local Network Access permission in the address bar's site settings. HTTPS mode does not bypass the prompt. Pages served from `localhost` (local dev) are same-address-space and unaffected.
+
 ## Error handling
 
 The SDK is designed to be fail-safe:

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -213,11 +213,20 @@ const prover = new AcceleratorProver({
 
 | Browser | Works | Notes |
 |---------|-------|-------|
-| Chrome | Yes | HTTP localhost exempt from mixed-content restrictions |
+| Chrome | Yes* | HTTP localhost exempt from mixed-content restrictions; Chrome 142+ shows a Local Network Access permission prompt (see below) |
 | Firefox | Yes | HTTP localhost exempt from mixed-content restrictions |
 | Safari | Yes* | Requires HTTPS mode enabled in the accelerator app |
 
 Safari blocks `fetch()` from HTTPS pages to `http://127.0.0.1`. The SDK works around this by probing both HTTP and HTTPS in parallel — Chrome/Firefox use HTTP, Safari uses HTTPS. See the [accelerator README](../../packages/accelerator/README.md#safari-support-macos-only) for setup instructions.
+
+### Chrome Local Network Access (Chrome 142+)
+
+Starting with Chrome 142 (October 2025), requests from a public website to loopback addresses are gated behind a **Local Network Access permission prompt** ("… wants to access devices on your local network"). Chrome 145 splits this into separate `local-network` and `loopback-network` permissions. This applies to the SDK's health probe and prove requests:
+
+- If the user **allows**, everything works as before.
+- If the user **blocks** (or dismisses) the prompt, the probe fails and the SDK reports the accelerator as unavailable — proving silently falls back to WASM (`fallback` phase), which is indistinguishable from the accelerator not running. To recover, the user must re-allow the permission via the icon in Chrome's address bar (Site settings).
+
+Note this is about the destination address space, not the scheme — enabling HTTPS mode on the accelerator does **not** bypass the prompt.
 
 ## Version Compatibility
 


### PR DESCRIPTION
## What

Doc-only. Two things surfaced while digging into the HTTPS-channel status:

1. **Chrome Local Network Access (Chrome 142+)** — Chrome now gates public-site → loopback requests behind a permission prompt (Chrome 145 splits out a dedicated `loopback-network` permission). A blocked/dismissed prompt makes the SDK's probe fail, so the accelerator looks offline and proving silently falls back to WASM — indistinguishable from the app not running. Documented in:
   - `packages/sdk/README.md` (Browser Compatibility section + table note)
   - `docs/PLATFORM_SUPPORT.md` (new Browser Notes section)
   - `packages/sdk/.claude/skills/aztec-accelerator/SKILL.md` (troubleshooting note for integrators)

   Key facts captured: the prompt is keyed on destination address space, not scheme (accelerator HTTPS mode does not exempt it); localhost-served dev pages are same-address-space and unaffected; recovery is via Chrome's site settings.

2. **Leaf validity doc fix** — `packages/accelerator/README.md` said 825 days, but `LEAF_VALIDITY_DAYS` in `certs.rs` is deliberately **824** (one day under Apple's inclusive 825-day TLS-server-cert cap). README now matches the code.

Historical records (audit reports, plan/lessons files) that mention 825 are left untouched.

## Refs

- https://developer.chrome.com/blog/local-network-access
- https://chromestatus.com/feature/5152728072060928

🤖 Generated with [Claude Code](https://claude.com/claude-code)