### PR TITLE
ci(C0): gate CI on PRs into security-hardening

### DIFF
--- a/.github/workflows/accelerator.yml
+++ b/.github/workflows/accelerator.yml
@@ -3,7 +3,7 @@ name: Accelerator
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
+    branches: [main, security-hardening]
 
 # Cancel a superseded in-flight run when a new commit is pushed to the same PR.
 concurrency:

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -3,7 +3,7 @@ name: "Lint: Infra & Workflows"
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
+    branches: [main, security-hardening]
 
 jobs:
   changes:

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -3,7 +3,7 @@ name: App
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
+    branches: [main, security-hardening]
 
 # Cancel a superseded in-flight run when a new commit is pushed to the same PR.
 concurrency:

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -3,7 +3,7 @@ name: SDK
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
+    branches: [main, security-hardening]
 
 # Cancel a superseded in-flight run when a new commit is pushed to the same PR.
 concurrency:


### PR DESCRIPTION
C0 bootstrap for the security-hardening campaign (implementations-plan/security-hardening/plan.md).

Adds security-hardening to pull_request.branches on accelerator/sdk/app/actionlint so later cluster PRs into the integration branch get CI. This PR cannot auto-trigger (base branch lacks the new trigger until this merges), so per the Codex-verified bootstrap the four gates are dispatched manually on this ref and merged only when all four are green. Temporary: reverted during the final integration PR into main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)