### PR TITLE
feat(landing): add amber pre-release notice banner

### DIFF
--- a/packages/landing/index.html
+++ b/packages/landing/index.html
@@ -25,6 +25,17 @@
   <link rel="stylesheet" href="/src/style.css" />
 </head>
 <body>
+  <!-- Pre-release notice — always visible -->
+  <aside class="prerelease-banner" role="status" aria-label="Pre-release notice">
+    <span class="prerelease-banner-dot" aria-hidden="true"></span>
+    <p class="prerelease-banner-text">
+      <strong>Early release</strong>
+      <span class="prerelease-banner-sep" aria-hidden="true">&middot;</span>
+      Not yet production-ready
+      <span class="prerelease-banner-sep" aria-hidden="true">&middot;</span>
+      Use at your own risk
+    </p>
+  </aside>
   <div class="hero-ambient" aria-hidden="true"></div>
   <div class="container">
 

--- a/packages/landing/src/style.css
+++ b/packages/landing/src/style.css
@@ -59,6 +59,63 @@ img, svg {
   padding: 0 1.5rem;
 }
 
+/* ── Pre-release banner ──────────────────────────────────────────── */
+.prerelease-banner {
+  position: sticky;
+  top: 0;
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.7rem;
+  padding: 0.55rem 1rem;
+  background: rgba(11, 10, 6, 0.85);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-bottom: 1px solid rgba(255, 179, 71, 0.3);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  text-align: center;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+.prerelease-banner-dot {
+  flex: none;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #ffb347;
+  box-shadow: 0 0 10px rgba(255, 179, 71, 0.45);
+  animation: prerelease-pulse 2.4s ease-out infinite;
+}
+
+.prerelease-banner-text {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0 0.7rem;
+  margin: 0;
+}
+
+.prerelease-banner-text strong {
+  font-weight: 600;
+  letter-spacing: 0.22em;
+  color: #ffb347;
+}
+
+.prerelease-banner-sep {
+  opacity: 0.35;
+}
+
+@keyframes prerelease-pulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.6); opacity: 0.55; }
+}
+
 /* ── Nav ──────────────────────────────────────────────────────────── */
 .nav {
   display: flex;


### PR DESCRIPTION
Adds an always-visible pre-release notice to the landing page, inspired by nulo.sh's header strip.

- Sticky top banner above the nav: **Early release · Not yet production-ready · Use at your own risk**
- Pulsing amber dot + amber highlights — deliberately *not* the lime accent, since lime is the site's "go"/verified color and a warning wearing it would read as endorsement
- `role="status"` aside, uppercase dot-separated text, backdrop blur; wraps gracefully on mobile
- Not dismissible by design — the warning shouldn't be closable while the software is pre-production
- Pulse animation is covered by the existing `prefers-reduced-motion` kill-switch

Validation: `biome check packages/landing` clean, `sort-package-json --check` clean, Vite build passes. (Root `bun run lint` currently trips on a nested `biome.json` from an unrelated in-clone worktree under `.claude/worktrees/` — environmental, not from this change; CI checks out clean.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)