### PR TITLE
chore(lint): exclude .claude/ from biome scanning

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
   },
   "files": {
     "ignoreUnknown": true,
-    "includes": ["packages/**/*.ts", "packages/**/*.js", "*.json", "*.md"]
+    "includes": ["packages/**/*.ts", "packages/**/*.js", "*.json", "*.md", "!.claude/**"]
   },
   "formatter": {
     "enabled": true,


### PR DESCRIPTION
In-clone agent worktrees under .claude/worktrees/ carry their own root
biome.json, which makes 'biome check .' fail with a nested-root-config
error. The dir is git-excluded via .git/info/exclude, which biome's
useIgnoreFile doesn't read, so exclude it explicitly.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
