### PR TITLE
fix(C2): witness temp perms + /prove memory DoS + trailing-dot origins (F-003/F-009/F-011)

### DIFF
--- a/packages/accelerator/core/Cargo.lock
+++ b/packages/accelerator/core/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "base64",
  "dirs",
  "flate2",
+ "futures-util",
  "hex",
  "http",
  "parking_lot",

--- a/packages/accelerator/core/Cargo.toml
+++ b/packages/accelerator/core/Cargo.toml
@@ -40,3 +40,4 @@ uuid = { version = "1.20.0", features = ["v4"] }
 tower = { version = "0.5", features = ["util"] }
 tokio = { version = "1", features = ["test-util"] }
 serial_test = "3"
+futures-util = "0.3" # stalled/error body streams for the F-009 /prove read-timeout tests

--- a/packages/accelerator/core/src/authorization.rs
+++ b/packages/accelerator/core/src/authorization.rs
@@ -280,7 +280,10 @@ impl AuthorizationManager {
             .ok()
             .filter(|u| matches!(u.scheme(), "http" | "https"))
             .and_then(|u| u.host_str().map(|h| h.to_ascii_lowercase()))
-            .is_some_and(|h| matches!(h.trim_end_matches('.'), "localhost" | "127.0.0.1" | "[::1]"))
+            // No trailing-dot trim: F-011 makes `canonicalize_origin` reject dotted hosts, so a
+            // CanonicalOrigin never carries one. Matching the exact host keeps this consistent for
+            // any direct caller too (a dotted `localhost.` is NOT auto-approved).
+            .is_some_and(|h| matches!(h.as_str(), "localhost" | "127.0.0.1" | "[::1]"))
     }
 
     /// Returns true if the origin is approved: in the persisted allowlist, OR — only when

--- a/packages/accelerator/core/src/authorization.rs
+++ b/packages/accelerator/core/src/authorization.rs
@@ -31,13 +31,19 @@ pub fn canonicalize_origin(input: &str) -> Option<String> {
         return None;
     }
 
+    let host = url.host_str()?;
+    // F-011: reject trailing-dot origins (e.g. `https://example.com.`) instead of silently
+    // collapsing them into the undotted origin. The browser treats the dotted FQDN as a
+    // DISTINCT origin, so it must earn its own approval rather than inherit the undotted
+    // site's grant (and its verified badge). Host-header normalization (server/host.rs) is a
+    // separate transport-level policy and is intentionally left unchanged.
+    if host.is_empty() || host.ends_with('.') {
+        return None;
+    }
+
     match url.scheme() {
         "http" | "https" | "ws" | "wss" => {
-            let host = url.host_str()?.to_ascii_lowercase();
-            let host = host.trim_end_matches('.');
-            if host.is_empty() {
-                return None;
-            }
+            let host = host.to_ascii_lowercase();
             Some(match url.port() {
                 Some(p) => format!("{}://{}:{}", url.scheme(), host, p),
                 None => format!("{}://{}", url.scheme(), host),
@@ -47,10 +53,7 @@ pub fn canonicalize_origin(input: &str) -> Option<String> {
             if url.port().is_some() {
                 return None;
             }
-            let id = url.host_str()?.to_ascii_lowercase();
-            if id.is_empty() {
-                return None;
-            }
+            let id = host.to_ascii_lowercase();
             Some(format!("{scheme}://{id}"))
         }
         _ => None,
@@ -458,9 +461,26 @@ mod tests {
     }
 
     #[test]
-    fn canon_trailing_dot_stripped() {
+    fn canon_trailing_dot_rejected() {
+        // F-011: a trailing-dot origin is a DISTINCT browser origin and must NOT be canonicalized
+        // into (and thereby inherit the approval of) the undotted form — it is rejected outright,
+        // across schemes and with/without an explicit port.
+        for input in [
+            "https://nulo.sh.",
+            "https://nulo.sh.:443",
+            "http://localhost.:5173",
+            "wss://example.com.",
+            "chrome-extension://abcdefghijklmnopabcdefghijklmnop.",
+        ] {
+            assert_eq!(
+                canonicalize_origin(input),
+                None,
+                "trailing-dot origin must be rejected, not collapsed: {input}"
+            );
+        }
+        // Sanity: the undotted forms still canonicalize normally.
         assert_eq!(
-            canonicalize_origin("https://nulo.sh."),
+            canonicalize_origin("https://nulo.sh"),
             Some("https://nulo.sh".to_string()),
         );
     }

--- a/packages/accelerator/core/src/bb.rs
+++ b/packages/accelerator/core/src/bb.rs
@@ -70,6 +70,37 @@ fn home_dir_fallback() -> Option<PathBuf> {
     std::env::var("HOME").ok().map(PathBuf::from)
 }
 
+/// Create the per-prove temp workspace. On Unix the directory is created `0o700` (owner-only)
+/// at the creation syscall — never write-then-chmod — so the private witness never has a
+/// world-traversable window (F-003). `tempfile::tempdir()` alone applies no mode and inherits
+/// the umask default (typically `0o755`). Windows relies on inherited temp-dir ACLs.
+fn create_prove_tempdir() -> std::io::Result<tempfile::TempDir> {
+    let mut builder = tempfile::Builder::new();
+    builder.prefix("aztec-accelerator-prove-");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        builder.permissions(std::fs::Permissions::from_mode(0o700));
+    }
+    builder.tempdir()
+}
+
+/// Write the proving witness (private ZK inputs) with mode `0o600` supplied to the creation
+/// syscall (F-003) — no write-then-chmod window. `create_new(true)` fails closed if the path
+/// already exists (defends against a pre-planted file/symlink in the workspace).
+fn write_witness(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(path)?;
+    file.write_all(bytes)
+}
+
 /// Run `bb prove` on the given IVC inputs (msgpack bytes) and return the proof
 /// with a 4-byte BE field-count header suitable for `ChonkProofWithPublicInputs.fromBuffer()`.
 ///
@@ -83,11 +114,11 @@ pub async fn prove(
     let bb_path =
         find_bb(version).map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })?;
 
-    let tmp_dir = tempfile::tempdir()?;
+    let tmp_dir = create_prove_tempdir()?;
     let input_path = tmp_dir.path().join("ivc-inputs.msgpack");
     let output_dir = tmp_dir.path().join("output");
     std::fs::create_dir_all(&output_dir)?;
-    std::fs::write(&input_path, ivc_inputs)?;
+    write_witness(&input_path, ivc_inputs)?;
 
     tracing::info!(
         version = version.map_or("bundled", |v| v.as_str()),
@@ -175,6 +206,32 @@ fn truncate_stderr(stderr: &str) -> String {
 mod tests {
     use super::*;
     use serial_test::serial;
+
+    /// F-003: the per-prove workspace dir is created `0o700` and the witness file `0o600` — at
+    /// the creation syscall, so no other local user can read the private witness while proving.
+    #[cfg(unix)]
+    #[test]
+    fn prove_workspace_and_witness_have_private_modes() {
+        use std::os::unix::fs::MetadataExt;
+
+        let dir = create_prove_tempdir().unwrap();
+        let witness = dir.path().join("ivc-inputs.msgpack");
+        write_witness(&witness, b"secret-witness-bytes").unwrap();
+
+        assert_eq!(
+            std::fs::metadata(dir.path()).unwrap().mode() & 0o777,
+            0o700,
+            "prove workspace dir must be owner-only"
+        );
+        assert_eq!(
+            std::fs::metadata(&witness).unwrap().mode() & 0o777,
+            0o600,
+            "witness file must be owner-only"
+        );
+
+        // create_new fails closed on a pre-existing path (no silent overwrite of a planted file).
+        assert!(write_witness(&witness, b"again").is_err());
+    }
 
     #[test]
     fn truncate_stderr_cuts_at_char_boundary_without_panic() {

--- a/packages/accelerator/core/src/bb.rs
+++ b/packages/accelerator/core/src/bb.rs
@@ -70,19 +70,53 @@ fn home_dir_fallback() -> Option<PathBuf> {
     std::env::var("HOME").ok().map(PathBuf::from)
 }
 
-/// Create the per-prove temp workspace. On Unix the directory is created `0o700` (owner-only)
-/// at the creation syscall — never write-then-chmod — so the private witness never has a
-/// world-traversable window (F-003). `tempfile::tempdir()` alone applies no mode and inherits
-/// the umask default (typically `0o755`). Windows relies on inherited temp-dir ACLs.
+/// Per-user private base for prove workspaces: `<data-local>/aztec-accelerator/prove-tmp`, created
+/// owner-only. Using our OWN per-user directory (not the shared OS temp) keeps the witness off a
+/// world-readable / shared `$TMPDIR`/`%TEMP%` and out of a non-sticky temp parent where an
+/// attacker could replace an ancestor between creation and use (F-003 hardening). `None` if no
+/// data-local dir is resolvable (caller falls back to OS temp).
+fn prove_tmp_parent() -> Option<PathBuf> {
+    let base = dirs::data_local_dir()?
+        .join("aztec-accelerator")
+        .join("prove-tmp");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(&base)
+            .ok()?;
+        // Tighten even if it pre-existed with a looser mode.
+        std::fs::set_permissions(&base, std::fs::Permissions::from_mode(0o700)).ok()?;
+    }
+    #[cfg(not(unix))]
+    std::fs::create_dir_all(&base).ok()?; // %LOCALAPPDATA% is already per-user on Windows
+    Some(base)
+}
+
+/// Create the per-prove temp workspace under the per-user private base (see `prove_tmp_parent`).
+/// On Unix the directory is created `0o700` (owner-only) at the creation syscall — never
+/// write-then-chmod — so the private witness never has a world-traversable window (F-003).
+/// `tempfile::tempdir()` alone applies no mode and inherits the umask default (typically `0o755`).
+/// Falls back to the OS temp dir (still `0o700` on Unix) only if no per-user dir is resolvable.
 fn create_prove_tempdir() -> std::io::Result<tempfile::TempDir> {
     let mut builder = tempfile::Builder::new();
-    builder.prefix("aztec-accelerator-prove-");
+    builder.prefix("prove-");
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         builder.permissions(std::fs::Permissions::from_mode(0o700));
     }
-    builder.tempdir()
+    match prove_tmp_parent() {
+        Some(parent) => builder.tempdir_in(parent),
+        None => {
+            tracing::warn!(
+                "No per-user data dir for a private prove workspace; using OS temp (0o700 on Unix)"
+            );
+            builder.tempdir()
+        }
+    }
 }
 
 /// Write the proving witness (private ZK inputs) with mode `0o600` supplied to the creation

--- a/packages/accelerator/core/src/config.rs
+++ b/packages/accelerator/core/src/config.rs
@@ -400,6 +400,15 @@ mod tests {
     }
 
     #[test]
+    fn de_origins_drops_trailing_dot_without_migrating() {
+        // F-011: a persisted dotted origin is DROPPED on load — never silently rewritten to its
+        // undotted (approved) form, so it cannot inherit the undotted origin's grant.
+        let loaded = de_origins(r#"["https://ok.example","https://bad.example."]"#);
+        assert_eq!(loaded, vec![co("https://ok.example")]);
+        assert!(!loaded.contains(&co("https://bad.example")));
+    }
+
+    #[test]
     fn de_origins_preserves_order() {
         assert_eq!(
             de_origins(r#"["https://b.com","https://a.com"]"#),

--- a/packages/accelerator/core/src/server.rs
+++ b/packages/accelerator/core/src/server.rs
@@ -322,8 +322,14 @@ async fn health(
 pub(crate) enum ProveError {
     InvalidVersion(String),
     PayloadTooLarge(String),
+    /// F-009: the request body did not finish arriving within the read timeout while holding
+    /// the single prove permit (slowloris / stalled upload). Distinct from PayloadTooLarge.
+    BodyReadTimeout,
     ServiceUnavailable,
-    DownloadFailed { version: String, detail: String },
+    DownloadFailed {
+        version: String,
+        detail: String,
+    },
     ProveFailed(String),
     InvalidOrigin,
     OriginDenied(String),
@@ -344,6 +350,11 @@ impl IntoResponse for ProveError {
                 StatusCode::PAYLOAD_TOO_LARGE,
                 "payload_too_large",
                 format!("Body too large or unreadable: {e}"),
+            ),
+            ProveError::BodyReadTimeout => (
+                StatusCode::REQUEST_TIMEOUT,
+                "body_read_timeout",
+                "Timed out while reading request body".to_string(),
             ),
             ProveError::ServiceUnavailable => (
                 StatusCode::SERVICE_UNAVAILABLE,

--- a/packages/accelerator/core/src/server.rs
+++ b/packages/accelerator/core/src/server.rs
@@ -30,6 +30,12 @@ mod prove;
 const PORT: u16 = 59833;
 pub const HTTPS_PORT: u16 = 59834;
 
+/// F-009: cap on concurrently in-flight + waiting authorized `/prove` requests (one holds the
+/// prove permit; the rest wait to buffer their body). Bounds the total queue so a burst of slow
+/// uploaders can't stack fresh per-request read timeouts and starve a legitimate request for
+/// minutes — excess authorized requests are shed immediately with 429 instead of queueing.
+pub(crate) const MAX_INFLIGHT_PROVE: usize = 8;
+
 /// Fallback Aztec bb version reported by `/health` + used as the proving default when no version is
 /// injected via `HeadlessState.bundled_version`. Core is `build.rs`-free, so this replaces the old
 /// `env!("AZTEC_BB_VERSION")` (which only existed via src-tauri/build.rs). Consumers inject the real
@@ -102,6 +108,10 @@ pub struct HeadlessState {
     pub auth_manager: Option<Arc<AuthorizationManager>>,
     /// Limits concurrent proving to 1 — bb already uses all cores. Always present (F-01).
     pub prove_semaphore: Arc<Semaphore>,
+    /// F-009: bounds total in-flight + waiting authorized `/prove` requests (`MAX_INFLIGHT_PROVE`).
+    /// Acquired (try, non-blocking) right after origin auth and held for the whole request, so a
+    /// burst of slow uploaders is shed with 429 rather than stacking per-request read timeouts.
+    pub prove_waiters: Arc<Semaphore>,
 }
 
 /// Full app state: the headless `core` plus the optional GUI callbacks. `Deref`s to `core`, so the
@@ -133,6 +143,7 @@ impl Default for HeadlessState {
             config: None,
             auth_manager: None,
             prove_semaphore: Arc::new(Semaphore::new(1)),
+            prove_waiters: Arc::new(Semaphore::new(MAX_INFLIGHT_PROVE)),
         }
     }
 }
@@ -154,6 +165,7 @@ impl HeadlessState {
             config,
             auth_manager,
             prove_semaphore: Arc::new(Semaphore::new(1)),
+            prove_waiters: Arc::new(Semaphore::new(MAX_INFLIGHT_PROVE)),
         }
     }
 }
@@ -334,6 +346,9 @@ pub(crate) enum ProveError {
     InvalidOrigin,
     OriginDenied(String),
     TooManyRequests,
+    /// F-009: the authorized-`/prove` waiter cap (`MAX_INFLIGHT_PROVE`) is full — shed with 429
+    /// rather than queueing behind slow uploaders. Distinct from `TooManyRequests` (auth backlog).
+    ProveQueueFull,
     AuthorizationTimeout,
     AuthorizationCancelled,
 }
@@ -381,6 +396,11 @@ impl IntoResponse for ProveError {
                 StatusCode::TOO_MANY_REQUESTS,
                 "too_many_requests",
                 "Too many pending authorization requests".to_string(),
+            ),
+            ProveError::ProveQueueFull => (
+                StatusCode::TOO_MANY_REQUESTS,
+                "prove_queue_full",
+                "Too many concurrent proving requests; retry shortly".to_string(),
             ),
             ProveError::AuthorizationTimeout => (
                 StatusCode::FORBIDDEN,

--- a/packages/accelerator/core/src/server/prove.rs
+++ b/packages/accelerator/core/src/server/prove.rs
@@ -114,15 +114,44 @@ const BODY_READ_TIMEOUT: Duration = Duration::from_secs(30);
 /// permit. Chunked/underreported requests are still bounded by `to_bytes` — this is a cheap
 /// fast-path, never the sole limit.
 fn reject_declared_oversize(headers: &axum::http::HeaderMap) -> Result<(), ProveError> {
-    if let Some(len) = headers
-        .get(axum::http::header::CONTENT_LENGTH)
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.parse::<usize>().ok())
-    {
-        if len > MAX_BODY_SIZE {
-            return Err(ProveError::PayloadTooLarge(format!(
-                "declared Content-Length {len} exceeds {MAX_BODY_SIZE}"
-            )));
+    // Inspect EVERY Content-Length value, and each comma-separated element within it (HTTP/2 and
+    // some proxies emit a duplicate-but-consistent list). Parse as u64 so a value that would
+    // overflow usize on 32-bit targets can't wrap below the cap; reject if any element exceeds the
+    // cap or is malformed. Cheap pre-permit fast-path — the to_bytes limit remains authoritative.
+    let mut seen: Option<u64> = None;
+    for value in headers.get_all(axum::http::header::CONTENT_LENGTH) {
+        let Ok(s) = value.to_str() else {
+            return Err(ProveError::PayloadTooLarge(
+                "non-ASCII Content-Length".to_string(),
+            ));
+        };
+        for part in s.split(',') {
+            let part = part.trim();
+            // RFC 7230 §3.3.2: a Content-Length is `1*DIGIT`. Reject empty/partial/non-digit
+            // elements (a permissive skip let `""`, `","`, `1,`, `,1` slip past); parse as u64 so
+            // an over-long value can't wrap below the cap.
+            if part.is_empty() || !part.bytes().all(|b| b.is_ascii_digit()) {
+                return Err(ProveError::PayloadTooLarge(format!(
+                    "malformed Content-Length {part:?}"
+                )));
+            }
+            let len: u64 = part.parse().map_err(|_| {
+                ProveError::PayloadTooLarge(format!("unparsable Content-Length {part:?}"))
+            })?;
+            if len > MAX_BODY_SIZE as u64 {
+                return Err(ProveError::PayloadTooLarge(format!(
+                    "declared Content-Length {len} exceeds {MAX_BODY_SIZE}"
+                )));
+            }
+            // RFC 7230 §3.3.2: multiple Content-Length values must all agree.
+            match seen {
+                Some(prev) if prev != len => {
+                    return Err(ProveError::PayloadTooLarge(format!(
+                        "conflicting Content-Length values {prev} and {len}"
+                    )));
+                }
+                _ => seen = Some(len),
+            }
         }
     }
     Ok(())
@@ -160,6 +189,16 @@ async fn acquire_and_read_body(
     Ok((permit, body))
 }
 
+/// F-009: try to enter the bounded set of in-flight + waiting authorized `/prove` requests.
+/// Non-blocking: if the cap (`MAX_INFLIGHT_PROVE` permits) is full, shed immediately with 429
+/// (`ProveQueueFull`) rather than queueing. The returned guard must be held for the whole request
+/// so it is released (RAII) on every exit path. Testable seam.
+fn try_enter(waiters: Arc<Semaphore>) -> Result<OwnedSemaphorePermit, ProveError> {
+    waiters
+        .try_acquire_owned()
+        .map_err(|_| ProveError::ProveQueueFull)
+}
+
 pub(crate) async fn prove(
     State(state): State<AppState>,
     request: Request,
@@ -171,7 +210,12 @@ pub(crate) async fn prove(
     let (parts, raw_body) = request.into_parts();
     authorize_origin(&state, &parts.headers).await?;
 
-    // F-009: turn away an honestly-declared oversize body before taking the permit.
+    // F-009: cap total in-flight + waiting authorized /prove requests. Held (RAII) for the whole
+    // request; a burst beyond MAX_INFLIGHT_PROVE is shed immediately with 429 instead of queueing
+    // behind slow uploaders and stacking fresh per-request read timeouts.
+    let _inflight = try_enter(state.prove_waiters.clone())?;
+
+    // F-009: turn away an honestly-declared oversize body before taking the prove permit.
     reject_declared_oversize(&parts.headers)?;
 
     // F-009: acquire the single prove permit BEFORE buffering the body, so concurrent requests
@@ -306,6 +350,62 @@ mod tests {
         // At/under the cap and absent are allowed (still bounded later by to_bytes).
         assert!(reject_declared_oversize(&content_length(&MAX_BODY_SIZE.to_string())).is_ok());
         assert!(reject_declared_oversize(&HeaderMap::new()).is_ok());
+        // Comma-list (HTTP/2 duplicate) with an oversize element must NOT slip past.
+        assert!(matches!(
+            reject_declared_oversize(&content_length(&format!("{0}, {0}", MAX_BODY_SIZE + 1))),
+            Err(ProveError::PayloadTooLarge(_))
+        ));
+        // Malformed / empty / partial values are rejected, not silently ignored.
+        for bad in ["not-a-number", "", ",", "1,", ",1", "1 2"] {
+            assert!(
+                matches!(
+                    reject_declared_oversize(&content_length(bad)),
+                    Err(ProveError::PayloadTooLarge(_))
+                ),
+                "must reject malformed Content-Length {bad:?}"
+            );
+        }
+        // Conflicting comma-list values (RFC 7230 §3.3.2) are rejected even when each is under cap.
+        assert!(matches!(
+            reject_declared_oversize(&content_length("10, 20")),
+            Err(ProveError::PayloadTooLarge(_))
+        ));
+        // Agreeing duplicates under the cap are fine.
+        assert!(reject_declared_oversize(&content_length("10, 10")).is_ok());
+    }
+
+    #[test]
+    fn waiter_cap_sheds_excess_with_queue_full() {
+        // F-009: fill the cap; the next entry is shed with ProveQueueFull; a slot frees on drop.
+        let waiters = Arc::new(Semaphore::new(2));
+        let g1 = try_enter(waiters.clone()).expect("slot 1");
+        let _g2 = try_enter(waiters.clone()).expect("slot 2");
+        assert!(matches!(
+            try_enter(waiters.clone()),
+            Err(ProveError::ProveQueueFull)
+        ));
+        drop(g1);
+        assert!(try_enter(waiters.clone()).is_ok(), "slot freed on drop");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn body_not_read_until_permit_available() {
+        // F-009 ordering: with zero prove permits, even a READY body must not be returned — the
+        // permit gates the read (proves permit-before-body, not merely that the guard is live).
+        let sem = Arc::new(Semaphore::new(0));
+        let fut = acquire_and_read_body(
+            sem,
+            Body::from(Bytes::from_static(b"ready")),
+            1024,
+            Duration::from_secs(30),
+        );
+        tokio::pin!(fut);
+        assert!(
+            tokio::time::timeout(Duration::from_secs(60), &mut fut)
+                .await
+                .is_err(),
+            "acquire_and_read_body must not resolve without a prove permit"
+        );
     }
 
     #[tokio::test]

--- a/packages/accelerator/core/src/server/prove.rs
+++ b/packages/accelerator/core/src/server/prove.rs
@@ -5,10 +5,15 @@
 //! version, then run the proof and return base64 + an `x-prove-duration-ms` header. Extracted
 //! from server.rs (Q2).
 
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::{Body, Bytes};
 use axum::extract::{Request, State};
 use axum::http::HeaderValue;
 use axum::response::IntoResponse;
 use serde_json::json;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use crate::{bb, versions};
 
@@ -98,6 +103,63 @@ pub(crate) fn compute_threads(state: &AppState) -> Option<usize> {
 
 const MAX_BODY_SIZE: usize = 50 * 1024 * 1024; // 50MB
 
+/// F-009: absolute deadline for buffering the request body while holding the single prove
+/// permit. Bounds a slowloris/stalled uploader before the permit is released. 30s is generous
+/// for 50MB over loopback (~1.7 MiB/s); it is a whole-body deadline, not an idle timeout, so
+/// drip-feeding cannot extend it.
+const BODY_READ_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Reject an honestly-declared oversize body BEFORE acquiring the prove permit, so a client
+/// advertising `Content-Length > MAX_BODY_SIZE` is turned away without occupying the single
+/// permit. Chunked/underreported requests are still bounded by `to_bytes` — this is a cheap
+/// fast-path, never the sole limit.
+fn reject_declared_oversize(headers: &axum::http::HeaderMap) -> Result<(), ProveError> {
+    if let Some(len) = headers
+        .get(axum::http::header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<usize>().ok())
+    {
+        if len > MAX_BODY_SIZE {
+            return Err(ProveError::PayloadTooLarge(format!(
+                "declared Content-Length {len} exceeds {MAX_BODY_SIZE}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// F-009: acquire the single prove permit, THEN buffer the body (under the size cap + an
+/// absolute read timeout). Returns the owned permit alongside the bytes so the caller holds it
+/// for the whole prove; the permit is released by RAII on every exit path (timeout, size error,
+/// disconnect, cancellation, panic, success). Testable seam.
+async fn acquire_and_read_body(
+    semaphore: Arc<Semaphore>,
+    raw_body: Body,
+    max_body_size: usize,
+    read_timeout: Duration,
+) -> Result<(OwnedSemaphorePermit, Bytes), ProveError> {
+    let permit = semaphore
+        .acquire_owned()
+        .await
+        .map_err(|_| ProveError::ServiceUnavailable)?;
+
+    let body = tokio::time::timeout(read_timeout, axum::body::to_bytes(raw_body, max_body_size))
+        .await
+        .map_err(|_| {
+            tracing::warn!(
+                timeout_secs = read_timeout.as_secs(),
+                "Timed out reading /prove request body"
+            );
+            ProveError::BodyReadTimeout
+        })?
+        .map_err(|e| {
+            tracing::warn!("Failed to read request body: {e}");
+            ProveError::PayloadTooLarge(e.to_string())
+        })?;
+
+    Ok((permit, body))
+}
+
 pub(crate) async fn prove(
     State(state): State<AppState>,
     request: Request,
@@ -109,20 +171,21 @@ pub(crate) async fn prove(
     let (parts, raw_body) = request.into_parts();
     authorize_origin(&state, &parts.headers).await?;
 
-    let body = axum::body::to_bytes(raw_body, MAX_BODY_SIZE)
-        .await
-        .map_err(|e| {
-            tracing::warn!("Failed to read request body: {e}");
-            ProveError::PayloadTooLarge(e.to_string())
-        })?;
-    tracing::debug!(payload_bytes = body.len(), "Prove request payload size");
+    // F-009: turn away an honestly-declared oversize body before taking the permit.
+    reject_declared_oversize(&parts.headers)?;
 
-    // Limit to one concurrent prove — bb already uses all cores.
-    let _permit = state
-        .prove_semaphore
-        .acquire()
-        .await
-        .map_err(|_| ProveError::ServiceUnavailable)?;
+    // F-009: acquire the single prove permit BEFORE buffering the body, so concurrent requests
+    // can't each pin a 50MB buffer ahead of the concurrency gate (memory DoS), and read the body
+    // under an absolute timeout so a stalled uploader can't hold the only permit indefinitely.
+    // `_permit` is held for the whole prove and released by RAII on every exit path.
+    let (_permit, body) = acquire_and_read_body(
+        state.prove_semaphore.clone(),
+        raw_body,
+        MAX_BODY_SIZE,
+        BODY_READ_TIMEOUT,
+    )
+    .await?;
+    tracing::debug!(payload_bytes = body.len(), "Prove request payload size");
 
     let requested_version = parts
         .headers
@@ -220,4 +283,79 @@ pub(crate) async fn prove(
     );
 
     Ok(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::{header::CONTENT_LENGTH, HeaderMap};
+
+    fn content_length(v: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(CONTENT_LENGTH, HeaderValue::from_str(v).unwrap());
+        h
+    }
+
+    #[test]
+    fn declared_oversize_rejected_before_permit() {
+        // F-009: an honestly-declared oversize Content-Length is turned away up front.
+        assert!(matches!(
+            reject_declared_oversize(&content_length(&(MAX_BODY_SIZE + 1).to_string())),
+            Err(ProveError::PayloadTooLarge(_))
+        ));
+        // At/under the cap and absent are allowed (still bounded later by to_bytes).
+        assert!(reject_declared_oversize(&content_length(&MAX_BODY_SIZE.to_string())).is_ok());
+        assert!(reject_declared_oversize(&HeaderMap::new()).is_ok());
+    }
+
+    #[tokio::test]
+    async fn permit_acquired_before_body_and_released_on_drop() {
+        let sem = Arc::new(Semaphore::new(1));
+        let (permit, body) = acquire_and_read_body(
+            sem.clone(),
+            Body::from(Bytes::from_static(b"hello")),
+            1024,
+            Duration::from_secs(30),
+        )
+        .await
+        .expect("happy path");
+        assert_eq!(&body[..], &b"hello"[..]);
+        assert_eq!(
+            sem.available_permits(),
+            0,
+            "permit held across the whole prove"
+        );
+        drop(permit);
+        assert_eq!(sem.available_permits(), 1, "permit released on drop");
+    }
+
+    #[tokio::test]
+    async fn oversized_body_errs_and_releases_permit() {
+        let sem = Arc::new(Semaphore::new(1));
+        let res = acquire_and_read_body(
+            sem.clone(),
+            Body::from(vec![0u8; 10]),
+            4, // tiny cap to force the length error deterministically
+            Duration::from_secs(30),
+        )
+        .await;
+        assert!(matches!(res, Err(ProveError::PayloadTooLarge(_))));
+        assert_eq!(
+            sem.available_permits(),
+            1,
+            "permit released after size error"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stalled_body_times_out_and_releases_permit() {
+        let sem = Arc::new(Semaphore::new(1));
+        // A body whose stream never yields → to_bytes never completes → the read timeout fires.
+        // Under start_paused the virtual clock auto-advances to the only pending timer.
+        let body =
+            Body::from_stream(futures_util::stream::pending::<Result<Bytes, std::io::Error>>());
+        let res = acquire_and_read_body(sem.clone(), body, 1024, Duration::from_secs(30)).await;
+        assert!(matches!(res, Err(ProveError::BodyReadTimeout)));
+        assert_eq!(sem.available_permits(), 1, "permit released after timeout");
+    }
 }

--- a/packages/accelerator/core/src/server/tests.rs
+++ b/packages/accelerator/core/src/server/tests.rs
@@ -1134,3 +1134,34 @@ async fn invalid_host_reply_stays_application_json_without_message() {
         "invalid_host must NOT carry a message field (minimal host-guard reply)"
     );
 }
+
+#[tokio::test]
+async fn prove_sheds_with_429_when_waiter_cap_full() {
+    // F-009 (handler-level): with the in-flight/waiting cap already full (prove_waiters exhausted),
+    // an authorized /prove request is shed IMMEDIATELY with 429 prove_queue_full — it never queues
+    // behind slow uploaders. Complements the try_enter unit test with end-to-end handler wiring.
+    let state = AppState {
+        core: std::sync::Arc::new(HeadlessState {
+            prove_waiters: std::sync::Arc::new(tokio::sync::Semaphore::new(0)),
+            ..HeadlessState::default()
+        }),
+        ..AppState::default()
+    };
+    let response = router(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .header("host", "127.0.0.1:59833")
+                .uri("/prove")
+                .body(Body::from("witness"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"], "prove_queue_full");
+}


### PR DESCRIPTION
Cluster C2 (core-request-safety) of the security-hardening campaign — see implementations-plan/security-hardening/plan.md + lessons/phase-C2.md (Codex gpt-5.6-sol@xhigh design).

**F-003** — witness temp dir 0o700 + file 0o600 at creation (never write-then-chmod); `tempfile::tempdir()` alone left the witness world-readable during proving.
**F-009** — acquire the single prove permit BEFORE buffering the body, under a 30s absolute read timeout; pre-permit fast-reject of declared-oversize Content-Length. Kills the concurrent-50MB-buffer memory DoS and slowloris permit-starvation. New `ProveError::BodyReadTimeout` (408).
**F-011** — reject trailing-dot origins instead of collapsing `https://x.`→approved `https://x`; old dotted config entries dropped-with-warn by the existing lenient loader.

Local gate (GUI-less VPS): `cargo fmt` + `clippy -D warnings` + 138 core tests green; headless `server` crate checks. src-tauri (GUI) validated by CI.

New tests: witness 0o700/0o600 modes; trailing-dot rejection vectors (5 schemes); permit acquired-before-body + released on drop/size-error/timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)