### PR TITLE
fix: code-review findings from the 5.0.1 bump (max review)

### DIFF
--- a/implementations-plan/aztec-5.0.1-2026-07-16/plan.md
+++ b/implementations-plan/aztec-5.0.1-2026-07-16/plan.md
@@ -59,7 +59,7 @@ Pure bump cycle first, token swap as a second playground-only cycle. Codex prefe
 
 **Validation gate:** PR CI green (sdk.yml transmit + app.yml incl. 3-graph typecheck + accelerator.yml + actionlint.yml + local-network job with whatever token-spec disposition P1 set); local download gate passes vs 5.0.1; PR auto-merges. Layers: lint · typecheck · unit · e2e (native bb 5.0.1) · download+digest.
 
-### P3 — FPC redeploy → pre-publish smoke → publish `testnet` → acceptance (incl. live-bundle token pass) → promote `latest`
+### P3 ✓ — FPC redeploy → pre-publish smoke → publish `testnet` → acceptance (incl. live-bundle token pass) → promote `latest` — gate passed 2026-07-16 (FPC `0x1441…970c` funded 1000 FJ; pre-publish standards smoke green; `testnet`=`latest`=5.0.1; registry-artifact + released-1.0.6 native + Safari owner-verified + WASM green; LIVE-BUNDLE standards token 500/500 recorded; contingency never fired)
 
 - **(a)** Fail-closed pre-flight (nodeVersion **expect `5.0.0` — correct this cycle**; l1ChainId 11155111; derived 5.0.1 salt-0 FPC `getContract` logged, RPC-error ≠ absent). Deploy `--salt 0x0`, `BRIDGE_AMOUNT=1000000000000000000000`; key via gitignored `scripts/.env` (recreate; delete at P3 end). Post-flight balance query in lessons.
 - **(b)** Pre-publish smoke on `dev:testnet` (registry port; playground-local vite): account deploy + **standards-token flow** (deploy w/ minter, mint 1000, private transfer 500, balances 500/500 — same narrative assertion as today's demo). Gates the publish. **CONTINGENCY TRIGGER LIVES HERE**: standards leg fails & not quickly fixable → revert swap commit → re-run account+FPC leg → proceed with the pure security patch → re-land swap later via `skip_sdk_publish=true` deploy.

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "test": "bun run lint && bun run test:typecheck && bun run test:unit",
     "test:all": "bun run test && bun run test:e2e",
     "test:e2e": "bun run --cwd packages/sdk test:e2e",
-    "test:scripts": "bun test scripts/",
-    "test:typecheck": "bun run --cwd packages/sdk test:lint && bun run --cwd packages/playground typecheck && bun run --cwd packages/playground typecheck:scripts",
+    "test:scripts": "bun test scripts/*.test.ts",
+    "test:typecheck": "tsc --noEmit -p tsconfig.scripts.json && bun run --cwd packages/sdk test:lint && bun run --cwd packages/playground typecheck && bun run --cwd packages/playground typecheck:scripts",
     "test:unit": "bun run --cwd packages/sdk test:unit && bun run --cwd packages/playground test:unit && bun run --cwd packages/accelerator test:unit && bun run test:scripts"
   },
   "lint-staged": {

--- a/packages/playground/e2e/demo.local-network.spec.ts
+++ b/packages/playground/e2e/demo.local-network.spec.ts
@@ -41,8 +41,10 @@ test.describe("Accelerated", () => {
 
   // Re-enabled at 5.0.1 (the "~7 min WASM regression" note was pre-5.0): the standards-token
   // demo is the surface under test. Self-skips without ACCELERATOR_URL (the CI job doesn't
-  // provide the accelerator today).
+  // provide the accelerator today). The 4-minute timeout IS the plan's CI-time budget —
+  // mechanized, not a comment asking a human to re-measure.
   test("runs full token flow", async () => {
+    test.setTimeout(240_000);
     const page = sharedPage;
     await expect(page.locator("#mode-accelerated")).toHaveClass(/mode-active/);
     await runTokenFlowAndAssert(page, "accelerated");
@@ -69,9 +71,10 @@ test.describe("Local", () => {
   });
 
   // Re-enabled at 5.0.1 as the automated behavioral gate on the standards token (WASM path;
-  // asserts the 500/500 balance outcome). Plan rule: if the measured CI time exceeds ~4 min,
-  // re-skip with the number recorded in the plan ledger.
+  // asserts a NEW 500/500 balance outcome). The 4-minute timeout IS the plan's CI-time
+  // budget — mechanized (measured: ~2 min in CI at 5.0.1).
   test("runs full token flow", async () => {
+    test.setTimeout(240_000);
     const page = sharedPage;
     await expect(page.locator("#mode-local")).toHaveClass(/mode-active/);
     await runTokenFlowAndAssert(page, "local");

--- a/packages/playground/e2e/fullstack.helpers.ts
+++ b/packages/playground/e2e/fullstack.helpers.ts
@@ -52,7 +52,9 @@ export async function initSharedPage(browser: { newPage: () => Promise<Page> }):
   }
 
   await expect(page.locator("#deploy-btn")).toBeEnabled();
-  await expect(page.locator("#token-flow-btn")).toBeEnabled();
+  // The token flow needs a session-deployed sender, so its button stays disabled
+  // until the first deploy of the session (ensureSessionAccount handles that).
+  await expect(page.locator("#token-flow-btn")).toBeDisabled();
 
   return page;
 }
@@ -92,11 +94,27 @@ export async function deployAndAssert(page: Page, mode: "local" | "accelerated")
   await expect(page.locator("#token-flow-btn")).toBeEnabled();
 }
 
+/**
+ * Ensure a session-deployed account exists (the token flow's sender requirement).
+ * The token-flow button stays disabled until one does, so its state is the signal.
+ */
+export async function ensureSessionAccount(page: Page, mode: "local" | "accelerated") {
+  if (await page.locator("#token-flow-btn").isDisabled()) {
+    await deployAndAssert(page, mode);
+  }
+}
+
 /** Run token flow and assert all UI state transitions. */
 export async function runTokenFlowAndAssert(
   page: Page,
   mode: "local" | "accelerated",
 ): Promise<void> {
+  await ensureSessionAccount(page, mode);
+  // Snapshot the shared #log BEFORE the run: the balance assertion below must match a NEW
+  // occurrence, not a stale line from an earlier token flow on the same page.
+  const priorMatches =
+    (await page.locator("#log").textContent())?.match(/Balances — Alice: 500, Bob: 500/g)?.length ??
+    0;
   await page.click("#token-flow-btn");
 
   await expect(page.locator("#progress")).not.toHaveClass(/hidden/);
@@ -112,7 +130,9 @@ export async function runTokenFlowAndAssert(
   );
   // Behavioral assertion, not just flow completion: mint 1000 → transfer 500 must land
   // exactly 500/500 (guards the standards-token semantics, not only the UI plumbing).
-  expect(flowLog).toContain("Balances — Alice: 500, Bob: 500");
+  // Occurrence-counted so a stale line from an earlier run can't satisfy it.
+  const nowMatches = flowLog?.match(/Balances — Alice: 500, Bob: 500/g)?.length ?? 0;
+  expect(nowMatches, "a NEW 500/500 balance line must appear for THIS run").toBe(priorMatches + 1);
 
   await expect(page.locator("#progress")).toHaveClass(/hidden/);
   await expect(page.locator("#results")).not.toHaveClass(/hidden/);

--- a/packages/playground/src/aztec.test.ts
+++ b/packages/playground/src/aztec.test.ts
@@ -17,7 +17,6 @@ afterEach(() => {
   state.embeddedWallet = null;
   state.registeredAddresses = [];
   state.sessionAddresses = [];
-  state.selectedAccountIndex = 0;
   state.uiMode = "accelerated";
   state.proofsRequired = false;
   state.feePaymentMethod = undefined;

--- a/packages/playground/src/aztec.ts
+++ b/packages/playground/src/aztec.ts
@@ -3,7 +3,6 @@ import {
   type AcceleratorPhaseData,
   AcceleratorProver,
 } from "@alejoamiras/aztec-accelerator";
-import { getInitialTestAccountsData } from "@aztec/accounts/testing/lazy";
 import { NO_FROM } from "@aztec/aztec.js/account";
 import { AztecAddress } from "@aztec/aztec.js/addresses";
 import { NO_WAIT } from "@aztec/aztec.js/contracts";
@@ -64,7 +63,6 @@ export interface AztecState {
    * so its entrypoint fails in-circuit with "Failed to get a note".
    */
   sessionAddresses: AztecAddress[];
-  selectedAccountIndex: number;
   uiMode: UiMode;
   /** True when the network requires real proofs (not simulated). */
   proofsRequired: boolean;
@@ -83,19 +81,14 @@ export const state: AztecState = {
   embeddedWallet: null,
   registeredAddresses: [],
   sessionAddresses: [],
-  selectedAccountIndex: 0,
   uiMode: "accelerated",
   proofsRequired: false,
   feePaymentMethod: undefined,
 };
 
-/** Pick the tx sender: the selected account if session-deployed, else any session account. */
+/** Pick the tx sender: the first session-deployed account (imported accounts can't sign here). */
 function pickSessionSender(): AztecAddress {
-  const selected = state.registeredAddresses[state.selectedAccountIndex];
-  const sender =
-    selected && state.sessionAddresses.some((a) => a.equals(selected))
-      ? selected
-      : state.sessionAddresses[0];
+  const sender = state.sessionAddresses[0];
   if (!sender) {
     throw new Error(
       "Deploy a test account first — imported accounts (e.g. sandbox test accounts) can't send from this session's wallet",
@@ -237,6 +230,11 @@ export async function initializeFPC(wallet: Wallet, log: LogFn): Promise<void> {
 }
 
 async function doInitializeWallet(log: LogFn): Promise<boolean> {
+  // Fresh wallet instance → any previously-tracked addresses belong to a dead ephemeral
+  // store and must not survive a retry (their notes are gone with the old store).
+  state.registeredAddresses = [];
+  state.sessionAddresses = [];
+
   await initializeNode(log);
 
   log("Creating wallet (may take a moment)...");
@@ -256,22 +254,8 @@ async function doInitializeWallet(log: LogFn): Promise<boolean> {
 
   await initializeFPC(state.wallet!, log);
 
-  if (!state.proofsRequired) {
-    log("Registering sandbox accounts...");
-    // Register accounts serially: one wallet store, deterministic ordering (historically this
-    // also dodged an IndexedDB TransactionInactiveError; the 5.0 store is in-memory).
-    const testAccounts = await getInitialTestAccountsData();
-    state.registeredAddresses = [];
-    for (const account of testAccounts) {
-      const mgr = await state.embeddedWallet!.createSchnorrAccount(
-        account.secret,
-        account.salt,
-        account.signingKey,
-      );
-      state.registeredAddresses.push(mgr.address);
-    }
-    log(`Registered ${state.registeredAddresses.length} accounts`, "success");
-  }
+  // NOTE: sandbox genesis test accounts are deliberately NOT registered anymore — since only
+  // session-deployed accounts can send (see sessionAddresses), importing them served nothing.
 
   return true;
 }
@@ -583,81 +567,17 @@ export async function deployTestAccount(
   }
 }
 
-export async function deployToken(
-  log: LogFn,
-  onTick: (elapsedMs: number) => void,
-  onStep: (stepName: string) => void,
-  onPhase?: (phase: AcceleratorPhase, data?: AcceleratorPhaseData) => void,
-): Promise<DeployResult> {
-  if (!state.wallet || state.registeredAddresses.length < 1) {
-    throw new Error("Wallet not initialized — no registered addresses");
-  }
-
-  const mode = state.uiMode;
-  const alice = pickSessionSender();
-  const steps: StepTiming[] = [];
-  const totalStart = Date.now();
-  const proveTracker = createProveTracker();
-  state.prover?.setOnPhase(
-    onPhase
-      ? (phase, data) => {
-          if (phase === "proved" && data?.durationMs) proveTracker.set(data.durationMs);
-          onPhase(phase, data);
-        }
-      : null,
-  );
-
-  const interval = setInterval(() => {
-    onTick(Date.now() - totalStart);
-  }, 100);
-
-  try {
-    onStep("deploying token");
-    log("Deploying TokenContract (minter=Alice)...");
-    // constructor_with_minter: auth_contract = ZERO disables the authorization hooks
-    // (verified against the aztec-standards Noir source — "zero address to disable").
-    const tokenDeploy = TokenContract.deployWithOpts(
-      { method: "constructor_with_minter", wallet: state.wallet },
-      "Accelerator",
-      "ACEL",
-      18,
-      alice,
-      AztecAddress.ZERO,
-    );
-    const { timing: tokenStep, txHash: tokenTxHash } = await executeStep({
-      step: "deploy token",
-      method: tokenDeploy,
-      sendOpts: { from: alice, fee: { paymentMethod: state.feePaymentMethod! } },
-      log,
-      onConfirming: () => onStep("confirming token deploy"),
-      proveTracker,
-    });
-    steps.push(tokenStep);
-
-    const address = (await tokenDeploy.getAddress()).toString();
-    const totalDurationMs = Date.now() - totalStart;
-    log(
-      `Token deployed in ${(totalDurationMs / 1000).toFixed(1)}s → ${address}`,
-      "success",
-      `${EXPLORER_BASE}/${tokenTxHash}`,
-    );
-
-    return { address, steps, totalDurationMs, mode };
-  } finally {
-    state.prover?.setOnPhase(null);
-    clearInterval(interval);
-  }
-}
-
 export async function runTokenFlow(
   log: LogFn,
   onTick: (elapsedMs: number) => void,
   onStep: (stepName: string) => void,
   onPhase?: (phase: AcceleratorPhase, data?: AcceleratorPhaseData) => void,
 ): Promise<TokenFlowResult> {
-  if (!state.wallet || state.registeredAddresses.length < 1) {
-    throw new Error("Wallet not initialized — deploy at least one account first");
+  if (!state.wallet) {
+    throw new Error("Wallet not initialized");
   }
+  // Sender validity (session-deployed account exists) is checked by pickSessionSender below,
+  // which throws the actionable "deploy a test account first" guidance on every network.
 
   const mode = state.uiMode;
   const alice = pickSessionSender();

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -94,7 +94,9 @@ function handleProverPhase(ascii: AsciiController, phase: string, _data?: unknow
 
 function setActionButtonsDisabled(disabled: boolean): void {
   $btn("deploy-btn").disabled = disabled;
-  $btn("token-flow-btn").disabled = disabled;
+  // The token flow needs a session-deployed sender (see pickSessionSender) — an enabled
+  // button must imply the action can succeed, so it stays disabled until one exists.
+  $btn("token-flow-btn").disabled = disabled || state.sessionAddresses.length === 0;
 }
 
 // ── Deploy ──

--- a/scripts/check-aztec-update.ts
+++ b/scripts/check-aztec-update.ts
@@ -8,7 +8,7 @@
  * Output: JSON with { current, latest, needsUpdate }
  */
 
-const distTag = process.argv[2];
+const distTag = process.argv[2] ?? "";
 if (!distTag) {
   console.error("Usage: bun scripts/check-aztec-update.ts <dist-tag>");
   console.error("Examples:");

--- a/scripts/update-aztec-version.ts
+++ b/scripts/update-aztec-version.ts
@@ -98,9 +98,11 @@ async function pinWindowsBbChecksum(version: string): Promise<string> {
     if (!res.ok) return `Windows bb checksum: fetch failed (HTTP ${res.status}) — pin "${version}" in ${COPY_BB_FILE} manually.`;
     const digest = await crypto.subtle.digest("SHA-256", await res.arrayBuffer());
     const sha = [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
-    const marker = "};\n\nexport function resolveWindowsBbChecksum";
-    const idx = original.indexOf(marker);
-    const entry = `  // @aztec/bb.js ${version} — sha256 of barretenberg-amd64-windows.tar.gz from the v${version} release (auto-pinned).\n  "${version}": "${sha}",\n`;
+    // Anchor on the CHECKSUMS map's own closing brace — not on whatever declaration happens
+    // to follow the map (that anchor went stale once before and auto-insert silently failed).
+    const mapStart = original.indexOf("const WINDOWS_BB_CHECKSUMS");
+    const idx = mapStart === -1 ? -1 : original.indexOf("\n};", mapStart);
+    const entry = `\n  // @aztec/bb.js ${version} — sha256 of barretenberg-amd64-windows.tar.gz from the v${version} release (auto-pinned).\n  "${version}": "${sha}",`;
     if (idx === -1) return `Windows bb checksum for ${version} = ${sha} — couldn't auto-insert; add it to ${COPY_BB_FILE} manually.`;
     await Bun.write(COPY_BB_FILE, original.slice(0, idx) + entry + original.slice(idx));
     return `Windows bb checksum: pinned ${version} = ${sha.slice(0, 12)}… in ${COPY_BB_FILE}.`;
@@ -128,6 +130,18 @@ async function main() {
   const skipPackages = await findMissingPackages(newVersion, PACKAGE_JSON_FILES);
   if (skipPackages.size > 0) {
     console.log(`Skipping unpublished packages: ${[...skipPackages].join(", ")}`);
+    // LOCKSTEP packages track @aztec/* releases from a DIFFERENT publisher — a skip here means
+    // the app would run mixed versions (undeclared runtime imports of @aztec/aztec.js make that
+    // lockstep a hard requirement). Loud, not fatal: nightlies stay unblocked, and the CI token
+    // spec is the behavioral gate that catches a truly broken mix.
+    const lockstepSkipped = [...skipPackages].filter((p) => LOCKSTEP_PACKAGES.has(p));
+    if (lockstepSkipped.length > 0) {
+      console.warn(
+        `⚠️  LOCKSTEP PACKAGE(S) NOT PUBLISHED AT ${newVersion}: ${lockstepSkipped.join(", ")} — ` +
+          `left at their previous version; the app will mix versions until they publish. ` +
+          `Verify the CI token spec passes before trusting this bump.`,
+      );
+    }
   }
 
   let updatedFiles = 0;

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // Root has no "type: module", so NodeNext would treat these Bun-run ESM scripts as CJS.
+    "module": "Preserve",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["scripts/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Applies 13 of 15 verified findings from the post-merge `/code-review max` pass on the net 5.0.1 diff (#395). No behavior change to the release artifacts — this hardens the playground demo path, the e2e gates, and the bump tooling.

### Playground (`src/`)
- **Dead code removal**: unused `deployToken` function and the never-read `selectedAccountIndex` state field.
- **State reset on re-init**: `doInitializeWallet` now clears `registeredAddresses`/`sessionAddresses` so a re-initialized wallet can't reference stale addresses.
- **Genesis-account registration block removed**: those accounts' notes are undiscoverable in the ephemeral PXE (the sessionAddresses fix in #395); registering them only invited misuse.
- **Token-flow button gated** on an existing session sender — an enabled button now implies the action can succeed; the actionable "deploy a test account first" error still reaches live-network users via `pickSessionSender`.

### E2E (`e2e/`)
- **Stale-log-proof balance assertion**: the 500/500 check now counts occurrences before/after the run, so a leftover line from an earlier token flow can't satisfy the gate.
- **Self-sufficient token-flow specs**: `ensureSessionAccount` deploys a sender if the button is disabled, instead of depending on spec ordering.
- **Mechanized time budget**: `test.setTimeout(240_000)` encodes the plan's ~4-min CI budget instead of a comment asking a human to re-measure.

### Bump tooling (`scripts/`)
- **Loud LOCKSTEP-skip warning**: if `@aztec-foundation/aztec-standards` isn't published at the target version, the skip is now flagged as a version-mix hazard (still exit 0 — the CI token spec is the behavioral gate).
- **Fixed silently-dead checksum auto-insert**: the Windows bb.js pin anchored on a declaration that no longer follows the map; now anchors on the map's own closing brace (verified against the real file).
- **Root scripts typecheck**: new `tsconfig.scripts.json` wired into `test:typecheck` — immediately caught a real `string | undefined` bug in `check-aztec-update.ts`. Also fixed `test:scripts` to `bun test scripts/*.test.ts` so it can't substring-match `packages/accelerator/scripts/`.

### Skipped (2)
- Bob-deploy timing skew in the live flow — pre-existing behavior, explicitly itemized in the steps breakdown.
- Deep-path standards import — ledgered residual; upstream package has no exports map.

## Validation
- `bun run test` green (lint + typecheck incl. new scripts tsconfig + all units incl. 20 scripts tests)
- Playground production build green; mocked e2e 8/8; production smoke 2/2; `bun run lint:actions` clean
- Checksum auto-insert simulated against the real `copy-bb.ts` — entry lands inside the map

🤖 Generated with [Claude Code](https://claude.com/claude-code)