### PR TITLE
fix(C1): validate + env-quote _publish-sdk.yml inputs (F-006)

### DIFF
--- a/.github/workflows/_publish-sdk.yml
+++ b/.github/workflows/_publish-sdk.yml
@@ -37,6 +37,21 @@ jobs:
       id-token: write # needed for --provenance (Sigstore attestation)
       contents: write
     steps:
+      # F-006: reject a malformed dist_tag BEFORE checkout or any token-bearing step. Job perms
+      # (id-token/contents: write) and checkout-persisted git credentials are live from step 1, so
+      # validation must come first. Whole-string bash match (not grep, which would pass a multiline
+      # value with one valid line); must start with a lowercase letter, so no leading '-' (npm
+      # option/argument injection) and no semver-like tag. Read via env, never interpolated into shell.
+      - name: Validate dist_tag
+        env:
+          DIST_TAG: ${{ inputs.dist_tag }}
+          LC_ALL: C
+        run: |
+          if [[ ! "$DIST_TAG" =~ ^[a-z][a-z0-9._-]*$ ]]; then
+            echo "::error::Invalid dist_tag '$DIST_TAG' (must match ^[a-z][a-z0-9._-]*\$)"
+            exit 1
+          fi
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -76,17 +91,21 @@ jobs:
 
       - name: Determine SDK publish version
         id: sdk-version
+        env:
+          AZTEC_VERSION: ${{ steps.aztec-version.outputs.version }}
         run: |
-          VERSION=$(bun scripts/get-sdk-publish-version.ts "${{ steps.aztec-version.outputs.version }}")
+          VERSION=$(bun scripts/get-sdk-publish-version.ts "$AZTEC_VERSION")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "SDK publish version: $VERSION"
 
       - name: Set SDK version and fix exports for npm
         working-directory: packages/sdk
+        env:
+          SDK_VERSION: ${{ steps.sdk-version.outputs.version }}
         run: |
           node -e "
             const p = require('./package.json');
-            p.version = '${{ steps.sdk-version.outputs.version }}';
+            p.version = process.env.SDK_VERSION;
             p.main = './dist/index.js';
             p.types = './dist/index.d.ts';
             p.exports = { '.': { types: './dist/index.d.ts', default: './dist/index.js' } };
@@ -98,32 +117,37 @@ jobs:
         working-directory: packages/sdk
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --provenance --access public --tag ${{ inputs.dist_tag }} --workspaces=false
+          DIST_TAG: ${{ inputs.dist_tag }}
+        # --tag="$DIST_TAG" (=-form + quoted): DIST_TAG is validated + inert shell data, and the
+        # =-form stops a value from being parsed as a separate npm option.
+        run: npm publish --provenance --access public --tag="$DIST_TAG" --workspaces=false
 
       - name: Also tag as 'latest' on npm
         if: inputs.latest && inputs.dist_tag != 'latest'
         working-directory: packages/sdk
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm dist-tag add "@alejoamiras/aztec-accelerator@${{ steps.sdk-version.outputs.version }}" latest
+          SDK_VERSION: ${{ steps.sdk-version.outputs.version }}
+        run: npm dist-tag add "@alejoamiras/aztec-accelerator@${SDK_VERSION}" latest
 
       - name: Create git tag and GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
+          SDK_VERSION: ${{ steps.sdk-version.outputs.version }}
+          AZTEC_VERSION: ${{ steps.aztec-version.outputs.version }}
+          DIST_TAG: ${{ inputs.dist_tag }}
         run: |
-          VERSION="${{ steps.sdk-version.outputs.version }}"
-          AZTEC_VERSION="${{ steps.aztec-version.outputs.version }}"
-          TAG="@alejoamiras/aztec-accelerator@${VERSION}"
+          TAG="@alejoamiras/aztec-accelerator@${SDK_VERSION}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "$TAG" || true
           git push origin "$TAG" || true
 
-          if [ "$VERSION" = "$AZTEC_VERSION" ]; then
-            NOTES="Aligned with Aztec ${{ inputs.dist_tag }} version \`${AZTEC_VERSION}\`."
+          if [ "$SDK_VERSION" = "$AZTEC_VERSION" ]; then
+            NOTES="Aligned with Aztec ${DIST_TAG} version \`${AZTEC_VERSION}\`."
           else
-            NOTES="SDK revision for Aztec ${{ inputs.dist_tag }} version \`${AZTEC_VERSION}\`."
+            NOTES="SDK revision for Aztec ${DIST_TAG} version \`${AZTEC_VERSION}\`."
           fi
 
           # ALWAYS --latest=false: `inputs.latest` governs the npm dist-tag only. The repo's GitHub

--- a/.github/workflows/_publish-sdk.yml
+++ b/.github/workflows/_publish-sdk.yml
@@ -41,14 +41,18 @@ jobs:
       # (id-token/contents: write) and checkout-persisted git credentials are live from step 1, so
       # validation must come first. Whole-string bash match (not grep, which would pass a multiline
       # value with one valid line); must start with a lowercase letter, so no leading '-' (npm
-      # option/argument injection) and no semver-like tag. Read via env, never interpolated into shell.
+      # option/argument injection) and no leading digit. Read via env, never interpolated into shell.
+      # (A still-invalid tag like a semver range that slips the regex fails later at npm — not an injection.)
       - name: Validate dist_tag
         env:
           DIST_TAG: ${{ inputs.dist_tag }}
           LC_ALL: C
         run: |
           if [[ ! "$DIST_TAG" =~ ^[a-z][a-z0-9._-]*$ ]]; then
-            echo "::error::Invalid dist_tag '$DIST_TAG' (must match ^[a-z][a-z0-9._-]*\$)"
+            # Do NOT echo the rejected value: a malformed multiline dist_tag could otherwise inject
+            # ::workflow-commands:: into the log stream. The value is already masked/available to the
+            # operator via the dispatch inputs.
+            echo "::error::Invalid dist_tag (must match ^[a-z][a-z0-9._-]*\$)"
             exit 1
           fi
 

--- a/implementations-plan/security-hardening/clusters/C1-audit-codex.md
+++ b/implementations-plan/security-hardening/clusters/C1-audit-codex.md
@@ -1,0 +1,50 @@
+# C1 plan-audit — Codex gpt-5.6-sol @ xhigh
+
+Verdict: **REJECT** → folded into the revised plan + implementation.
+
+## Adopted
+- Argument-injection: use `--tag="$DIST_TAG"` (=-form) + regex must start with a letter `^[a-z][a-z0-9._-]*$` (rejects leading `-` option-injection + semver-like tags).
+- Validator robustness: env-only bash `[[ "$DIST_TAG" =~ ^...$ ]]` (whole-string, not grep-per-line) with `LC_ALL=C`; no `printf "$VAR"` format-string bug.
+- Broaden scope within the file: route ALL run:/node interpolations through env + quoted refs — L80 (AZTEC_VERSION arg), L89 (node reads process.env.SDK_VERSION), L101 (DIST_TAG), L108 (SDK_VERSION), L114/115 + L124/126 (release step SDK_VERSION/AZTEC_VERSION/DIST_TAG). 'Computed output is not a trust boundary.'
+- Validation is the FIRST step (before checkout), since job perms + checkout-persisted creds are live from step 1.
+- Fact 6 corrected: the regex is a PROJECT-policy allowlist, not npm's charset.
+- Proof: exact-context grep over run:/node blocks (not just the run: line) + enumerate test cases (empty, multiline, --dry-run, semver-like, shell payload).
+
+## Deferred / out-of-scope (documented, not silently dropped)
+- **persist-credentials:false / split unprivileged-build from privileged-publish** — bigger refactor; `git push` currently relies on checkout-persisted creds. Validate-first already blocks a malicious dist_tag before any step runs. Tracked as a follow-up hardening.
+- **Trusted publishing / protected environment / remove direct workflow_dispatch / restrict actors** — org+release policy beyond F-006 (closing the injection). Tracked.
+- **SHA-pin actions + mutable bun-version/rust** — that is cluster C3 (F-015).
+- **Adjacent correctness (not F-006):** `git tag/push … || true` swallows failures; the `latest` input descriptions say GitHub `--latest` but the step hardcodes `--latest=false`. Noted for a follow-up; not fixed in this security cluster.
+- **Semver-validate the computed versions** — env-quoting already makes them inert shell data (closes the injection, which is F-006); value-validation is robustness DiD, deferred.
+
+---
+
+## Full verdict transcript
+```
+reject (with blocking findings: leading-option values survive the allowlist, validation/proof is not newline-safe, and unvalidated computed outputs remain interpolated in token-bearing shell)
+
+- [`^[a-z0-9._-]+$` plus `--tag "$DIST_TAG"`](implementations-plan/security-hardening/clusters/C1-workflow-input-hardening.md:12) does not fully close argument injection. It permits `--dry-run`, `--force`, `-ddd`, etc.; npm parses these as options when passed separately after `--tag`. Require `--tag="$DIST_TAG"` and either an exact enum (`testnet|nightlies|latest`) or at least `^[a-z][a-z0-9._-]*$`.
+
+- The regex is not “npm’s legal charset.” It accepts values npm rejects as semver ranges, including `1.2.3` and `v1.4`; npm explicitly documents this restriction. It also excludes potentially valid uppercase tags. It is compatible with the three known project tags, but that is a project policy, not npm validation. [npm dist-tag documentation](https://docs.npmjs.com/cli/v11/commands/npm-dist-tag/)
+
+- A validator implemented as `printf '%s\n' "$DIST_TAG" | grep -Eq ...` is bypassable with a multiline input containing one valid line. `printf "$DIST_TAG"` additionally creates a format-string bug. Use an env-only Bash `[[ ... =~ ... ]]`/`case` check with `LC_ALL=C`; a composite action is unnecessary. GitHub recommends the intermediate-environment-variable pattern. [GitHub secure-use guidance](https://docs.github.com/en/actions/reference/security/secure-use)
+
+- Step-level env plus quoted expansion safely closes shell evaluation at [publish L101](.github/workflows/_publish-sdk.yml:101) and release-notes L124/L126. Variable contents are not recursively parsed; the escaped backticks remain literal.
+
+- L104 is safe: `if: inputs.latest && inputs.dist_tag != 'latest'` is structural GitHub expression evaluation, not generated shell.
+
+- L108 must not remain optional. “Computed output” is not a trust boundary: the version derives from checked-out `package.json`, repo code, and registry data. Raw expressions also enter shell at [L80/L89](.github/workflows/_publish-sdk.yml:80), [L108](.github/workflows/_publish-sdk.yml:108), and [L114/L115](.github/workflows/_publish-sdk.yml:114); L108 carries `NPM_TOKEN`, while L114/L115 carry `GH_TOKEN`. Move all outputs through env, quote them, validate versions as semver, and make the Node script read `process.env.SDK_VERSION`.
+
+- The proposed grep proof only detects expressions on the `run:` line; it misses block-scalar bodies such as current L124/L126. Actionlint does not prove injection safety. Add exact-context inspection plus cases for empty, multiline, `--dry-run`, semver-like, and shell-payload inputs.
+
+- Make validation the first step, before checkout. “Before Install/Build” is not equivalent to “before token-bearing”: `contents: write` and `id-token: write` are job-wide, and checkout receives/persists GitHub credentials by default. Split unprivileged build from npm publish and GitHub release, or at minimum use `persist-credentials: false` outside the release step.
+
+- Facts 1–5 are accurate; Fact 6 is misstated. The backtick inference is sound. No other `inputs.dist_tag` shell interpolation exists in this target; current reusable-workflow callers use literal `testnet`/`nightlies`.
+
+- “Asks: none” silently assumes arbitrary manual tags remain supported, direct dispatch is necessary, arbitrary refs may publish, and computed versions are trusted. Those are unresolved policy decisions.
+
+- Stronger boundary: remove direct `workflow_dispatch` from the reusable workflow or expose choice-only wrappers, restrict publishing to a protected ref/environment with approval, and restrict workflow actors. By default, repository write access can manually dispatch workflows. [GitHub manual-dispatch documentation](https://docs.github.com/en/enterprise-cloud%40latest/actions/how-tos/manage-workflow-runs/manually-run-a-workflow)
+
+- Supply-chain gaps remain: mutable action tags, `bun-version: latest`, privileged build/install steps, and a long-lived npm token. Prefer npm trusted publishing with token publishing disabled, environment binding, immutable action SHAs, and separated privileges. Provenance links a package to its workflow; it does not establish benign contents. [npm trusted publishing](https://docs.npmjs.com/trusted-publishers/), [npm provenance limitations](https://docs.npmjs.com/generating-provenance-statements/)
+
+- Missed integrity/correctness issues: both `latest` input descriptions claim GitHub `--latest`, while the workflow hardcodes `--latest=false`; `git tag` and `git push` failures are swallowed with `|| true`.```

--- a/implementations-plan/security-hardening/clusters/C1-eli5.html
+++ b/implementations-plan/security-hardening/clusters/C1-eli5.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Blueprint ELI5 — C1 workflow-input-hardening (F-006)</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; max-width: 720px; margin: 2rem auto; padding: 0 1rem; color: #222; line-height: 1.6; }
+    h1,h2,h3 { font-weight: 600; } h1 { font-size: 1.6rem; } h2 { font-size: 1.2rem; margin-top: 2rem; } h3 { font-size: 1rem; color: #444; }
+    code, pre { font-family: ui-monospace, Menlo, monospace; font-size: 0.9rem; }
+    pre { background: #f6f6f6; padding: 1rem; border-radius: 4px; overflow-x: auto; white-space: pre-wrap; }
+    .phase { margin: 1.25rem 0; padding: 0.9rem 1.1rem; border-left: 3px solid #ccc; background: #fafafa; }
+    .approval { background: #eef6ff; padding: 1rem 1.1rem; border-left: 3px solid #0366d6; margin: 1.5rem 0; }
+    .muted { color: #666; font-size: 0.9rem; }
+  </style>
+</head>
+<body>
+  <h1>C1 — workflow-input-hardening (F-006)</h1>
+  <p>The SDK publish workflow (<code>_publish-sdk.yml</code>) takes a text input, <code>dist_tag</code>, and pastes it straight into shell commands that hold the npm and GitHub tokens. Because GitHub substitutes the text <em>before</em> the shell runs, whoever can start that workflow could type a command instead of a tag and steal the tokens (or publish a fake package). The fix: check <code>dist_tag</code> against a strict allowlist and pass it as a quoted environment variable so it can only ever be data, never a command.</p>
+
+  <h2>Why this tier was chosen</h2>
+  <p><strong>light.</strong> One file, one finding, a well-known fix. Only one risk dimension is high (it touches the token-bearing publish pipeline); everything else — novelty, reversibility, migration, external coupling — is low. So: one plan, one Codex audit, then implement.</p>
+
+  <h2>Phase 1 — validate + quote <code>dist_tag</code></h2>
+  <div class="phase">
+    <p>Add an early step that rejects any <code>dist_tag</code> not matching <code>^[a-z0-9._-]+$</code> (real tags like <code>testnet</code>/<code>nightlies</code>/<code>latest</code> pass; spaces, <code>;</code>, backticks, <code>$</code>, quotes don't). Then pass <code>dist_tag</code> into the publish and release-notes steps as a quoted env var (<code>"$DIST_TAG"</code>) instead of raw <code>${{ … }}</code> in the shell.</p>
+    <p class="muted">Proves itself by: <code>bun run lint:actions</code> (actionlint) green, no <code>${{ inputs.dist_tag }}</code> left inside any <code>run:</code> block, and the validate step running before any token-bearing step — plus <code>actionlint.yml</code> green in CI.</p>
+  </div>
+
+  <h2>Human context</h2>
+  <p>This is part of the security-hardening campaign; it's driven by the campaign-level <code>/goal</code> + <code>/loop</code> (one cluster at a time, each blueprinted, audited by Codex, and merged only on green). This page documents cluster C1 specifically.</p>
+
+  <h2>Open questions</h2>
+  <ul>
+    <li>Whether to also env-quote the computed <code>version</code> interpolation at L108 as cheap defense-in-depth (it's an internal output, not user input) — decided with the Codex audit.</li>
+  </ul>
+
+  <div class="approval">
+    <h2>Approval</h2>
+    <p>This cluster runs under the campaign's autonomous <code>/goal</code> + <code>/loop</code>; the per-cluster gate is the Codex <code>light</code> audit (verdict recorded in <code>audit-codex.md</code>) rather than an interactive human approval. Merge happens only when the audit is clean AND local (actionlint) AND CI are green.</p>
+  </div>
+
+  <p class="muted"><a href="C1-workflow-input-hardening.md">Full C1 plan</a> · <a href="../plan.md">campaign plan (/goal + /loop)</a> · <a href="./lessons/">lessons</a></p>
+</body>
+</html>

--- a/implementations-plan/security-hardening/clusters/C1-workflow-input-hardening.md
+++ b/implementations-plan/security-hardening/clusters/C1-workflow-input-hardening.md
@@ -1,0 +1,47 @@
+# C1 — workflow-input-hardening (F-006) · /blueprint light
+
+**Cluster:** C1 of the security-hardening campaign · **Branch:** `sechard/workflow-input-hardening` off `security-hardening` · **Tier:** light.
+
+## Summary
+`.github/workflows/_publish-sdk.yml` takes a `workflow_dispatch` input `dist_tag` and interpolates it **unquoted** into `run:` shell steps that carry `NPM_TOKEN` and `GH_TOKEN`. Because GitHub expands `${{ … }}` **before** bash runs, a dispatch-capable actor can set `dist_tag` to a shell payload and exfiltrate the tokens or publish a malicious package (F-006, CWE-78). Fix: validate `dist_tag` against a strict allowlist and pass it via `env:` referenced quoted, so it is inert shell data.
+
+## Tier justification (Phase 0.5 rubric)
+Novelty L · Blast-radius (publish pipeline → all SDK consumers) — but the FIX is a well-known, contained pattern · Irreversibility L (workflow edit, reversible) · Migration L · External-coupling L · Security-sensitivity **H** (token-bearing publish). 1 high, single file, single finding, known fix → **light**.
+
+## Phase 1 — validate + env-quote `dist_tag` (single phase)
+1. Add an early **Validate dist_tag** step (before Install/Build/Publish — i.e. before any token-bearing step) that reads `dist_tag` via `env:` and fails unless it matches `^[a-z0-9._-]+$` (npm dist-tag legal charset; forbids whitespace, `;`, backticks, `$`, quotes).
+2. Publish step (L101): move `dist_tag` to `env: DIST_TAG: ${{ inputs.dist_tag }}` and use `--tag "$DIST_TAG"` (quoted, no `${{ }}` in `run:`).
+3. Release-notes step (L110-136): the step already sets `GH_TOKEN`; add `DIST_TAG` to its `env:` and replace the two `${{ inputs.dist_tag }}` occurrences in `NOTES=` (L124/126) with `"$DIST_TAG"`.
+4. Leave L104 `if: inputs.latest && inputs.dist_tag != 'latest'` unchanged — GHA **expression** context, not shell; no injection. (Validation upstream makes it moot regardless.)
+5. Consider L108 `npm dist-tag add "…@${{ steps.sdk-version.outputs.version }}"` — a COMPUTED output (not user input) from `get-sdk-publish-version.ts`; low risk, but env-quote it too as cheap defense-in-depth if Codex concurs.
+
+### Validation gate (Phase 1)
+- **Commands:** `bun run lint:actions` (actionlint over the edited workflow).
+- **Pass criteria:** exit 0; no `${{ inputs.dist_tag }}` remains inside any `run:` block (grep proof: `! grep -nE 'run:.*\$\{\{ *inputs.dist_tag' … `); the validate step precedes every token-bearing step.
+- **Layers:** lint (actionlint). CI: `actionlint.yml` green on the PR into `security-hardening`.
+
+## Security & Adversarial Considerations
+- **Threat model:** actor with `workflow_dispatch`/write capability (collaborator or a compromised owner/CI token — this is a single-owner repo, so not an anonymous outsider) runs `_publish-sdk.yml` with a crafted `dist_tag` → shell injection in a token-bearing step → `NPM_TOKEN`/`GH_TOKEN` exfiltration or malicious publish.
+- **Least privilege:** unchanged (job perms `id-token: write` + `contents: write` are required for provenance + release; not widened).
+- **Input validation:** the core fix — strict `^[a-z0-9._-]+$` allowlist at the trust boundary, before any secret is in scope.
+- **Supply chain:** npm publish stays `--provenance` (OIDC-attested); the fix prevents hijacking that identity via injection.
+- **Crypto:** none.
+- **Residual:** a dispatch-capable actor can still trigger a *legitimate* publish (that's the workflow's purpose); F-006 is only about denying **arbitrary shell**. Restricting who can dispatch is org/branch-protection policy, out of this cluster's scope.
+
+## Assumptions
+**Facts (verified):**
+1. `_publish-sdk.yml` declares `workflow_dispatch` with a `dist_tag` string input (L3-10) and is also `workflow_call`able.
+2. L101 `run: npm publish … --tag ${{ inputs.dist_tag }} …` runs with `env: NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` (L99-101).
+3. L124/126 interpolate `${{ inputs.dist_tag }}` into a double-quoted `NOTES=` in a step carrying `env: GH_TOKEN: ${{ github.token }}` (L110-127).
+4. Local lint gate is `actionlint` via `bun run lint:actions` (root package.json script).
+5. CI gate `actionlint.yml` runs on `pull_request: [main, security-hardening]` (post-C0).
+6. `dist_tag` is an npm dist-tag; npm dist-tags are constrained (no spaces; not a valid semver) — `^[a-z0-9._-]+$` is a safe superset of the project's real tags (`testnet`, `nightlies`, `latest`).
+
+**Inferences (unverified):**
+- The release-notes backtick usage `\`${AZTEC_VERSION}\`` is already escaped/literal; adding `"$DIST_TAG"` won't interact with it. (Attack in audit.)
+- No other workflow interpolates `inputs.dist_tag` into shell (scope stays single-file). (grep to confirm.)
+
+**Asks (user):** none — fix is fully determined by the finding; autonomous per the campaign goal.
+
+## Seeds
+Not applicable per-cluster — the campaign-level `/goal` + `/loop` (in `../plan.md`) drive this. This cluster is one loop iteration.


### PR DESCRIPTION
Cluster C1 (workflow-input-hardening) — closes F-006 (command injection / token exfil in the SDK publish workflow).

**Fix:** validate dist_tag first (whole-string bash regex, letter-led, LC_ALL=C, env-read); npm publish uses `--tag=\"$DIST_TAG\"`; ALL run:/node interpolations env-routed + quoted (dist_tag + computed version outputs). No `${{ }}` remains in any run body.

**Blueprint (GATE 1):** /blueprint light; Codex gpt-5.6-sol@xhigh plan-audit = REJECT → folded (argument injection, validator multiline bypass, computed-output-not-a-trust-boundary, validate-first). See implementations-plan/security-hardening/clusters/C1-*.

**Local (GATE 4):** actionlint exit 0; interpolation-in-run proof clean; validator rejects attack vectors 13/13.

Deferred (documented): persist-credentials/split-priv, trusted-publishing/protected-env, SHA-pin (→C3), adjacent non-F-006 bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)