### PR TITLE
fix(version-policy): replace bb version floor with a revocation denylist (no UX break)

### DIFF
--- a/packages/accelerator/core/src/server/prove.rs
+++ b/packages/accelerator/core/src/server/prove.rs
@@ -72,6 +72,21 @@ pub(crate) fn resolve_version(
     };
     tracing::info!(version = %version, "Requested Aztec version");
 
+    // `x-aztec-version` is remote-controlled, so check well-formedness + the known-vulnerable REVOCATION
+    // denylist FIRST — BEFORE the bundled short-circuit below (codex denylist-review #1), so a version
+    // the owner has revoked is refused even if it happens to be the bundled one (fail closed; the owner
+    // ships a new bundled version alongside any such revocation). There is NO version FLOOR: the header
+    // is the Aztec version (not a bb version) and many Aztec releases share one bb, so an
+    // older-but-compatible request must be honoured (downloads are still digest-verified against Aztec's
+    // published hash). The denylist is empty by default ⇒ any well-formed version is allowed.
+    if let Err(rej) = versions::check_version_selectable(&version) {
+        tracing::warn!(version = %version, reason = rej.reason(), "Refused remote Aztec version");
+        return Err(ProveError::VersionNotAllowed {
+            version: version.to_string(),
+            reason: rej.reason(),
+        });
+    }
+
     let bundled = state
         .bundled_version
         .as_deref()
@@ -85,18 +100,6 @@ pub(crate) fn resolve_version(
         return Ok(ResolvedVersion {
             version: None,
             needs_download: false,
-        });
-    }
-
-    // codex audit #3: `x-aztec-version` is remote-controlled, so a non-bundled request must clear the
-    // downgrade policy BEFORE we download/execute it — otherwise a dApp could force an authentic-but-
-    // -vulnerable OLD bb (or an arbitrary dev build). Every version that survives this gate is one we
-    // consider safe to prove with. The bundled request already returned above.
-    if let Err(rej) = versions::check_version_selectable(&version, bundled) {
-        tracing::warn!(version = %version, bundled = %bundled, reason = rej.reason(), "Refused remote bb version");
-        return Err(ProveError::VersionNotAllowed {
-            version: version.to_string(),
-            reason: rej.reason(),
         });
     }
 

--- a/packages/accelerator/core/src/server/tests.rs
+++ b/packages/accelerator/core/src/server/tests.rs
@@ -998,12 +998,10 @@ fn resolve_version_flags_uncached_for_download() {
     // (download_bb needs the network); the no-download arm is pinned by
     // `prove_success_path_and_status_sequence`, and prove() emits Downloading/Proving structurally
     // around this flag.
-    // codex #3: a non-bundled request must now clear the downgrade policy, so use a bundled FLOOR
-    // strictly below the request on the same rc channel.
     let core = HeadlessState::headless("1.0.0", Some("5.0.0-rc.1".to_string()), None, None);
     let state = AppState::headless(core);
     let version = Some("5.0.0-rc.2".to_string());
-    let resolved = resolve_version(&state, &version).expect("valid newer version resolves");
+    let resolved = resolve_version(&state, &version).expect("valid version resolves");
     assert_eq!(resolved.version.as_deref(), Some("5.0.0-rc.2"));
     assert!(
         resolved.needs_download,
@@ -1012,14 +1010,17 @@ fn resolve_version_flags_uncached_for_download() {
 }
 
 #[test]
-fn resolve_version_rejects_downgrade_below_bundled() {
-    // codex #3: a remote x-aztec-version older than the bundled floor is a downgrade → 403, never
-    // downloaded/executed. Bundled is rc.2; requesting the older rc.1 must be refused.
+fn resolve_version_allows_older_compatible_version() {
+    // The x-aztec-version header is an Aztec version, not a bb version, and many Aztec releases share
+    // one bb — so an OLDER-but-compatible request (e.g. a 5.0.0-rc.1 dApp against a 5.0.0-rc.2 bundle)
+    // MUST be honoured, not rejected. (This is the over-blocking bug the earlier floor introduced; the
+    // gate is now a known-vulnerable revocation denylist, empty by default.) It still resolves for
+    // download + digest verification.
     let core = HeadlessState::headless("1.0.0", Some("5.0.0-rc.2".to_string()), None, None);
     let state = AppState::headless(core);
-    let result = resolve_version(&state, &Some("5.0.0-rc.1".to_string()));
-    let err = result.expect_err("a downgrade must be refused");
-    assert_eq!(err.into_response().status(), StatusCode::FORBIDDEN);
+    let resolved = resolve_version(&state, &Some("5.0.0-rc.1".to_string()))
+        .expect("an older compatible version must be allowed");
+    assert_eq!(resolved.version.as_deref(), Some("5.0.0-rc.1"));
 }
 
 #[test]

--- a/packages/accelerator/core/src/versions/version_policy.rs
+++ b/packages/accelerator/core/src/versions/version_policy.rs
@@ -180,116 +180,83 @@ pub fn versions_to_evict(
     to_evict
 }
 
-/// Older bb versions that are BELOW the bundled floor yet explicitly vetted-safe, so a remote
-/// `x-aztec-version` request for one is still honoured. **EMPTY by default** — the app owner curates
-/// this list after confirming each entry has no known proving-soundness or security defect. It is a
-/// COMPILE-TIME constant on purpose: a remote dApp must never be able to widen the set of selectable
-/// versions at runtime (that would defeat the whole downgrade gate). See CONVERGED-SCOPE "NEEDS THE
-/// OWNER — vetted bb-version policy content".
-pub const VETTED_OLDER_VERSIONS: &[&str] = &[];
+/// Aztec versions whose bundled `bb` is KNOWN to be vulnerable — a REVOCATION list, **EMPTY by default**.
+///
+/// `x-aztec-version` carries the **Aztec** version (the SDK's `@aztec/stdlib` dependency version), NOT a
+/// barretenberg/`bb` version — and many Aztec releases ship the *same* `bb`. So a "newer-is-safer" floor
+/// keyed on this string would wrongly reject a legitimate older-but-compatible dApp (e.g. an Aztec 5.0.1
+/// app talking to a 5.1.0-bundled accelerator). Instead this is a targeted denylist: the app owner adds a
+/// version string here ONLY if a security defect is found in the `bb` shipped with that Aztec release,
+/// and a remote request for it is then refused (403). Empty ⇒ no restriction — any version the dApp
+/// requests is allowed, and it is still digest-verified against Aztec's published hash on download (so it
+/// is always an AUTHENTIC Aztec `bb`). COMPILE-TIME so a remote dApp cannot change it. Entries must be the
+/// exact wire version string the SDK sends.
+pub const KNOWN_VULNERABLE_VERSIONS: &[&str] = &[];
 
 /// Why a remote-requested version was refused by [`check_version_selectable`]. Carried into the 403
-/// body + a `warn!` so a legitimate integrator can see WHY their pin was rejected.
+/// body + a `warn!` so a legitimate integrator sees WHY their pin was rejected.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VersionRejection {
-    /// Passed the `is_valid_version` charset gate but is not a strict semver — a syntactic alias
-    /// (`latest`, `5`, `5.0`, `5.0.0-alpha_beta`, …). Rejected so only well-formed versions are ever
-    /// floored/compared.
+    /// Passed the `is_valid_version` charset gate but is not a canonical strict semver — a syntactic
+    /// alias (`latest`, `5`, `5.0`) or a non-canonical spelling. Rejected so only well-formed versions
+    /// are ever fetched or exact-matched against the revocation list (codex denylist-review #2).
     NotSemver,
-    /// Carries `+build` metadata. SemVer precedence IGNORES build metadata, so two builds with equal
-    /// precedence are distinct release identities we cannot reason about — refuse them (codex audit #3).
-    /// NOTE: over HTTP this is unreachable — `is_valid_version` rejects `+` first (400 `invalid_version`);
-    /// this arm is for direct/future callers and keeps the policy self-contained (codex r2 #7).
+    /// Carries `+build` metadata. Two builds with equal SemVer precedence are distinct release
+    /// identities we can't reason about — refuse them.
     HasBuildMetadata,
-    /// Not strictly newer than the bundled baseline (by SemVer *precedence*) — a downgrade/sidegrade to
-    /// a potentially-vulnerable bb. Blocked.
-    BelowFloor,
-    /// A prerelease on a channel the bundled baseline is NOT on (e.g. a `nightly`/`devnet` dev build, or
-    /// any prerelease requested against a stable bundled). Only stable, or the bundled's own prerelease
-    /// channel, is a valid forward target.
-    ChannelNotAllowed,
+    /// The requested Aztec version is on the [`KNOWN_VULNERABLE_VERSIONS`] revocation list.
+    KnownVulnerable,
 }
 
 impl VersionRejection {
     /// Short, stable reason string for logs + the error body.
     pub fn reason(self) -> &'static str {
         match self {
-            Self::NotSemver => "not a strict semver version",
-            Self::HasBuildMetadata => "carries build metadata (ambiguous precedence)",
-            Self::BelowFloor => "not strictly newer than the bundled version (downgrade refused)",
-            Self::ChannelNotAllowed => "prerelease channel not selectable for this release",
+            Self::NotSemver => "not a canonical strict semver version",
+            Self::HasBuildMetadata => "carries build metadata (ambiguous release identity)",
+            Self::KnownVulnerable => "on the known-vulnerable revocation list",
         }
     }
 }
 
-/// The release "channel" of a version, for the forward-target rule. `Stable` = no prerelease; a
-/// prerelease's channel is its FIRST dot-separated prerelease identifier (`rc`, `nightly`, `devnet`,
-/// `aztecnr-rc`, …). Compared verbatim (case-sensitive) so `RC` ≠ `rc`.
-fn channel(v: &semver::Version) -> Option<&str> {
-    if v.pre.is_empty() {
-        None // stable
-    } else {
-        Some(v.pre.as_str().split('.').next().unwrap_or(v.pre.as_str()))
-    }
+/// Gate a REMOTE `x-aztec-version` request.
+///
+/// The header is the **Aztec** version, not a `bb` version, and the accelerator downloads the `bb`
+/// tarball attached to the Aztec release of that exact version. We therefore CANNOT impose a
+/// "newer-is-safer" floor here — many Aztec versions share one `bb`, so a floor would break a legitimate
+/// older-but-compatible dApp (this was the over-blocking bug this function replaces). Every download is
+/// already digest-verified against Aztec's published hash, so a requested version is always an authentic
+/// Aztec `bb`. The only residual risk — an approved dApp pinning an Aztec version whose bundled `bb` is
+/// *later* found vulnerable — is handled REACTIVELY via the [`KNOWN_VULNERABLE_VERSIONS`] revocation list
+/// (empty by default). Everything not on that list is allowed.
+///
+/// Well-formedness is STILL enforced (codex denylist-review #2): the request must be canonical strict
+/// semver with no build metadata. This rejects aliases (`latest`) the looser `is_valid_version` charset
+/// gate lets through, and keeps the exact-string revocation match meaningful.
+///
+/// (A precise FUTURE gate could run `bb --version` on the downloaded binary to obtain the true
+/// barretenberg build id — distinct from the Aztec/npm version — and denylist on THAT, or ship a signed
+/// updateable revocation manifest. Larger cross-package changes, tracked separately.)
+pub fn check_version_selectable(requested: &str) -> Result<(), VersionRejection> {
+    check_version_against(requested, KNOWN_VULNERABLE_VERSIONS)
 }
 
-/// Gate a REMOTE `x-aztec-version` request against a safe-default downgrade policy.
-///
-/// `x-aztec-version` is remote-controlled, and any requested version is downloaded AUTHENTICALLY
-/// (GitHub asset digest-checked). The residual risk is therefore NOT a tampered binary but a remote
-/// dApp forcing a *downgrade* to an authentic-but-known-vulnerable old bb, or coercing an arbitrary
-/// nightly/devnet dev build. The caller MUST have already normalized an exact-bundled request to the
-/// sidecar path — this function only ever sees NON-bundled requests.
-///
-/// Policy (safe default — every selectable version must already be safe; codex #3 / r2 #2 / r3 #2 / r4 #1):
-/// 1. The request must parse as STRICT semver (rejects syntactic aliases the looser [`is_valid_version`]
-///    charset gate lets through) and carry no `+build` metadata (ambiguous precedence). Checked FIRST so
-///    it holds for every path below (allowlist / no-baseline included).
-/// 2. An explicitly owner-vetted older version ([`VETTED_OLDER_VERSIONS`]) then bypasses only the
-///    floor/channel (it may be below the floor by design) — never the well-formedness gate.
-/// 3. If the BUNDLED baseline does not parse as semver, there is no floor to enforce (the normal
-///    headless case — no shipped bb to downgrade FROM), so allow: the request is validated above and the
-///    download is digest-verified. Desktop always has a compile-time baseline.
-/// 4. Floor: the request must be STRICTLY NEWER than bundled by SemVer *precedence* (`cmp_precedence`,
-///    which ignores build metadata — not Rust's total `Ord`). This is the downgrade block. Note SemVer
-///    precedence is a label order, not a chronology/safety order, hence rules 2 & 5 on top of it.
-/// 5. Forward target: the request must be stable, OR share the bundled baseline's exact prerelease
-///    channel. This drops nightly/devnet dev builds, unknown prerelease channels, and stable→prerelease
-///    unless the shipped baseline is itself on that channel.
-pub fn check_version_selectable(requested: &str, bundled: &str) -> Result<(), VersionRejection> {
-    use std::cmp::Ordering;
-
-    // 1. Validate the REQUEST unconditionally (codex r2 #2 / r3 #2 / r4 #1): strict semver + no `+build`
-    //    metadata. This runs BEFORE the allowlist and the baseline check so the guarantee holds for EVERY
-    //    path — a syntactic alias (`latest`) or a `+build` version is rejected even if it were later
-    //    allowlisted or the bundled version is unknown (headless). A real SDK always pins a strict semver.
-    let req = semver::Version::parse(requested).map_err(|_| VersionRejection::NotSemver)?;
-    if !req.build.is_empty() {
+/// Inner, denylist-parameterized core of [`check_version_selectable`] — unit-testable against an
+/// arbitrary revocation list (the production const is empty). Validates well-formedness FIRST, then the
+/// revocation match.
+fn check_version_against(requested: &str, denylist: &[&str]) -> Result<(), VersionRejection> {
+    // Canonical strict semver, no build metadata — same well-formedness the earlier gate enforced.
+    let v = semver::Version::parse(requested).map_err(|_| VersionRejection::NotSemver)?;
+    if v.to_string() != requested {
+        return Err(VersionRejection::NotSemver); // non-canonical spelling
+    }
+    if !v.build.is_empty() {
         return Err(VersionRejection::HasBuildMetadata);
     }
-    // 2. Owner-vetted older version bypasses only the FLOOR/channel (may be below the floor by design);
-    //    it does NOT bypass the well-formedness gate above.
-    if VETTED_OLDER_VERSIONS.contains(&requested) {
-        return Ok(());
+    if denylist.contains(&requested) {
+        return Err(VersionRejection::KnownVulnerable);
     }
-    // 3. No parseable bundled baseline ⇒ NO floor/channel to compare against. This is the normal
-    //    headless case (no shipped bb to downgrade FROM), so failing closed would brick its documented
-    //    first-request-download mode. The request is already validated above + digest-verified on
-    //    download. The DESKTOP app always has a compile-time `AZTEC_BB_VERSION`, so its floor holds below.
-    let Ok(base) = semver::Version::parse(bundled) else {
-        return Ok(());
-    };
-    // 4. Strictly-newer by PRECEDENCE (ignores build metadata). Exact-bundled is handled upstream, so
-    //    an equal-precedence request here is a sidegrade — refuse it.
-    if req.cmp_precedence(&base) != Ordering::Greater {
-        return Err(VersionRejection::BelowFloor);
-    }
-    // 5. Stable, or the bundled baseline's own prerelease channel — nothing else.
-    match channel(&req) {
-        None => Ok(()), // stable is always a safe forward target
-        Some(req_ch) if channel(&base) == Some(req_ch) => Ok(()),
-        Some(_) => Err(VersionRejection::ChannelNotAllowed),
-    }
+    Ok(())
 }
 
 /// Validate a version string before it is used to build cache paths or download URLs. THE single
@@ -604,116 +571,73 @@ mod tests {
         assert!(evicted.contains(&av("5.0.0-nightly.20260301")));
     }
 
-    // ─── remote version-downgrade policy (codex audit #3) ───────────────────
+    // ─── remote version selection: known-vulnerable revocation denylist ─────────
 
     #[test]
-    fn version_policy_allows_strictly_newer_same_channel_and_stable() {
-        // Newer rc, same channel as an rc baseline → allowed (the legit "dApp on a newer testnet" case).
-        assert_eq!(check_version_selectable("5.0.0-rc.5", "5.0.0-rc.2"), Ok(()));
-        assert_eq!(check_version_selectable("5.1.0-rc.1", "5.0.0-rc.2"), Ok(()));
-        // Stable is always a safe forward target above the floor, whatever the baseline channel.
-        assert_eq!(check_version_selectable("5.0.0", "5.0.0-rc.2"), Ok(()));
-        assert_eq!(check_version_selectable("5.1.0", "5.0.0"), Ok(()));
+    fn version_policy_allows_everything_by_default() {
+        // The header is the Aztec version (not a bb version), and many Aztec releases share one bb, so
+        // there is NO floor: any well-formed version a dApp requests is allowed — including OLDER ones —
+        // so a legitimate older-but-compatible app is never broken. Default (empty) production denylist.
+        for v in [
+            "5.0.0",
+            "5.1.0",
+            "5.0.1", // older than a 5.1.0 bundle — MUST still be allowed (the bug this replaces)
+            "5.0.0-rc.1", // older rc
+            "5.0.0-nightly.20260307",
+            "4.2.0-aztecnr-rc.2",
+        ] {
+            assert_eq!(check_version_selectable(v), Ok(()), "{v} must be allowed");
+        }
     }
 
     #[test]
-    fn version_policy_blocks_downgrade_and_sidegrade() {
-        // Older rc, older stable, and the SAME precedence (sidegrade) are all refused.
+    fn version_policy_refuses_a_denylisted_version() {
+        // Exercise the REAL implementation (check_version_against) with a simulated revocation list —
+        // the production const is empty, so this is how we cover the refusal path (codex review #3).
+        let deny = &["5.0.7", "5.1.3-rc.1"];
         assert_eq!(
-            check_version_selectable("5.0.0-rc.1", "5.0.0-rc.2"),
-            Err(VersionRejection::BelowFloor)
+            check_version_against("5.0.7", deny),
+            Err(VersionRejection::KnownVulnerable)
         );
         assert_eq!(
-            check_version_selectable("4.9.0", "5.0.0"),
-            Err(VersionRejection::BelowFloor)
+            check_version_against("5.1.3-rc.1", deny),
+            Err(VersionRejection::KnownVulnerable)
         );
-        // A stable request equals the FINAL release precedence-wise but is strictly greater than its
-        // own rc, so this pair specifically checks the equal-precedence sidegrade guard:
-        assert_eq!(
-            check_version_selectable("5.0.0-rc.2", "5.0.0-rc.2"),
-            Err(VersionRejection::BelowFloor),
-            "exact-bundled is normalized upstream; reaching here with equal precedence is a sidegrade"
-        );
-    }
-
-    #[test]
-    fn version_policy_blocks_dev_and_unknown_channels() {
-        // nightly/devnet dev builds, even when strictly newer, are refused against an rc/stable baseline.
-        assert_eq!(
-            check_version_selectable("5.1.0-nightly.20260307", "5.0.0-rc.2"),
-            Err(VersionRejection::ChannelNotAllowed)
-        );
-        assert_eq!(
-            check_version_selectable("6.0.0-devnet.20260307", "5.0.0"),
-            Err(VersionRejection::ChannelNotAllowed)
-        );
-        // An unknown/foreign prerelease channel above the floor is refused too.
-        assert_eq!(
-            check_version_selectable("6.0.0-alpha.1", "5.0.0-rc.2"),
-            Err(VersionRejection::ChannelNotAllowed)
-        );
-        // …but if the baseline is ITSELF a nightly dev build, a newer nightly on the same channel is fine.
-        assert_eq!(
-            check_version_selectable("5.0.0-nightly.20260310", "5.0.0-nightly.20260307"),
-            Ok(())
-        );
+        // Neighbouring versions are unaffected — the denylist is exact, not a range.
+        assert_eq!(check_version_against("5.0.8", deny), Ok(()));
+        assert_eq!(check_version_against("5.0.6", deny), Ok(()));
     }
 
     #[test]
     fn version_policy_rejects_aliases_and_build_metadata() {
-        // Syntactic aliases that pass is_valid_version's charset gate but are not strict semver.
+        // Well-formedness is still enforced (codex review #2): aliases the charset gate lets through, a
+        // non-canonical spelling, and build metadata are all rejected BEFORE any download / revocation
+        // match — regardless of the denylist.
         for alias in ["latest", "5", "5.0", "5.0.0-alpha_beta"] {
             assert_eq!(
-                check_version_selectable(alias, "5.0.0-rc.2"),
+                check_version_selectable(alias),
                 Err(VersionRejection::NotSemver),
                 "alias {alias:?} must be rejected"
             );
         }
-        // Build metadata is refused (ambiguous precedence) even when otherwise newer.
         assert_eq!(
-            check_version_selectable("5.1.0+build9", "5.0.0-rc.2"),
+            check_version_selectable("5.1.0+build9"),
             Err(VersionRejection::HasBuildMetadata)
         );
     }
 
     #[test]
-    fn version_policy_unknown_bundled_has_no_floor_but_still_validates_request() {
-        // codex r2 #2: a headless server without AZTEC_BB_VERSION has bundled = "unknown" (unparseable).
-        // There is no shipped bb to downgrade FROM, so the policy imposes NO FLOOR/CHANNEL — otherwise
-        // the documented first-request-download mode would be bricked (every real version → 403). Any
-        // strict-semver version (even a nightly / an older one) is allowed.
-        assert_eq!(check_version_selectable("5.0.0", "unknown"), Ok(()));
-        assert_eq!(check_version_selectable("4.0.0", "unknown"), Ok(()));
-        assert_eq!(
-            check_version_selectable("5.0.0-nightly.20260307", "unknown"),
-            Ok(())
-        );
-        // codex r3 #2: but the REQUEST is still validated even without a baseline — aliases and build
-        // metadata are rejected (a headless caller can't select `latest` or a `+build` version).
-        assert_eq!(
-            check_version_selectable("latest", "unknown"),
-            Err(VersionRejection::NotSemver)
-        );
-        assert_eq!(
-            check_version_selectable("5.0.0+build9", "unknown"),
-            Err(VersionRejection::HasBuildMetadata)
-        );
-    }
-
-    #[test]
-    fn version_policy_allowlist_overrides_floor() {
-        // The default allowlist is empty, so an older version is refused…
-        assert!(VETTED_OLDER_VERSIONS.is_empty());
-        assert_eq!(
-            check_version_selectable("4.0.0", "5.0.0"),
-            Err(VersionRejection::BelowFloor)
-        );
-        // …and every allowlist entry (if the owner adds any later) must itself be strict semver so the
-        // exact-match compare is meaningful.
-        for v in VETTED_OLDER_VERSIONS {
-            assert!(
-                semver::Version::parse(v).is_ok(),
-                "VETTED_OLDER_VERSIONS entry {v:?} must be strict semver"
+    fn version_policy_denylist_entries_are_wellformed_if_present() {
+        // If the owner ever populates the list, each entry must be a canonical strict semver so it
+        // matches the exact wire version the SDK sends. Does NOT assert emptiness (codex review #4: an
+        // emptiness assertion would break CI exactly when an emergency revocation is added).
+        for v in KNOWN_VULNERABLE_VERSIONS {
+            let parsed = semver::Version::parse(v)
+                .unwrap_or_else(|_| panic!("KNOWN_VULNERABLE_VERSIONS entry {v:?} must be semver"));
+            assert_eq!(
+                &parsed.to_string(),
+                v,
+                "KNOWN_VULNERABLE_VERSIONS entry {v:?} must be canonical"
             );
         }
     }


### PR DESCRIPTION
Follow-up to #400. Removes the `x-aztec-version` version **floor** shipped there and replaces it
with a **revocation denylist**, because the floor over-blocks a legitimate, common case.

## Why the floor was wrong
`x-aztec-version` is the **Aztec** version (the SDK's `@aztec/stdlib` dependency version), **not** a
barretenberg/`bb` version — and many Aztec releases ship the **same** `bb`. Three code
investigations confirmed:
- The SDK sends its `@aztec/stdlib` dep version verbatim (`accelerator-prover.ts` → header).
- `@aztec/bb.js` exposes no bb version to JS; the real bb build id is only obtainable via
  `bb --version` on the compiled binary (and it differs from the npm version).
- The accelerator downloads `bb` from `AztecProtocol/aztec-packages` releases **tagged by the
  Aztec version**, digest-verified against Aztec's published hash.

So "newer Aztec version = safer" is false, and the floor **certainly breaks** a valid client:
bundle Aztec 5.1.0, a dApp on Aztec 5.0.1 (same `bb`) connects → wrongly rejected. The downgrade
threat the floor defended is only *conditional* (needs an authentic-but-known-vulnerable old `bb`
+ a malicious origin-approved dApp).

## What this does instead
- `KNOWN_VULNERABLE_VERSIONS` — a targeted **revocation denylist, empty by default**. Any
  well-formed Aztec version is allowed (older ones included); the owner adds an entry only when a
  defect is found in that release's `bb`. This is the reactive "revocation" codex recommended in
  round 1, with **zero UX cost**.
- Downloads stay digest-verified → a requested version is always an **authentic** Aztec `bb`.
- Well-formedness (canonical strict semver, no build metadata) is still enforced, so aliases like
  `latest` are rejected and exact-string revocation stays meaningful.

## Codex xhigh reviewed; findings addressed
- Revocation checked **before** the exact-bundled short-circuit (fail closed even for the bundled
  version).
- Kept strict-semver validation (only floor/channel comparison removed).
- Refusal-path test exercises the real logic via a denylist-parameterized inner fn.
- Dropped the `is_empty()` assertion that would break CI on an emergency revocation.
- Log says "Aztec version", not "bb version".

## Accepted residual
An approved dApp can select any authentic historical/dev Aztec release until it is revoked + the
app updated. A stronger future gate — denylist by the true `bb --version` build id, or a signed
updateable revocation manifest — is a larger cross-package change, tracked separately.

## Validation
core 184 unit tests + clippy + fmt; server + tauri (webdriver) `cargo check`. `resolve_version`
now has an explicit test that an **older compatible version is allowed** (the case this fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
