### PR TITLE
fix(security): whole-branch codex audit + remediation (F2/A1/B1-B2/G2/H3 + owner runbook)

### DIFF
--- a/.github/workflows/_publish-sdk.yml
+++ b/.github/workflows/_publish-sdk.yml
@@ -145,8 +145,25 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "$TAG" || true
-          git push origin "$TAG" || true
+
+          # F2 (full-branch audit): NEVER suppress tag/push failures with `|| true`. The old form let a
+          # pre-claimed tag (an attacker pushing $TAG at a different commit) survive silently — both git
+          # commands failed, but `gh release create` below then blessed that wrong-commit tag while npm
+          # published from HEAD, so the release/source disagreed with the package. Now: an existing tag
+          # MUST already resolve to the exact commit we're publishing (HEAD); anything else aborts.
+          EXPECTED_SHA="$(git rev-parse HEAD)"
+          git fetch origin "refs/tags/$TAG:refs/tags/$TAG" 2>/dev/null || true
+          if git rev-parse -q --verify "refs/tags/$TAG^{commit}" >/dev/null 2>&1; then
+            EXISTING_SHA="$(git rev-parse "refs/tags/$TAG^{commit}")"
+            if [ "$EXISTING_SHA" != "$EXPECTED_SHA" ]; then
+              echo "::error::Tag $TAG already exists at $EXISTING_SHA, not the published commit ($EXPECTED_SHA); aborting"
+              exit 1
+            fi
+            echo "Tag $TAG already exists at the expected commit; reusing it"
+          else
+            git tag "$TAG"
+            git push origin "$TAG"
+          fi
 
           if [ "$SDK_VERSION" = "$AZTEC_VERSION" ]; then
             NOTES="Aligned with Aztec ${DIST_TAG} version \`${AZTEC_VERSION}\`."

--- a/.github/workflows/_publish-sdk.yml
+++ b/.github/workflows/_publish-sdk.yml
@@ -146,20 +146,26 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # F2 (full-branch audit): NEVER suppress tag/push failures with `|| true`. The old form let a
-          # pre-claimed tag (an attacker pushing $TAG at a different commit) survive silently — both git
-          # commands failed, but `gh release create` below then blessed that wrong-commit tag while npm
-          # published from HEAD, so the release/source disagreed with the package. Now: an existing tag
-          # MUST already resolve to the exact commit we're publishing (HEAD); anything else aborts.
+          # F2 (full-branch audit): NEVER suppress tag/push failures. The old `git tag/push || true` let a
+          # pre-claimed tag (an attacker pushing $TAG at a different commit) survive silently, then
+          # `gh release create` below blessed that wrong-commit tag while npm published from HEAD.
+          # We query the REMOTE directly with `git ls-remote` (which — unlike `git fetch ... || true` —
+          # exits NON-ZERO on network/auth failure, so a masked error can't let a stale local tag pass) and
+          # require any existing remote tag to resolve to the exact commit we publish (HEAD). `set -e` (the
+          # job default) aborts on an ls-remote failure.
           EXPECTED_SHA="$(git rev-parse HEAD)"
-          git fetch origin "refs/tags/$TAG:refs/tags/$TAG" 2>/dev/null || true
-          if git rev-parse -q --verify "refs/tags/$TAG^{commit}" >/dev/null 2>&1; then
-            EXISTING_SHA="$(git rev-parse "refs/tags/$TAG^{commit}")"
-            if [ "$EXISTING_SHA" != "$EXPECTED_SHA" ]; then
-              echo "::error::Tag $TAG already exists at $EXISTING_SHA, not the published commit ($EXPECTED_SHA); aborting"
+          # Ask for both the ref and its peeled (^{}) form; an annotated tag reports the commit on the
+          # `^{}` line, a lightweight tag (what `git tag` creates) reports the commit on the plain line.
+          REMOTE_REFS="$(git ls-remote origin "refs/tags/$TAG" "refs/tags/$TAG^{}")"
+          if [ -n "$REMOTE_REFS" ]; then
+            # Prefer the peeled commit if present (annotated), else the direct SHA (lightweight).
+            REMOTE_SHA="$(printf '%s\n' "$REMOTE_REFS" | awk '/\^\{\}$/ {print $1; exit}')"
+            [ -z "$REMOTE_SHA" ] && REMOTE_SHA="$(printf '%s\n' "$REMOTE_REFS" | awk 'NR==1 {print $1}')"
+            if [ "$REMOTE_SHA" != "$EXPECTED_SHA" ]; then
+              echo "::error::Tag $TAG already exists on origin at $REMOTE_SHA, not the published commit ($EXPECTED_SHA); aborting"
               exit 1
             fi
-            echo "Tag $TAG already exists at the expected commit; reusing it"
+            echo "Tag $TAG already on origin at the expected commit; reusing it"
           else
             git tag "$TAG"
             git push origin "$TAG"

--- a/implementations-plan/security-hardening/full-audit-2026-07-24/FINDINGS.md
+++ b/implementations-plan/security-hardening/full-audit-2026-07-24/FINDINGS.md
@@ -1,0 +1,38 @@
+# Full-branch codex audit — security-hardening (2026-07-24)
+
+Scope: the entire `main...security-hardening` **code** delta (docs excluded), #400+#401 folded in.
+8 chunks, each a codex gpt-5.6-sol xhigh adversarial pass. Every finding **verified by hand** against
+the real code before disposition — the chunk boundaries produce false positives (a chunk can't see a
+caller/early-return in another chunk).
+
+## Disposition summary
+
+| ID | Chunk | Codex sev | Verdict | Disposition |
+|----|-------|-----------|---------|-------------|
+| A2 | auth | Med | **FALSE POSITIVE** | headless denies immediately (`auth.rs:58-60`), never reaches the backstop wait |
+| A3 | auth | Med | **FALSE POSITIVE** | `respond_auth` DOES route through `resolve_active` (`commands.rs:203`); arbiter is wired |
+| C  | acl/certs/recovery | — | **CLEAN** | confirmed |
+| D1,D2 | updater | Med | **KNOWN-ACCEPTED** | the #345/M6 unbounded-plugin-buffer residual; the fix (fork/hand-roll downloader) was rejected in a prior round (would make hand-written verify the sole authenticity control). Availability-only; Ed25519 integrity intact |
+| H1 | infra | Crit | **OWNER-ACCEPTED** | `required_approving_review_count: 0` = the solo-dev risk-accept decision (release-env item #1) |
+| H2 | infra | High | **KNOWN-OWNER** | legacy role = the legacy-role-retirement owner item (#4) |
+| F1,G1 | ci/scripts | High/Crit | **PARTLY-KNOWN** | prod signing key in CI smoke-job env; overlaps owner protected-env item #1. Real key-hygiene concern; full fix = ephemeral smoke key + isolated signer |
+| F2 | ci | Med | **REAL — FIX** | `_publish-sdk.yml:148-149` `|| true` swallows tag failures → a pre-claimed wrong-commit tag gets blessed. Cheap, mine |
+| A1 | auth | Med | **REAL-BOUNDED** | prove permit held during body read → ≤8 slow uploaders 429 others. Bounded by MAX_INFLIGHT_PROVE + 30s timeout. Hardening |
+| B1,B2 | versions | Med | **REAL-BOUNDED** | concurrent stage-reap / cleanup can evict another request's in-use version → proof failure + re-download churn. Availability; needs an approved origin |
+| E1 | tauri | High | **REAL-BOUNDED** | queued auth requests each build a webview + 1s poller. Bounded to MAX_PENDING_ORIGINS (10 windows). Annoyance/resource, not crash |
+| G2 | scripts | High | **SUPPLY-CHAIN-INHERENT** | bb archive + its digest both come from the same (mutable) Aztec release. Inherent trust-in-Aztec; `immutable:false` in fixture never checked. Cheap partial: require immutable releases |
+| H3 | infra | Med | **REAL — FIX (tofu, human-applies)** | S3 versioning w/o `noncurrent_version_expiration` → storage-cost exhaustion by a compromised deploy job |
+| H4 | infra | rel-block? | **NEEDS-OWNER-VERIFY** | iam.tf conditions on the `workflow` OIDC claim; codex says AWS won't evaluate it → roles unassumable after cutover. `sub` is load-bearing regardless. Best fix ties to GitHub Environments (owner item #1). Verify at the human-gated cutover |
+
+## What the audit did NOT find
+No new Critical/High in the core prover, origin-auth, canonicalization, crypto/manifest verification, or
+Windows ACL surface. The two scary auth findings (A2/A3) were false positives; chunk C was clean; the
+updater's manifest binding is sound. The real signal is in the **supply-chain surface** (CI/scripts/infra)
+— mostly key-hygiene + integrity items that overlap already-known owner decisions.
+
+## Remediation plan
+- **Fix now (mine, in-code/YAML):** F2 (tag `|| true`), G2-partial (require immutable bb releases).
+- **Fix now (tofu, commit+validate, human applies):** H3 (S3 noncurrent expiration).
+- **Availability hardening (judgment — bounded, approved-origin-only):** A1, B1/B2, E1 — see owner steer.
+- **Owner/infra (known or human-gated):** H1 (accepted), H2/H4 (legacy-role + OIDC cutover), F1/G1 (CI
+  signing-key isolation — pairs with protected environments). Rolled into the release-CI owner runbook.

--- a/implementations-plan/security-hardening/full-audit-2026-07-24/FINDINGS.md
+++ b/implementations-plan/security-hardening/full-audit-2026-07-24/FINDINGS.md
@@ -19,7 +19,7 @@ caller/early-return in another chunk).
 | F2 | ci | Med | **REAL — FIX** | `_publish-sdk.yml:148-149` `|| true` swallows tag failures → a pre-claimed wrong-commit tag gets blessed. Cheap, mine |
 | A1 | auth | Med | **REAL-BOUNDED** | prove permit held during body read → ≤8 slow uploaders 429 others. Bounded by MAX_INFLIGHT_PROVE + 30s timeout. Hardening |
 | B1,B2 | versions | Med | **REAL-BOUNDED** | concurrent stage-reap / cleanup can evict another request's in-use version → proof failure + re-download churn. Availability; needs an approved origin |
-| E1 | tauri | High | **REAL-BOUNDED** | queued auth requests each build a webview + 1s poller. Bounded to MAX_PENDING_ORIGINS (10 windows). Annoyance/resource, not crash |
+| E1 | tauri | High | **REAL-BOUNDED → DOCUMENTED-ACCEPTED** | queued auth requests each build a webview + 1s poller. Bounded to MAX_PENDING_ORIGINS (10 windows), non-crashing, only for UNAPPROVED origins. Proper fix (defer webview to promotion) re-architects the 5-round-converged C9 arbiter across the lib/bin boundary (`arm_active_popup` would need to build windows + reconcile double-arming) — disproportionate + regression-risky for a bounded annoyance. **Recommend NOT fixing in code**; owner may opt into the refactor. See rationale below |
 | G2 | scripts | High | **SUPPLY-CHAIN-INHERENT** | bb archive + its digest both come from the same (mutable) Aztec release. Inherent trust-in-Aztec; `immutable:false` in fixture never checked. Cheap partial: require immutable releases |
 | H3 | infra | Med | **REAL — FIX (tofu, human-applies)** | S3 versioning w/o `noncurrent_version_expiration` → storage-cost exhaustion by a compromised deploy job |
 | H4 | infra | rel-block? | **NEEDS-OWNER-VERIFY** | iam.tf conditions on the `workflow` OIDC claim; codex says AWS won't evaluate it → roles unassumable after cutover. `sub` is load-bearing regardless. Best fix ties to GitHub Environments (owner item #1). Verify at the human-gated cutover |
@@ -30,9 +30,22 @@ Windows ACL surface. The two scary auth findings (A2/A3) were false positives; c
 updater's manifest binding is sound. The real signal is in the **supply-chain surface** (CI/scripts/infra)
 — mostly key-hygiene + integrity items that overlap already-known owner decisions.
 
-## Remediation plan
-- **Fix now (mine, in-code/YAML):** F2 (tag `|| true`), G2-partial (require immutable bb releases).
-- **Fix now (tofu, commit+validate, human applies):** H3 (S3 noncurrent expiration).
-- **Availability hardening (judgment — bounded, approved-origin-only):** A1, B1/B2, E1 — see owner steer.
-- **Owner/infra (known or human-gated):** H1 (accepted), H2/H4 (legacy-role + OIDC cutover), F1/G1 (CI
-  signing-key isolation — pairs with protected environments). Rolled into the release-CI owner runbook.
+## E1 rationale (why documented-accepted, not code-fixed)
+The proper fix — build the auth webview only when its request becomes ACTIVE, keeping queued requests as
+arbiter metadata — requires the promotion path (`arm_active_popup`, in the **lib** `commands.rs`) to
+BUILD a window, which lives in the **bin** (`windows.rs`) behind the lib/bin split. It would also have to
+reconcile its arming with `show_auth_popup_window`'s own active-arming (double-arm risk), and it edits the
+single-active-popup arbiter that took FIVE codex rounds to converge. The impact it defends is BOUNDED
+(≤ `MAX_PENDING_ORIGINS` = 10 windows), non-crashing, and only for UNAPPROVED origins the user is actively
+visiting (they see the popups and simply don't approve). Trading a real regression risk on converged auth
+code for a bounded annoyance is the wrong call — the same proportionality that stopped the version-floor
+brick. **Owner can opt into the refactor** if the popup-flood UX is deemed worth it; otherwise accepted.
+
+## Remediation status (this PR)
+- **FIXED (code/YAML):** F2 (tag `|| true`), G2 (immutable warning + doc), A1 (prove-permit decouple),
+  B1/B2 (age-gated reap/eviction), H3 (S3 noncurrent-version expiration — tofu, human applies).
+- **DOCUMENTED-ACCEPTED:** E1 (bounded popup flood — rationale above), D1/D2 (updater buffer #345/M6),
+  H1 (0-approval branch protection = solo-dev risk-accept).
+- **OWNER RUNBOOK** (`../quality-audit-2026-07-24/release-ci-owner-runbook.md`): F1/G1 (CI signing-key
+  isolation), H2 (legacy-role retirement), H4 (IAM `workflow`-claim / GitHub-Environments cutover).
+- **VERIFIED FALSE POSITIVES:** A2, A3. **CLEAN:** chunk C.

--- a/implementations-plan/security-hardening/full-audit-2026-07-24/chunks/A-auth-prove.diff
+++ b/implementations-plan/security-hardening/full-audit-2026-07-24/chunks/A-auth-prove.diff
@@ -1,0 +1,1099 @@
+diff --git a/packages/accelerator/core/src/authorization.rs b/packages/accelerator/core/src/authorization.rs
+index 7a9bb80..ae84e17 100644
+--- a/packages/accelerator/core/src/authorization.rs
++++ b/packages/accelerator/core/src/authorization.rs
+@@ -1,5 +1,5 @@
+ use parking_lot::Mutex;
+-use std::collections::HashMap;
++use std::collections::{HashMap, VecDeque};
+ use tokio::sync::oneshot;
+ use url::Url;
+ 
+@@ -31,13 +31,19 @@ pub fn canonicalize_origin(input: &str) -> Option<String> {
+         return None;
+     }
+ 
++    let host = url.host_str()?;
++    // F-011: reject trailing-dot origins (e.g. `https://example.com.`) instead of silently
++    // collapsing them into the undotted origin. The browser treats the dotted FQDN as a
++    // DISTINCT origin, so it must earn its own approval rather than inherit the undotted
++    // site's grant (and its verified badge). Host-header normalization (server/host.rs) is a
++    // separate transport-level policy and is intentionally left unchanged.
++    if host.is_empty() || host.ends_with('.') {
++        return None;
++    }
++
+     match url.scheme() {
+         "http" | "https" | "ws" | "wss" => {
+-            let host = url.host_str()?.to_ascii_lowercase();
+-            let host = host.trim_end_matches('.');
+-            if host.is_empty() {
+-                return None;
+-            }
++            let host = host.to_ascii_lowercase();
+             Some(match url.port() {
+                 Some(p) => format!("{}://{}:{}", url.scheme(), host, p),
+                 None => format!("{}://{}", url.scheme(), host),
+@@ -47,8 +53,16 @@ pub fn canonicalize_origin(input: &str) -> Option<String> {
+             if url.port().is_some() {
+                 return None;
+             }
+-            let id = url.host_str()?.to_ascii_lowercase();
+-            if id.is_empty() {
++            let id = host.to_ascii_lowercase();
++            // D7 (C9): extension IDs have a FIXED plain-ASCII grammar. `url` treats these as opaque-host
++            // schemes, so (unlike http/https) it applies NO IDNA/punycode — a bidi/zero-width/non-ASCII or
++            // wrong-length host would otherwise survive into the canonical origin as a homograph. Validate
++            // the exact grammar and reject anything else BEFORE it becomes a `CanonicalOrigin`.
++            let valid = match scheme {
++                "chrome-extension" => is_chrome_extension_id(&id),
++                _ => is_extension_uuid(&id), // moz-extension / safari-web-extension use a per-install UUID
++            };
++            if !valid {
+                 return None;
+             }
+             Some(format!("{scheme}://{id}"))
+@@ -57,6 +71,23 @@ pub fn canonicalize_origin(input: &str) -> Option<String> {
+     }
+ }
+ 
++/// Chrome/Edge extension ID: exactly 32 chars, each in `a`..=`p` (the "mpdecimal" base-16 alphabet
++/// Chromium uses for extension IDs). Always plain ASCII — no legitimate ID contains anything else.
++fn is_chrome_extension_id(id: &str) -> bool {
++    id.len() == 32 && id.bytes().all(|b| matches!(b, b'a'..=b'p'))
++}
++
++/// Firefox/Safari web-extension host: a lowercase UUID (`8-4-4-4-12` hex) — the addon's per-install
++/// internal UUID. Reject any non-hex / misplaced-dash / wrong-length value.
++fn is_extension_uuid(id: &str) -> bool {
++    let b = id.as_bytes();
++    b.len() == 36
++        && b.iter().enumerate().all(|(i, &c)| match i {
++            8 | 13 | 18 | 23 => c == b'-',
++            _ => matches!(c, b'0'..=b'9' | b'a'..=b'f'),
++        })
++}
++
+ /// An origin string guaranteed canonical (RFC 6454) **by construction**.
+ ///
+ /// The only ways to build one run [`canonicalize_origin`], so a `CanonicalOrigin` can never
+@@ -151,6 +182,15 @@ pub enum AuthDecision {
+     Deny,
+ }
+ 
++/// Outcome of [`AuthorizationManager::resolve_active`] — the server-side arbiter gate for a USER decision.
++#[derive(Debug, PartialEq, Eq)]
++pub enum ResolveOutcome {
++    /// Resolved; carries the newly-promoted active `request_id` (if a queued popup was promoted).
++    Resolved(Option<String>),
++    /// Rejected — the request is not the currently-active popup (arbiter enforcement).
++    NotActive,
++}
++
+ /// Manages pending authorization requests.
+ ///
+ /// When a `/prove` request arrives from an unknown origin, the handler calls
+@@ -158,8 +198,18 @@ pub enum AuthDecision {
+ /// shows an authorization popup. Subsequent requests from the same origin
+ /// piggyback on the same popup — they all share the decision.
+ /// Maximum number of distinct origins that can have pending authorization simultaneously.
+-/// Prevents popup/memory spam from a malicious site generating many subdomains.
+-const MAX_PENDING_ORIGINS: usize = 10;
++/// Prevents popup/memory spam from a malicious site generating many subdomains. Public so the server's
++/// queue backstop (`AUTH_QUEUE_BACKSTOP`) can bound the worst-case queued wait at `MAX × 60 s` (C9 D18).
++pub const MAX_PENDING_ORIGINS: usize = 10;
++
++/// Maximum number of concurrent `/prove` requests from ONE origin that may piggyback on a single
++/// pending popup. Each piggyback holds a live `oneshot::Sender` in [`PendingRequest::senders`] until
++/// the user decides (or the 60 s auto-deny fires), so without a cap an approved-pending origin could
++/// flood `/prove` during the decision window and grow that `Vec` without bound (per-origin memory
++/// exhaustion — codex quality audit #2). This bounds the survivors to `MAX × MAX_PENDING_ORIGINS`
++/// senders; the (N+1)-th piggyback is shed with `TooManyRequests` (429). 16 is far above any
++/// legitimate retry burst while a popup is on screen — a real dApp fires one prove and awaits it.
++pub const MAX_PIGGYBACK_SENDERS: usize = 16;
+ 
+ /// A pending authorization awaiting the user's decision: its origin (for display + cleanup) and the
+ /// receivers of every request piggybacking on it.
+@@ -176,33 +226,61 @@ struct PendingState {
+     by_origin: HashMap<CanonicalOrigin, String>,
+     /// `request_id` → the pending request. Decisions resolve by **id**, not origin (SEC-06).
+     by_request: HashMap<String, PendingRequest>,
++    /// C9 (D18/D19): the single-active-popup arbiter. `active` is the ONE `request_id` that owns the
++    /// actionable + always-on-top slot; `queue` is the FIFO of built-but-not-actionable requests. Exactly
++    /// one popup is actionable at a time; on the active one resolving, the head of `queue` is promoted.
++    active: Option<String>,
++    queue: VecDeque<String>,
+ }
+ 
+ impl PendingState {
+     /// q7e3-F-09: insert a new pending request, updating BOTH indexes. The origin↔request_id coupling
+     /// lives here, not hand-synced at each call site, so a future mutator can't update one map and
+-    /// forget the other.
++    /// forget the other. C9 (D18): returns whether this new request became the ACTIVE one (slot was free)
++    /// vs. was enqueued (another popup is already active).
+     fn insert(
+         &mut self,
+         origin: CanonicalOrigin,
+         request_id: String,
+         tx: oneshot::Sender<AuthDecision>,
+-    ) {
++    ) -> bool {
+         self.by_origin.insert(origin.clone(), request_id.clone());
+         self.by_request.insert(
+-            request_id,
++            request_id.clone(),
+             PendingRequest {
+                 origin,
+                 senders: vec![tx],
+             },
+         );
++        if self.active.is_none() {
++            self.active = Some(request_id);
++            true
++        } else {
++            self.queue.push_back(request_id);
++            false
++        }
+     }
+ 
+-    /// q7e3-F-09: remove a pending request by id, updating BOTH indexes; returns it if present.
+-    fn remove(&mut self, request_id: &str) -> Option<PendingRequest> {
++    /// q7e3-F-09: remove a pending request by id, updating BOTH indexes. C9 (D18/D19): if the removed
++    /// request was the ACTIVE one, promote the head of `queue` to active and return its id (so the caller
++    /// can raise+arm that window); if it was merely queued, drop it from `queue` and return `None`.
++    /// Returns `(request, newly_promoted_active)`.
++    fn remove(&mut self, request_id: &str) -> Option<(PendingRequest, Option<String>)> {
+         let req = self.by_request.remove(request_id)?;
+         self.by_origin.remove(&req.origin);
+-        Some(req)
++        let promoted = if self.active.as_deref() == Some(request_id) {
++            let next = self.queue.pop_front();
++            self.active = next.clone();
++            next
++        } else {
++            self.queue.retain(|q| q != request_id);
++            None
++        };
++        Some((req, promoted))
++    }
++
++    fn is_active(&self, request_id: &str) -> bool {
++        self.active.as_deref() == Some(request_id)
+     }
+ }
+ 
+@@ -233,17 +311,27 @@ impl AuthorizationManager {
+     /// by origin string, so a caller that knows only an origin cannot resolve a concurrent request.
+     ///
+     /// Returns `Err` if the maximum number of pending requests is exceeded (DoS protection).
++    /// Returns `Ok((receiver, request_id, is_first, is_active))`. `is_first` ⇒ the caller shows a popup
++    /// carrying `request_id`; `is_active` (C9 D18) ⇒ that popup owns the actionable + always-on-top slot
++    /// now (vs. being enqueued behind an already-active popup). For a piggyback (`!is_first`), `is_active`
++    /// reflects the existing request it joined.
+     pub fn request(
+         &self,
+         origin: &CanonicalOrigin,
+-    ) -> Result<(oneshot::Receiver<AuthDecision>, String, bool), &'static str> {
++    ) -> Result<(oneshot::Receiver<AuthDecision>, String, bool, bool), &'static str> {
+         let (tx, rx) = oneshot::channel();
+         let mut st = self.state.lock();
+         // Piggyback on an existing pending request for this origin.
+         if let Some(request_id) = st.by_origin.get(origin).cloned() {
++            let is_active = st.is_active(&request_id);
+             if let Some(req) = st.by_request.get_mut(&request_id) {
++                // Bound the per-origin piggyback fan-out: a flood of concurrent /prove during the
++                // decision window must not grow `senders` without limit (per-origin memory DoS).
++                if req.senders.len() >= MAX_PIGGYBACK_SENDERS {
++                    return Err("too many concurrent requests for this origin");
++                }
+                 req.senders.push(tx);
+-                return Ok((rx, request_id, false));
++                return Ok((rx, request_id, false, is_active));
+             }
+         }
+         // New request.
+@@ -251,22 +339,55 @@ impl AuthorizationManager {
+             return Err("too many pending authorization requests");
+         }
+         let request_id = uuid::Uuid::new_v4().to_string();
+-        st.insert(origin.clone(), request_id.clone(), tx);
+-        Ok((rx, request_id, true))
++        let is_active = st.insert(origin.clone(), request_id.clone(), tx);
++        Ok((rx, request_id, true, is_active))
++    }
++
++    /// Resolve the pending request identified by `request_id` with `decision` (SYSTEM paths: the 60 s
++    /// auto-deny timeout, a user closing the window). Sends to every piggybacking receiver and clears both
++    /// maps. C9 (D18/D19): returns the newly-promoted active `request_id` if the resolved one owned the
++    /// active slot and a queued request was promoted — the caller raises + arms that window. A no-op
++    /// (returns `None`) for an unknown/stale id (already resolved, or a tampered/guessed id).
++    pub fn resolve(&self, request_id: &str, decision: AuthDecision) -> Option<String> {
++        let mut st = self.state.lock();
++        let (req, promoted) = st.remove(request_id)?;
++        for tx in req.senders {
++            let _ = tx.send(decision);
++        }
++        promoted
+     }
+ 
+-    /// Resolve the pending request identified by `request_id` with `decision`. Sends to every
+-    /// piggybacking receiver and clears both maps. A no-op for an unknown/stale id (already resolved,
+-    /// or a tampered/guessed id that matches nothing).
+-    pub fn resolve(&self, request_id: &str, decision: AuthDecision) {
++    /// C9 (D19): resolve a USER decision (from `respond_auth`), enforced SERVER-SIDE — succeeds ONLY if
++    /// `request_id` currently owns the ACTIVE slot, so a queued (non-actionable) popup cannot resolve
++    /// itself even if its webview is coerced into calling `respond_auth`. The `{active}` button-disable in
++    /// the frontend is a reflection of this, NOT the gate. On success behaves like [`resolve`] and returns
++    /// the promoted active id; otherwise [`ResolveOutcome::NotActive`].
++    pub fn resolve_active(&self, request_id: &str, decision: AuthDecision) -> ResolveOutcome {
+         let mut st = self.state.lock();
+-        if let Some(req) = st.remove(request_id) {
+-            for tx in req.senders {
+-                let _ = tx.send(decision);
++        if !st.is_active(request_id) {
++            return ResolveOutcome::NotActive;
++        }
++        match st.remove(request_id) {
++            Some((req, promoted)) => {
++                for tx in req.senders {
++                    let _ = tx.send(decision);
++                }
++                ResolveOutcome::Resolved(promoted)
+             }
++            None => ResolveOutcome::NotActive,
+         }
+     }
+ 
++    /// C9 (D8/D15): peek a pending request's SERVER-authoritative origin + whether it currently owns the
++    /// active/actionable slot, WITHOUT consuming it. `None` for an unknown/resolved id. Backs
++    /// `get_pending_auth` so the popup renders the origin the server will actually grant and disables its
++    /// buttons while it is merely queued.
++    pub fn peek(&self, request_id: &str) -> Option<(CanonicalOrigin, bool)> {
++        let st = self.state.lock();
++        let origin = st.by_request.get(request_id)?.origin.clone();
++        Some((origin, st.is_active(request_id)))
++    }
++
+     /// Returns true for localhost origins that should be auto-approved.
+     pub fn is_auto_approved(origin: &str) -> bool {
+         // Q14: reuse the same `url::Url` parsing as `canonicalize_origin` (Substitute Algorithm)
+@@ -277,7 +398,10 @@ impl AuthorizationManager {
+             .ok()
+             .filter(|u| matches!(u.scheme(), "http" | "https"))
+             .and_then(|u| u.host_str().map(|h| h.to_ascii_lowercase()))
+-            .is_some_and(|h| matches!(h.trim_end_matches('.'), "localhost" | "127.0.0.1" | "[::1]"))
++            // No trailing-dot trim: F-011 makes `canonicalize_origin` reject dotted hosts, so a
++            // CanonicalOrigin never carries one. Matching the exact host keeps this consistent for
++            // any direct caller too (a dotted `localhost.` is NOT auto-approved).
++            .is_some_and(|h| matches!(h.as_str(), "localhost" | "127.0.0.1" | "[::1]"))
+     }
+ 
+     /// Returns true if the origin is approved: in the persisted allowlist, OR — only when
+@@ -368,11 +492,11 @@ mod tests {
+     #[tokio::test]
+     async fn request_and_resolve() {
+         let mgr = AuthorizationManager::new();
+-        let (rx1, id1, is_first1) = mgr.request(&co("https://example.com")).unwrap();
++        let (rx1, id1, is_first1, _) = mgr.request(&co("https://example.com")).unwrap();
+         assert!(is_first1);
+ 
+         // A second request for the SAME origin piggybacks on the same request_id.
+-        let (rx2, id2, is_first2) = mgr.request(&co("https://example.com")).unwrap();
++        let (rx2, id2, is_first2, _) = mgr.request(&co("https://example.com")).unwrap();
+         assert!(!is_first2);
+         assert_eq!(id1, id2, "same origin must share one request_id");
+ 
+@@ -385,7 +509,7 @@ mod tests {
+     #[tokio::test]
+     async fn resolve_deny() {
+         let mgr = AuthorizationManager::new();
+-        let (rx, id, _) = mgr.request(&co("https://evil.com")).unwrap();
++        let (rx, id, _, _) = mgr.request(&co("https://evil.com")).unwrap();
+         mgr.resolve(&id, AuthDecision::Deny);
+         assert_eq!(rx.await.unwrap(), AuthDecision::Deny);
+     }
+@@ -396,7 +520,7 @@ mod tests {
+     #[tokio::test]
+     async fn resolve_ignores_wrong_request_id() {
+         let mgr = AuthorizationManager::new();
+-        let (mut rx, id, _) = mgr.request(&co("https://example.com")).unwrap();
++        let (mut rx, id, _, _) = mgr.request(&co("https://example.com")).unwrap();
+         mgr.resolve("not-the-real-id", AuthDecision::Allow { remember: true });
+         assert!(
+             rx.try_recv().is_err(),
+@@ -419,6 +543,106 @@ mod tests {
+         assert!(mgr.request(&co("https://site0.com")).is_ok());
+     }
+ 
++    /// codex quality audit #2: a single origin flooding /prove during the decision window must not
++    /// grow `senders` without bound. The first `MAX_PIGGYBACK_SENDERS` (the initial request + its
++    /// piggybacks) succeed; the next is shed with an error → the /prove handler maps it to 429.
++    #[test]
++    fn rejects_when_too_many_piggyback_senders() {
++        let mgr = AuthorizationManager::new();
++        let origin = co("https://flood.example");
++        // The first call creates the pending request (1 sender); each subsequent call piggybacks.
++        let mut kept = Vec::new();
++        for _ in 0..MAX_PIGGYBACK_SENDERS {
++            kept.push(mgr.request(&origin).expect("under the cap must succeed"));
++        }
++        assert!(
++            mgr.request(&origin).is_err(),
++            "the (MAX_PIGGYBACK_SENDERS + 1)-th concurrent request must be shed"
++        );
++        // A DIFFERENT origin is unaffected — the cap is per pending request, not global.
++        assert!(mgr.request(&co("https://other.example")).is_ok());
++    }
++
++    // ─── single-active-popup arbiter (C9 D18/D19) ───────────────────────
++
++    #[tokio::test]
++    async fn arbiter_first_is_active_second_is_queued() {
++        let mgr = AuthorizationManager::new();
++        let (_rx1, id1, _first1, active1) = mgr.request(&co("https://a.com")).unwrap();
++        assert!(active1, "first popup owns the active slot");
++        let (_rx2, id2, _first2, active2) = mgr.request(&co("https://b.com")).unwrap();
++        assert!(
++            !active2,
++            "second distinct-origin popup is queued, not active"
++        );
++        assert_eq!(mgr.peek(&id1).map(|(_, a)| a), Some(true));
++        assert_eq!(mgr.peek(&id2).map(|(_, a)| a), Some(false));
++    }
++
++    #[tokio::test]
++    async fn arbiter_resolving_active_promotes_next() {
++        let mgr = AuthorizationManager::new();
++        let (rx1, id1, _, _) = mgr.request(&co("https://a.com")).unwrap();
++        let (_rx2, id2, _, _) = mgr.request(&co("https://b.com")).unwrap();
++        // Resolving the active one (system path: timeout / window-close) promotes the queued one.
++        let promoted = mgr.resolve(&id1, AuthDecision::Deny);
++        assert_eq!(
++            promoted.as_deref(),
++            Some(id2.as_str()),
++            "queued b.com is promoted to active"
++        );
++        assert_eq!(rx1.await.unwrap(), AuthDecision::Deny);
++        assert_eq!(
++            mgr.peek(&id2).map(|(_, a)| a),
++            Some(true),
++            "b.com now active"
++        );
++    }
++
++    #[tokio::test]
++    async fn arbiter_resolving_queued_does_not_promote() {
++        let mgr = AuthorizationManager::new();
++        let (_rx1, id1, _, _) = mgr.request(&co("https://a.com")).unwrap();
++        let (rx2, id2, _, _) = mgr.request(&co("https://b.com")).unwrap();
++        // Resolving the QUEUED one (its window was closed) leaves the active one; nobody is promoted.
++        let promoted = mgr.resolve(&id2, AuthDecision::Deny);
++        assert_eq!(promoted, None, "resolving a queued popup promotes nobody");
++        assert_eq!(rx2.await.unwrap(), AuthDecision::Deny);
++        assert_eq!(
++            mgr.peek(&id1).map(|(_, a)| a),
++            Some(true),
++            "a.com remains active"
++        );
++    }
++
++    #[tokio::test]
++    async fn arbiter_user_resolve_rejects_non_active() {
++        let mgr = AuthorizationManager::new();
++        let (_rx1, id1, _, _) = mgr.request(&co("https://a.com")).unwrap();
++        let (mut rx2, id2, _, _) = mgr.request(&co("https://b.com")).unwrap();
++        // A USER decision from the QUEUED (non-active) popup is REJECTED server-side (arbiter enforcement).
++        assert_eq!(
++            mgr.resolve_active(&id2, AuthDecision::Allow { remember: true }),
++            ResolveOutcome::NotActive
++        );
++        assert!(
++            rx2.try_recv().is_err(),
++            "a queued popup's user-decision must not resolve it"
++        );
++        // The ACTIVE popup's user decision succeeds and promotes b.com.
++        match mgr.resolve_active(&id1, AuthDecision::Allow { remember: false }) {
++            ResolveOutcome::Resolved(promoted) => {
++                assert_eq!(promoted.as_deref(), Some(id2.as_str()))
++            }
++            other => panic!("expected Resolved, got {other:?}"),
++        }
++        assert_eq!(
++            mgr.peek(&id2).map(|(_, a)| a),
++            Some(true),
++            "b.com promoted after active resolved"
++        );
++    }
++
+     // ─── canonicalize_origin ────────────────────────────────────────────
+ 
+     #[test]
+@@ -458,9 +682,26 @@ mod tests {
+     }
+ 
+     #[test]
+-    fn canon_trailing_dot_stripped() {
++    fn canon_trailing_dot_rejected() {
++        // F-011: a trailing-dot origin is a DISTINCT browser origin and must NOT be canonicalized
++        // into (and thereby inherit the approval of) the undotted form — it is rejected outright,
++        // across schemes and with/without an explicit port.
++        for input in [
++            "https://nulo.sh.",
++            "https://nulo.sh.:443",
++            "http://localhost.:5173",
++            "wss://example.com.",
++            "chrome-extension://abcdefghijklmnopabcdefghijklmnop.",
++        ] {
++            assert_eq!(
++                canonicalize_origin(input),
++                None,
++                "trailing-dot origin must be rejected, not collapsed: {input}"
++            );
++        }
++        // Sanity: the undotted forms still canonicalize normally.
+         assert_eq!(
+-            canonicalize_origin("https://nulo.sh."),
++            canonicalize_origin("https://nulo.sh"),
+             Some("https://nulo.sh".to_string()),
+         );
+     }
+@@ -529,6 +770,43 @@ mod tests {
+         assert!(canonicalize_origin("chrome-extension-malicious://abc").is_none());
+     }
+ 
++    #[test]
++    fn canon_extension_accepts_valid_grammar() {
++        // D7: chrome = 32× a..=p; moz/safari = a lowercase UUID (uppercase folds to lowercase).
++        assert_eq!(
++            canonicalize_origin("chrome-extension://abcdefghijklmnopabcdefghijklmnop"),
++            Some("chrome-extension://abcdefghijklmnopabcdefghijklmnop".to_string()),
++        );
++        assert_eq!(
++            canonicalize_origin("moz-extension://12345678-90ab-cdef-1234-567890abcdef"),
++            Some("moz-extension://12345678-90ab-cdef-1234-567890abcdef".to_string()),
++        );
++        assert_eq!(
++            canonicalize_origin("safari-web-extension://DEADBEEF-0000-1111-2222-333344445555"),
++            Some("safari-web-extension://deadbeef-0000-1111-2222-333344445555".to_string()),
++        );
++    }
++
++    #[test]
++    fn canon_extension_rejects_invalid_grammar() {
++        // D7: a bidi/zero-width/non-ASCII/wrong-length/out-of-alphabet extension host must be REJECTED,
++        // not lowercased into a homograph canonical origin (opaque-host schemes skip url's IDNA).
++        for bad in [
++            "chrome-extension://short",                             // too short
++            "chrome-extension://abcdefghijklmnopabcdefghijklmno",   // 31 chars
++            "chrome-extension://abcdefghijklmnopabcdefghijklmnopq", // 33 chars
++            "chrome-extension://zbcdefghijklmnopabcdefghijklmnop",  // 'z' is out of a..=p
++            "moz-extension://not-a-uuid-at-all-nope-nope-nope-x",   // not a UUID
++            "moz-extension://12345678-1234-1234-1234-1234567890zz", // non-hex tail
++        ] {
++            assert_eq!(
++                canonicalize_origin(bad),
++                None,
++                "must reject invalid extension id: {bad}"
++            );
++        }
++    }
++
+     #[test]
+     fn canon_rejects_unknown_scheme() {
+         assert!(canonicalize_origin("file:///etc/passwd").is_none());
+@@ -541,7 +819,7 @@ mod tests {
+         let cases = [
+             "https://nulo.sh",
+             "https://nulo.sh:8443",
+-            "chrome-extension://abc",
++            "chrome-extension://abcdefghijklmnopabcdefghijklmnop",
+         ];
+         for c in cases {
+             let once = canonicalize_origin(c).unwrap();
+diff --git a/packages/accelerator/core/src/config.rs b/packages/accelerator/core/src/config.rs
+index cf41624..32ff563 100644
+--- a/packages/accelerator/core/src/config.rs
++++ b/packages/accelerator/core/src/config.rs
+@@ -168,7 +168,16 @@ pub fn save_to(
+             .open(&tmp_path)?;
+         file.write_all(json.as_bytes())?;
+     }
+-    #[cfg(not(unix))]
++    #[cfg(windows)]
++    {
++        use std::io::Write;
++        // F-003 Windows tail: write the temp with an owner-only DACL; the SD travels with the same-volume
++        // rename to `config.json`. Clear any stale temp first so CREATE_NEW succeeds.
++        let _ = std::fs::remove_file(&tmp_path);
++        let mut file = crate::win_acl::secure_create_file(&tmp_path)?;
++        file.write_all(json.as_bytes())?;
++    }
++    #[cfg(all(not(unix), not(windows)))]
+     {
+         std::fs::write(&tmp_path, &json)?;
+     }
+@@ -370,8 +379,13 @@ mod tests {
+     #[test]
+     fn de_origins_keeps_canonical() {
+         assert_eq!(
+-            de_origins(r#"["https://nulo.sh","chrome-extension://abc"]"#),
+-            vec![co("https://nulo.sh"), co("chrome-extension://abc")],
++            de_origins(
++                r#"["https://nulo.sh","chrome-extension://abcdefghijklmnopabcdefghijklmnop"]"#
++            ),
++            vec![
++                co("https://nulo.sh"),
++                co("chrome-extension://abcdefghijklmnopabcdefghijklmnop"),
++            ],
+         );
+     }
+ 
+@@ -399,6 +413,15 @@ mod tests {
+         );
+     }
+ 
++    #[test]
++    fn de_origins_drops_trailing_dot_without_migrating() {
++        // F-011: a persisted dotted origin is DROPPED on load — never silently rewritten to its
++        // undotted (approved) form, so it cannot inherit the undotted origin's grant.
++        let loaded = de_origins(r#"["https://ok.example","https://bad.example."]"#);
++        assert_eq!(loaded, vec![co("https://ok.example")]);
++        assert!(!loaded.contains(&co("https://bad.example")));
++    }
++
+     #[test]
+     fn de_origins_preserves_order() {
+         assert_eq!(
+diff --git a/packages/accelerator/core/src/server/auth.rs b/packages/accelerator/core/src/server/auth.rs
+index 83b466a..9a66756 100644
+--- a/packages/accelerator/core/src/server/auth.rs
++++ b/packages/accelerator/core/src/server/auth.rs
+@@ -9,7 +9,7 @@
+ use crate::authorization::{AuthDecision, AuthorizationManager, CanonicalOrigin};
+ use crate::config;
+ 
+-use super::{AppState, ProveError, AUTH_DECISION_TIMEOUT};
++use super::{AppState, ProveError, AUTH_QUEUE_BACKSTOP};
+ 
+ /// Check if the request origin is authorized. Returns Ok(()) if approved.
+ pub(crate) async fn authorize_origin(
+@@ -61,21 +61,26 @@ pub(crate) async fn authorize_origin(
+     }
+ 
+     tracing::info!(origin = %origin, "Origin not approved, requesting authorization");
+-    let (rx, request_id, is_first) = auth_manager.request(&origin).map_err(|_| {
++    let (rx, request_id, is_first, _is_active) = auth_manager.request(&origin).map_err(|_| {
+         tracing::warn!(origin = %origin, "Too many pending authorization requests");
+         ProveError::TooManyRequests
+     })?;
+ 
+     if is_first {
+         if let Some(ref show_popup) = state.show_auth_popup {
++            // C9 (D18): the desktop callback (show_auth_popup_window) peeks the arbiter for active-ness and
++            // builds the popup active-or-queued, arming the ACTIVATION-relative 60 s auto-deny itself.
+             show_popup(&origin, &request_id);
+         }
+     }
+ 
+-    let decision = tokio::time::timeout(AUTH_DECISION_TIMEOUT, rx)
++    // C9 (D18): wait up to the QUEUE BACKSTOP, not 60 s-from-enqueue. The real per-popup 60 s deadline is
++    // the popup's activation-armed auto-deny (which resolves Deny → this `rx`), so a request queued behind
++    // a busy popup is never denied before the user actually sees it.
++    let decision = tokio::time::timeout(AUTH_QUEUE_BACKSTOP, rx)
+         .await
+         .map_err(|_| {
+-            tracing::warn!(origin = %origin, "Authorization timed out");
++            tracing::warn!(origin = %origin, "Authorization queue backstop elapsed");
+             auth_manager.resolve(&request_id, AuthDecision::Deny);
+             ProveError::AuthorizationTimeout
+         })?
+diff --git a/packages/accelerator/core/src/server/probe.rs b/packages/accelerator/core/src/server/probe.rs
+index a8a78d7..815bc05 100644
+--- a/packages/accelerator/core/src/server/probe.rs
++++ b/packages/accelerator/core/src/server/probe.rs
+@@ -44,6 +44,32 @@ pub async fn healthy_aztec_on_port() -> bool {
+     is_healthy_aztec_response(&body)
+ }
+ 
++/// Probe `/health` and return the reported `version` iff the responder is a healthy Aztec
++/// (`status=="ok"`, `api_version==1`) AND carries a string `version`; `None` otherwise. Lets the
++/// F-004 launch tracker confirm it is observing THIS build's OWN server (by matching the reported
++/// version to `CARGO_PKG_VERSION`) rather than a foreign healthy Aztec that happens to own `:59833`.
++/// This matters because the redundant-instance bow-out is Windows-only — on macOS/Linux a second
++/// instance keeps running after losing the bind, so without the version-match a broken new build could
++/// see the incumbent's healthy `/health` and ratchet the floor to a version whose server never ran.
++pub async fn healthy_aztec_version_on_port() -> Option<String> {
++    let url = format!("http://127.0.0.1:{PORT}/health");
++    let client = reqwest::Client::builder()
++        .timeout(Duration::from_secs(3))
++        .build()
++        .ok()?;
++    let resp = client.get(&url).send().await.ok()?;
++    if !resp.status().is_success() {
++        return None;
++    }
++    let body = resp.json::<serde_json::Value>().await.ok()?;
++    if !is_healthy_aztec_response(&body) {
++        return None;
++    }
++    body.get("version")
++        .and_then(|v| v.as_str())
++        .map(str::to_string)
++}
++
+ #[cfg(test)]
+ mod tests {
+     use super::*;
+diff --git a/packages/accelerator/core/src/server/prove.rs b/packages/accelerator/core/src/server/prove.rs
+index 4006ca8..84d294c 100644
+--- a/packages/accelerator/core/src/server/prove.rs
++++ b/packages/accelerator/core/src/server/prove.rs
+@@ -5,10 +5,15 @@
+ //! version, then run the proof and return base64 + an `x-prove-duration-ms` header. Extracted
+ //! from server.rs (Q2).
+ 
++use std::sync::Arc;
++use std::time::Duration;
++
++use axum::body::{Body, Bytes};
+ use axum::extract::{Request, State};
+ use axum::http::HeaderValue;
+ use axum::response::IntoResponse;
+ use serde_json::json;
++use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+ 
+ use crate::{bb, versions};
+ 
+@@ -67,14 +72,42 @@ pub(crate) fn resolve_version(
+     };
+     tracing::info!(version = %version, "Requested Aztec version");
+ 
++    // `x-aztec-version` is remote-controlled, so check well-formedness + the known-vulnerable REVOCATION
++    // denylist FIRST — BEFORE the bundled short-circuit below (codex denylist-review #1), so a version
++    // the owner has revoked is refused even if it happens to be the bundled one (fail closed; the owner
++    // ships a new bundled version alongside any such revocation). There is NO version FLOOR: the header
++    // is the Aztec version (not a bb version) and many Aztec releases share one bb, so an
++    // older-but-compatible request must be honoured (downloads are still digest-verified against Aztec's
++    // published hash). The denylist is empty by default ⇒ any well-formed version is allowed.
++    if let Err(rej) = versions::check_version_selectable(&version) {
++        tracing::warn!(version = %version, reason = rej.reason(), "Refused remote Aztec version");
++        return Err(ProveError::VersionNotAllowed {
++            version: version.to_string(),
++            reason: rej.reason(),
++        });
++    }
++
+     let bundled = state
+         .bundled_version
+         .as_deref()
+         .unwrap_or(super::DEFAULT_BB_VERSION);
+ 
+-    let needs_download = v != bundled && !versions::version_bb_path(&version).exists();
++    // F-007: normalize an explicit bundled request to `None` — the bundled bb ships as the sidecar, never
++    // the version cache, so it resolves via `find_bb(None)`. This also makes any `Some(v)` downstream an
++    // unambiguously NON-bundled request, so `find_bb` can hard-error on a bad cache entry without a
++    // wrong-version fallback (a bundled `Some(v)` would otherwise be indistinguishable).
++    if v == bundled {
++        return Ok(ResolvedVersion {
++            version: None,
++            needs_download: false,
++        });
++    }
++
++    // Re-download when the cache entry is absent OR present-but-marker-invalid (tampered/legacy), not
++    // merely when the path is missing — `verify_cached_bb` rehashes the binary against its marker (F-007).
++    let needs_download = versions::verify_cached_bb(&version).is_err();
+     if needs_download {
+-        tracing::info!(version = %version, "Version not cached, will download");
++        tracing::info!(version = %version, "Version not cached (or unverified), will download");
+     }
+ 
+     Ok(ResolvedVersion {
+@@ -98,6 +131,102 @@ pub(crate) fn compute_threads(state: &AppState) -> Option<usize> {
+ 
+ const MAX_BODY_SIZE: usize = 50 * 1024 * 1024; // 50MB
+ 
++/// F-009: absolute deadline for buffering the request body while holding the single prove
++/// permit. Bounds a slowloris/stalled uploader before the permit is released. 30s is generous
++/// for 50MB over loopback (~1.7 MiB/s); it is a whole-body deadline, not an idle timeout, so
++/// drip-feeding cannot extend it.
++const BODY_READ_TIMEOUT: Duration = Duration::from_secs(30);
++
++/// Reject an honestly-declared oversize body BEFORE acquiring the prove permit, so a client
++/// advertising `Content-Length > MAX_BODY_SIZE` is turned away without occupying the single
++/// permit. Chunked/underreported requests are still bounded by `to_bytes` — this is a cheap
++/// fast-path, never the sole limit.
++fn reject_declared_oversize(headers: &axum::http::HeaderMap) -> Result<(), ProveError> {
++    // Inspect EVERY Content-Length value, and each comma-separated element within it (HTTP/2 and
++    // some proxies emit a duplicate-but-consistent list). Parse as u64 so a value that would
++    // overflow usize on 32-bit targets can't wrap below the cap; reject if any element exceeds the
++    // cap or is malformed. Cheap pre-permit fast-path — the to_bytes limit remains authoritative.
++    let mut seen: Option<u64> = None;
++    for value in headers.get_all(axum::http::header::CONTENT_LENGTH) {
++        let Ok(s) = value.to_str() else {
++            return Err(ProveError::PayloadTooLarge(
++                "non-ASCII Content-Length".to_string(),
++            ));
++        };
++        for part in s.split(',') {
++            let part = part.trim();
++            // RFC 7230 §3.3.2: a Content-Length is `1*DIGIT`. Reject empty/partial/non-digit
++            // elements (a permissive skip let `""`, `","`, `1,`, `,1` slip past); parse as u64 so
++            // an over-long value can't wrap below the cap.
++            if part.is_empty() || !part.bytes().all(|b| b.is_ascii_digit()) {
++                return Err(ProveError::PayloadTooLarge(format!(
++                    "malformed Content-Length {part:?}"
++                )));
++            }
++            let len: u64 = part.parse().map_err(|_| {
++                ProveError::PayloadTooLarge(format!("unparsable Content-Length {part:?}"))
++            })?;
++            if len > MAX_BODY_SIZE as u64 {
++                return Err(ProveError::PayloadTooLarge(format!(
++                    "declared Content-Length {len} exceeds {MAX_BODY_SIZE}"
++                )));
++            }
++            // RFC 7230 §3.3.2: multiple Content-Length values must all agree.
++            match seen {
++                Some(prev) if prev != len => {
++                    return Err(ProveError::PayloadTooLarge(format!(
++                        "conflicting Content-Length values {prev} and {len}"
++                    )));
++                }
++                _ => seen = Some(len),
++            }
++        }
++    }
++    Ok(())
++}
++
++/// F-009: acquire the single prove permit, THEN buffer the body (under the size cap + an
++/// absolute read timeout). Returns the owned permit alongside the bytes so the caller holds it
++/// for the whole prove; the permit is released by RAII on every exit path (timeout, size error,
++/// disconnect, cancellation, panic, success). Testable seam.
++async fn acquire_and_read_body(
++    semaphore: Arc<Semaphore>,
++    raw_body: Body,
++    max_body_size: usize,
++    read_timeout: Duration,
++) -> Result<(OwnedSemaphorePermit, Bytes), ProveError> {
++    let permit = semaphore
++        .acquire_owned()
++        .await
++        .map_err(|_| ProveError::ServiceUnavailable)?;
++
++    let body = tokio::time::timeout(read_timeout, axum::body::to_bytes(raw_body, max_body_size))
++        .await
++        .map_err(|_| {
++            tracing::warn!(
++                timeout_secs = read_timeout.as_secs(),
++                "Timed out reading /prove request body"
++            );
++            ProveError::BodyReadTimeout
++        })?
++        .map_err(|e| {
++            tracing::warn!("Failed to read request body: {e}");
++            ProveError::PayloadTooLarge(e.to_string())
++        })?;
++
++    Ok((permit, body))
++}
++
++/// F-009: try to enter the bounded set of in-flight + waiting authorized `/prove` requests.
++/// Non-blocking: if the cap (`MAX_INFLIGHT_PROVE` permits) is full, shed immediately with 429
++/// (`ProveQueueFull`) rather than queueing. The returned guard must be held for the whole request
++/// so it is released (RAII) on every exit path. Testable seam.
++fn try_enter(waiters: Arc<Semaphore>) -> Result<OwnedSemaphorePermit, ProveError> {
++    waiters
++        .try_acquire_owned()
++        .map_err(|_| ProveError::ProveQueueFull)
++}
++
+ pub(crate) async fn prove(
+     State(state): State<AppState>,
+     request: Request,
+@@ -109,20 +238,26 @@ pub(crate) async fn prove(
+     let (parts, raw_body) = request.into_parts();
+     authorize_origin(&state, &parts.headers).await?;
+ 
+-    let body = axum::body::to_bytes(raw_body, MAX_BODY_SIZE)
+-        .await
+-        .map_err(|e| {
+-            tracing::warn!("Failed to read request body: {e}");
+-            ProveError::PayloadTooLarge(e.to_string())
+-        })?;
+-    tracing::debug!(payload_bytes = body.len(), "Prove request payload size");
++    // F-009: cap total in-flight + waiting authorized /prove requests. Held (RAII) for the whole
++    // request; a burst beyond MAX_INFLIGHT_PROVE is shed immediately with 429 instead of queueing
++    // behind slow uploaders and stacking fresh per-request read timeouts.
++    let _inflight = try_enter(state.prove_waiters.clone())?;
+ 
+-    // Limit to one concurrent prove — bb already uses all cores.
+-    let _permit = state
+-        .prove_semaphore
+-        .acquire()
+-        .await
+-        .map_err(|_| ProveError::ServiceUnavailable)?;
++    // F-009: turn away an honestly-declared oversize body before taking the prove permit.
++    reject_declared_oversize(&parts.headers)?;
++
++    // F-009: acquire the single prove permit BEFORE buffering the body, so concurrent requests
++    // can't each pin a 50MB buffer ahead of the concurrency gate (memory DoS), and read the body
++    // under an absolute timeout so a stalled uploader can't hold the only permit indefinitely.
++    // `_permit` is held for the whole prove and released by RAII on every exit path.
++    let (_permit, body) = acquire_and_read_body(
++        state.prove_semaphore.clone(),
++        raw_body,
++        MAX_BODY_SIZE,
++        BODY_READ_TIMEOUT,
++    )
++    .await?;
++    tracing::debug!(payload_bytes = body.len(), "Prove request payload size");
+ 
+     let requested_version = parts
+         .headers
+@@ -158,6 +293,9 @@ pub(crate) async fn prove(
+                     .as_deref()
+                     .unwrap_or(super::DEFAULT_BB_VERSION)
+                     .to_string();
++                // F-007: the version we just downloaded is about to be proved — exempt it from this
++                // cleanup so the detached eviction can't delete it out from under `bb::prove`.
++                let in_use_owned = version.as_str().to_string();
+                 let on_versions_changed = state.on_versions_changed.clone();
+                 tokio::spawn(async move {
+                     // q7e3-F-08: the caller parses now; an unparseable bundled (defensive,
+@@ -165,7 +303,8 @@ pub(crate) async fn prove(
+                     // parse-else-return. The "unknown" sentinel still parses, so eviction semantics
+                     // in unknown-bundled builds are unchanged (#352 stays deferred).
+                     if let Some(bundled) = versions::AztecVersion::parse(&bundled_owned) {
+-                        versions::cleanup_old_versions(&bundled).await;
++                        let in_use = versions::AztecVersion::parse(&in_use_owned);
++                        versions::cleanup_old_versions(&bundled, in_use.as_ref()).await;
+                     }
+                     if let Some(cb) = on_versions_changed {
+                         cb();
+@@ -221,3 +360,134 @@ pub(crate) async fn prove(
+ 
+     Ok(response)
+ }
++
++#[cfg(test)]
++mod tests {
++    use super::*;
++    use axum::http::{header::CONTENT_LENGTH, HeaderMap};
++
++    fn content_length(v: &str) -> HeaderMap {
++        let mut h = HeaderMap::new();
++        h.insert(CONTENT_LENGTH, HeaderValue::from_str(v).unwrap());
++        h
++    }
++
++    #[test]
++    fn declared_oversize_rejected_before_permit() {
++        // F-009: an honestly-declared oversize Content-Length is turned away up front.
++        assert!(matches!(
++            reject_declared_oversize(&content_length(&(MAX_BODY_SIZE + 1).to_string())),
++            Err(ProveError::PayloadTooLarge(_))
++        ));
++        // At/under the cap and absent are allowed (still bounded later by to_bytes).
++        assert!(reject_declared_oversize(&content_length(&MAX_BODY_SIZE.to_string())).is_ok());
++        assert!(reject_declared_oversize(&HeaderMap::new()).is_ok());
++        // Comma-list (HTTP/2 duplicate) with an oversize element must NOT slip past.
++        assert!(matches!(
++            reject_declared_oversize(&content_length(&format!("{0}, {0}", MAX_BODY_SIZE + 1))),
++            Err(ProveError::PayloadTooLarge(_))
++        ));
++        // Malformed / empty / partial values are rejected, not silently ignored.
++        for bad in ["not-a-number", "", ",", "1,", ",1", "1 2"] {
++            assert!(
++                matches!(
++                    reject_declared_oversize(&content_length(bad)),
++                    Err(ProveError::PayloadTooLarge(_))
++                ),
++                "must reject malformed Content-Length {bad:?}"
++            );
++        }
++        // Conflicting comma-list values (RFC 7230 §3.3.2) are rejected even when each is under cap.
++        assert!(matches!(
++            reject_declared_oversize(&content_length("10, 20")),
++            Err(ProveError::PayloadTooLarge(_))
++        ));
++        // Agreeing duplicates under the cap are fine.
++        assert!(reject_declared_oversize(&content_length("10, 10")).is_ok());
++    }
++
++    #[test]
++    fn waiter_cap_sheds_excess_with_queue_full() {
++        // F-009: fill the cap; the next entry is shed with ProveQueueFull; a slot frees on drop.
++        let waiters = Arc::new(Semaphore::new(2));
++        let g1 = try_enter(waiters.clone()).expect("slot 1");
++        let _g2 = try_enter(waiters.clone()).expect("slot 2");
++        assert!(matches!(
++            try_enter(waiters.clone()),
++            Err(ProveError::ProveQueueFull)
++        ));
++        drop(g1);
++        assert!(try_enter(waiters.clone()).is_ok(), "slot freed on drop");
++    }
++
++    #[tokio::test(start_paused = true)]
++    async fn body_not_read_until_permit_available() {
++        // F-009 ordering: with zero prove permits, even a READY body must not be returned — the
++        // permit gates the read (proves permit-before-body, not merely that the guard is live).
++        let sem = Arc::new(Semaphore::new(0));
++        let fut = acquire_and_read_body(
++            sem,
++            Body::from(Bytes::from_static(b"ready")),
++            1024,
++            Duration::from_secs(30),
++        );
++        tokio::pin!(fut);
++        assert!(
++            tokio::time::timeout(Duration::from_secs(60), &mut fut)
++                .await
++                .is_err(),
++            "acquire_and_read_body must not resolve without a prove permit"
++        );
++    }
++
++    #[tokio::test]
++    async fn permit_acquired_before_body_and_released_on_drop() {
++        let sem = Arc::new(Semaphore::new(1));
++        let (permit, body) = acquire_and_read_body(
++            sem.clone(),
++            Body::from(Bytes::from_static(b"hello")),
++            1024,
++            Duration::from_secs(30),
++        )
++        .await
++        .expect("happy path");
++        assert_eq!(&body[..], &b"hello"[..]);
++        assert_eq!(
++            sem.available_permits(),
++            0,
++            "permit held across the whole prove"
++        );
++        drop(permit);
++        assert_eq!(sem.available_permits(), 1, "permit released on drop");
++    }
++
++    #[tokio::test]
++    async fn oversized_body_errs_and_releases_permit() {
++        let sem = Arc::new(Semaphore::new(1));
++        let res = acquire_and_read_body(
++            sem.clone(),
++            Body::from(vec![0u8; 10]),
++            4, // tiny cap to force the length error deterministically
++            Duration::from_secs(30),
++        )
++        .await;
++        assert!(matches!(res, Err(ProveError::PayloadTooLarge(_))));
++        assert_eq!(
++            sem.available_permits(),
++            1,
++            "permit released after size error"
++        );
++    }
++
++    #[tokio::test(start_paused = true)]
++    async fn stalled_body_times_out_and_releases_permit() {
++        let sem = Arc::new(Semaphore::new(1));
++        // A body whose stream never yields → to_bytes never completes → the read timeout fires.
++        // Under start_paused the virtual clock auto-advances to the only pending timer.
++        let body =
++            Body::from_stream(futures_util::stream::pending::<Result<Bytes, std::io::Error>>());
++        let res = acquire_and_read_body(sem.clone(), body, 1024, Duration::from_secs(30)).await;
++        assert!(matches!(res, Err(ProveError::BodyReadTimeout)));
++        assert_eq!(sem.available_permits(), 1, "permit released after timeout");
++    }
++}
+diff --git a/packages/accelerator/core/src/server/tests.rs b/packages/accelerator/core/src/server/tests.rs
+index fa9c03e..ce76c8b 100644
+--- a/packages/accelerator/core/src/server/tests.rs
++++ b/packages/accelerator/core/src/server/tests.rs
+@@ -998,10 +998,11 @@ fn resolve_version_flags_uncached_for_download() {
+     // (download_bb needs the network); the no-download arm is pinned by
+     // `prove_success_path_and_status_sequence`, and prove() emits Downloading/Proving structurally
+     // around this flag.
+-    let state = AppState::default();
+-    let version = Some("5.0.0-rc.1".to_string());
++    let core = HeadlessState::headless("1.0.0", Some("5.0.0-rc.1".to_string()), None, None);
++    let state = AppState::headless(core);
++    let version = Some("5.0.0-rc.2".to_string());
+     let resolved = resolve_version(&state, &version).expect("valid version resolves");
+-    assert_eq!(resolved.version.as_deref(), Some("5.0.0-rc.1"));
++    assert_eq!(resolved.version.as_deref(), Some("5.0.0-rc.2"));
+     assert!(
+         resolved.needs_download,
+         "uncached non-bundled version must be flagged for download"
+@@ -1009,13 +1010,32 @@ fn resolve_version_flags_uncached_for_download() {
+ }
+ 
+ #[test]
+-fn resolve_version_no_download_for_bundled() {
+-    // The bundled version is always present → never flagged for download (no Downloading status).
++fn resolve_version_allows_older_compatible_version() {
++    // The x-aztec-version header is an Aztec version, not a bb version, and many Aztec releases share
++    // one bb — so an OLDER-but-compatible request (e.g. a 5.0.0-rc.1 dApp against a 5.0.0-rc.2 bundle)
++    // MUST be honoured, not rejected. (This is the over-blocking bug the earlier floor introduced; the
++    // gate is now a known-vulnerable revocation denylist, empty by default.) It still resolves for
++    // download + digest verification.
++    let core = HeadlessState::headless("1.0.0", Some("5.0.0-rc.2".to_string()), None, None);
++    let state = AppState::headless(core);
++    let resolved = resolve_version(&state, &Some("5.0.0-rc.1".to_string()))
++        .expect("an older compatible version must be allowed");
++    assert_eq!(resolved.version.as_deref(), Some("5.0.0-rc.1"));
++}
++
++#[test]
++fn resolve_version_normalizes_bundled_to_none() {
++    // F-007: an explicit bundled request normalizes to `version: None` — the bundled bb ships as the
++    // sidecar (resolved via `find_bb(None)`), never the version cache. Never flagged for download, and
++    // `None` means a `Some(v)` downstream is unambiguously non-bundled (⇒ marker-verified cache only).
+     let core = HeadlessState::headless("1.0.0", Some("0.99.0".to_string()), None, None);
+     let state = AppState::headless(core);
+     let requested = Some("0.99.0".to_string());
+     let resolved = resolve_version(&state, &requested).expect("bundled resolves");
+-    assert_eq!(resolved.version.as_deref(), Some("0.99.0"));
++    assert!(
++        resolved.version.is_none(),
++        "bundled request must normalize to None (sidecar path)"
++    );
+     assert!(
+         !resolved.needs_download,
+         "bundled version must NOT download"
+@@ -1134,3 +1154,34 @@ async fn invalid_host_reply_stays_application_json_without_message() {
+         "invalid_host must NOT carry a message field (minimal host-guard reply)"
+     );
+ }
++
++#[tokio::test]
++async fn prove_sheds_with_429_when_waiter_cap_full() {
++    // F-009 (handler-level): with the in-flight/waiting cap already full (prove_waiters exhausted),
++    // an authorized /prove request is shed IMMEDIATELY with 429 prove_queue_full — it never queues
++    // behind slow uploaders. Complements the try_enter unit test with end-to-end handler wiring.
++    let state = AppState {
++        core: std::sync::Arc::new(HeadlessState {
++            prove_waiters: std::sync::Arc::new(tokio::sync::Semaphore::new(0)),
++            ..HeadlessState::default()
++        }),
++        ..AppState::default()
++    };
++    let response = router(state)
++        .oneshot(
++            Request::builder()
++                .method("POST")
++                .header("host", "127.0.0.1:59833")
++                .uri("/prove")
++                .body(Body::from("witness"))
++                .unwrap(),
++        )
++        .await
++        .unwrap();
++    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
++    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
++        .await
++        .unwrap();
++    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
++    assert_eq!(json["error"], "prove_queue_full");
++}

--- a/implementations-plan/security-hardening/full-audit-2026-07-24/chunks/B-bb-versions.diff
+++ b/implementations-plan/security-hardening/full-audit-2026-07-24/chunks/B-bb-versions.diff
@@ -1,0 +1,1369 @@
+diff --git a/packages/accelerator/core/src/bb.rs b/packages/accelerator/core/src/bb.rs
+index 9f467b1..46c0690 100644
+--- a/packages/accelerator/core/src/bb.rs
++++ b/packages/accelerator/core/src/bb.rs
+@@ -6,20 +6,25 @@ use crate::versions;
+ /// Maximum time to wait for bb prove to complete before killing the process.
+ const PROVE_TIMEOUT: Duration = Duration::from_secs(300); // 5 minutes
+ 
+-/// Find the `bb` binary. When `version` is provided, the version cache is checked
+-/// before the standard search chain.
++/// Find the `bb` binary. When `version` is provided, the marker-verified version cache is the ONLY
++/// acceptable source — never the standard search chain.
+ ///
+ /// Search order:
+-/// 0. `BB_BINARY_PATH` env var — explicit override (CI, testing, custom installs)
+-/// 1. Version cache (`~/.aztec-accelerator/versions/{version}/bb`) — when version specified
++/// 0. `BB_BINARY_PATH` env var — trusted, unversioned operator override (A4). The one documented
++///    exception to "no unverified execution": whoever sets the process env already owns the process.
++/// 1. Version cache (`~/.aztec-accelerator/versions/{version}/bb`) — when a version is requested.
+ /// 2. Bundled sidecar (Tauri externalBin) — `binaries/bb-{target-triple}` next to the executable
+ /// 3. `~/.bb/bb` — user-installed via `bbup`
+ /// 4. `bb` on `$PATH`
+ ///
+-/// q7e3-F-08: `version` is the validated `&AztecVersion` — the cache-path lookup below is
+-/// traversal-safe by construction.
++/// F-007: for a REQUESTED (non-bundled) version, the marker-verified cache entry is the ONLY acceptable
++/// source. `resolve_version` normalizes the bundled request to `None`, so a `Some(v)` here is always a
++/// genuinely non-bundled request; ANY cache failure (absent, tampered, unreadable) is a hard error —
++/// steps 2–4 would silently execute the WRONG version (or an unverified binary) over the private
++/// witness. Only `find_bb(None)` (bundled / unspecified) walks the sidecar → `~/.bb` → `$PATH` chain.
++/// q7e3-F-08: `version` is the validated `&AztecVersion` — the cache-path lookup is traversal-safe.
+ pub fn find_bb(version: Option<&versions::AztecVersion>) -> Result<PathBuf, String> {
+-    // 0. Explicit override via environment variable
++    // 0. Explicit override via environment variable (trusted, unversioned — A4).
+     if let Ok(path) = std::env::var("BB_BINARY_PATH") {
+         let explicit = PathBuf::from(&path);
+         if explicit.exists() {
+@@ -27,12 +32,11 @@ pub fn find_bb(version: Option<&versions::AztecVersion>) -> Result<PathBuf, Stri
+         }
+     }
+ 
+-    // 1. Version cache (only when a specific version is requested)
++    // 1. Version cache — a requested non-bundled version MUST resolve to a marker-verified entry, with
++    //    NO fall-through to a different bb (F-007).
+     if let Some(v) = version {
+-        let cached = versions::version_bb_path(v);
+-        if cached.exists() {
+-            return Ok(cached);
+-        }
++        return versions::verify_cached_bb(v)
++            .map_err(|e| format!("cached bb for {v} failed integrity verification: {e}"));
+     }
+ 
+     // 2. Sidecar: check next to the current executable (bb.exe on Windows)
+@@ -70,6 +74,110 @@ fn home_dir_fallback() -> Option<PathBuf> {
+     std::env::var("HOME").ok().map(PathBuf::from)
+ }
+ 
++/// Per-user private base for prove workspaces: `<data-local>/aztec-accelerator/prove-tmp`, created
++/// owner-only. Using our OWN per-user directory (not the shared OS temp) keeps the witness off a
++/// world-readable / shared `$TMPDIR`/`%TEMP%` and out of a non-sticky temp parent where an
++/// attacker could replace an ancestor between creation and use (F-003 hardening). `None` if no
++/// data-local dir is resolvable (caller falls back to OS temp).
++fn prove_tmp_parent() -> Option<PathBuf> {
++    let base = dirs::data_local_dir()?
++        .join("aztec-accelerator")
++        .join("prove-tmp");
++    #[cfg(unix)]
++    {
++        use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
++        std::fs::DirBuilder::new()
++            .recursive(true)
++            .mode(0o700)
++            .create(&base)
++            .ok()?;
++        // Tighten even if it pre-existed with a looser mode.
++        std::fs::set_permissions(&base, std::fs::Permissions::from_mode(0o700)).ok()?;
++    }
++    #[cfg(windows)]
++    {
++        // F-003 Windows tail: create `prove-tmp` with an owner-only PROTECTED+inheritable DACL, or harden
++        // it if it pre-exists. Fail closed (None → caller must NOT fall back to a shared temp on Windows).
++        if let Some(mid) = base.parent() {
++            std::fs::create_dir_all(mid).ok()?;
++        }
++        match crate::win_acl::secure_create_dir(&base) {
++            Ok(()) => {}
++            Err(_) if base.is_dir() => crate::win_acl::harden_existing_dir(&base).ok()?,
++            Err(_) => return None,
++        }
++    }
++    #[cfg(all(not(unix), not(windows)))]
++    std::fs::create_dir_all(&base).ok()?;
++    Some(base)
++}
++
++/// Create the per-prove temp workspace under the per-user private base (see `prove_tmp_parent`).
++/// On Unix the directory is created `0o700` (owner-only) at the creation syscall — never
++/// write-then-chmod — so the private witness never has a world-traversable window (F-003).
++/// `tempfile::tempdir()` alone applies no mode and inherits the umask default (typically `0o755`).
++/// Falls back to the OS temp dir (still `0o700` on Unix) only if no per-user dir is resolvable.
++fn create_prove_tempdir() -> std::io::Result<tempfile::TempDir> {
++    let mut builder = tempfile::Builder::new();
++    builder.prefix("prove-");
++    #[cfg(unix)]
++    {
++        use std::os::unix::fs::PermissionsExt;
++        builder.permissions(std::fs::Permissions::from_mode(0o700));
++    }
++    #[cfg(windows)]
++    {
++        // F-003 (D4/D21): fail closed on Windows — NO OS-`%TEMP%` fallback for the private witness. The
++        // `prove-tmp` parent is owner-only + inheritable, so the child tempdir inherits owner-only AT
++        // creation (no window); harden it explicitly (PROTECTED) too.
++        let parent = prove_tmp_parent().ok_or_else(|| {
++            std::io::Error::new(
++                std::io::ErrorKind::NotFound,
++                "no per-user data dir for a private prove workspace (refusing OS-temp fallback)",
++            )
++        })?;
++        let dir = builder.tempdir_in(parent)?;
++        crate::win_acl::harden_existing_dir(dir.path())?;
++        Ok(dir)
++    }
++    #[cfg(not(windows))]
++    match prove_tmp_parent() {
++        Some(parent) => builder.tempdir_in(parent),
++        None => {
++            tracing::warn!(
++                "No per-user data dir for a private prove workspace; using OS temp (0o700 on Unix)"
++            );
++            builder.tempdir()
++        }
++    }
++}
++
++/// Write the proving witness (private ZK inputs) with mode `0o600` supplied to the creation
++/// syscall (F-003) — no write-then-chmod window. `create_new(true)` fails closed if the path
++/// already exists (defends against a pre-planted file/symlink in the workspace).
++fn write_witness(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
++    use std::io::Write;
++    #[cfg(windows)]
++    {
++        // F-003 Windows tail: create the empty witness with an owner-only DACL BEFORE writing bytes
++        // (CREATE_NEW rejects a pre-planted file/symlink), then write.
++        let mut file = crate::win_acl::secure_create_file(path)?;
++        file.write_all(bytes)
++    }
++    #[cfg(not(windows))]
++    {
++        let mut options = std::fs::OpenOptions::new();
++        options.write(true).create_new(true);
++        #[cfg(unix)]
++        {
++            use std::os::unix::fs::OpenOptionsExt;
++            options.mode(0o600);
++        }
++        let mut file = options.open(path)?;
++        file.write_all(bytes)
++    }
++}
++
+ /// Run `bb prove` on the given IVC inputs (msgpack bytes) and return the proof
+ /// with a 4-byte BE field-count header suitable for `ChonkProofWithPublicInputs.fromBuffer()`.
+ ///
+@@ -83,11 +191,11 @@ pub async fn prove(
+     let bb_path =
+         find_bb(version).map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })?;
+ 
+-    let tmp_dir = tempfile::tempdir()?;
++    let tmp_dir = create_prove_tempdir()?;
+     let input_path = tmp_dir.path().join("ivc-inputs.msgpack");
+     let output_dir = tmp_dir.path().join("output");
+     std::fs::create_dir_all(&output_dir)?;
+-    std::fs::write(&input_path, ivc_inputs)?;
++    write_witness(&input_path, ivc_inputs)?;
+ 
+     tracing::info!(
+         version = version.map_or("bundled", |v| v.as_str()),
+@@ -176,6 +284,50 @@ mod tests {
+     use super::*;
+     use serial_test::serial;
+ 
++    /// F-003: the per-prove workspace dir is created `0o700` and the witness file `0o600` — at
++    /// the creation syscall, so no other local user can read the private witness while proving.
++    #[cfg(unix)]
++    #[test]
++    fn prove_workspace_and_witness_have_private_modes() {
++        use std::os::unix::fs::MetadataExt;
++
++        let dir = create_prove_tempdir().unwrap();
++        let witness = dir.path().join("ivc-inputs.msgpack");
++        write_witness(&witness, b"secret-witness-bytes").unwrap();
++
++        assert_eq!(
++            std::fs::metadata(dir.path()).unwrap().mode() & 0o777,
++            0o700,
++            "prove workspace dir must be owner-only"
++        );
++        assert_eq!(
++            std::fs::metadata(&witness).unwrap().mode() & 0o777,
++            0o600,
++            "witness file must be owner-only"
++        );
++
++        // create_new fails closed on a pre-existing path (no silent overwrite of a planted file).
++        assert!(write_witness(&witness, b"again").is_err());
++    }
++
++    /// F-003 Windows tail (runs in the `windows-build` CI lane). `create_prove_tempdir` / `write_witness`
++    /// apply an owner-only PROTECTED DACL and then READ IT BACK, failing closed if it did not take effect
++    /// (`win_acl::verify_owner_only` — catches FAT/exFAT no-op, foreign/world ACEs). So a successful
++    /// create+write IS the effective-DACL assertion: owner-only, no `BUILTIN\Users`/`Everyone`. Also
++    /// pins reparse/pre-plant rejection (CREATE_NEW / CreateDirectoryW fail if the path already exists).
++    #[cfg(windows)]
++    #[test]
++    fn prove_workspace_and_witness_are_owner_only_windows() {
++        let dir =
++            create_prove_tempdir().expect("secure prove workspace (owner-only DACL verified)");
++        let witness = dir.path().join("ivc-inputs.msgpack");
++        write_witness(&witness, b"secret-witness-bytes")
++            .expect("secure witness (owner-only DACL verified)");
++        assert!(witness.exists());
++        // CREATE_NEW must reject a second write to the same path (planted-file / symlink defense).
++        assert!(write_witness(&witness, b"again").is_err());
++    }
++
+     #[test]
+     fn truncate_stderr_cuts_at_char_boundary_without_panic() {
+         // 600 'é' = 1200 bytes / 600 chars → must truncate (char_count > 500); a byte slice at 500
+@@ -271,13 +423,18 @@ mod tests {
+     }
+ 
+     #[test]
+-    fn test_find_bb_with_version_checks_cache() {
+-        // Verify that find_bb with a version doesn't panic and follows the chain
++    #[serial]
++    fn test_find_bb_with_uncached_version_is_fail_closed() {
++        // F-007: a requested (non-bundled) version with no marker-verified cache entry MUST hard-error —
++        // it never falls through to the sidecar/~/.bb/$PATH (which would run the wrong/unverified bb over
++        // the witness). `#[serial]` + clearing the env override keeps this deterministic vs the env tests.
++        std::env::remove_var("BB_BINARY_PATH");
+         let version = versions::AztecVersion::parse("99.99.99-nonexistent").unwrap();
+         let result = find_bb(Some(&version));
+-        match result {
+-            Ok(path) => assert!(path.exists()),
+-            Err(msg) => assert!(msg.contains("bb binary not found")),
+-        }
++        assert!(
++            result.is_err(),
++            "uncached requested version must fail closed, got {result:?}"
++        );
++        assert!(result.unwrap_err().contains("integrity verification"));
+     }
+ }
+diff --git a/packages/accelerator/core/src/lib.rs b/packages/accelerator/core/src/lib.rs
+index 5b47dcf..149f293 100644
+--- a/packages/accelerator/core/src/lib.rs
++++ b/packages/accelerator/core/src/lib.rs
+@@ -11,7 +11,12 @@ pub mod authorization;
+ pub mod bb;
+ pub mod config;
+ pub mod server;
++pub mod update_manifest;
++pub mod updater_state;
+ pub mod versions;
++/// F-003 Windows tail — owner-only ACL helpers (Windows-only; the module is `#![cfg(windows)]`).
++#[cfg(windows)]
++pub mod win_acl;
+ 
+ use std::path::PathBuf;
+ 
+diff --git a/packages/accelerator/core/src/versions/cache_layout.rs b/packages/accelerator/core/src/versions/cache_layout.rs
+index 8a52200..538c30f 100644
+--- a/packages/accelerator/core/src/versions/cache_layout.rs
++++ b/packages/accelerator/core/src/versions/cache_layout.rs
+@@ -1,17 +1,27 @@
+ //! On-disk layout of the bb version cache (`~/.aztec-accelerator/versions/`). q7e3-F-07: split from
+ //! the `versions` module root; the root re-exports keep external paths unchanged.
+ 
++use super::release_metadata::current_platform;
+ use super::version_policy::AztecVersion;
+-use std::path::PathBuf;
+-
+-/// Returns the base directory for cached bb versions: `~/.aztec-accelerator/versions/`.
+-pub fn versions_base_dir() -> PathBuf {
+-    dirs::home_dir()
+-        .unwrap_or_else(|| PathBuf::from("."))
+-        .join(".aztec-accelerator")
+-        .join("versions")
++use std::path::{Path, PathBuf};
++
++/// The base directory for cached bb versions: `~/.aztec-accelerator/versions/`. Returns `None` when
++/// the user home directory cannot be resolved — every caller then FAILS CLOSED (codex audit #4).
++///
++/// The previous `unwrap_or_else(|| ".")` (current-working-directory) fallback was a real hole: the
++/// bb-cache integrity marker is only trustworthy inside a directory the *user* owns. If home
++/// resolution failed and the cache root became the CWD, an attacker who controls the working
++/// directory could preseed `./.aztec-accelerator/versions/<v>/{bb, bb.sha256.json}` with a bb and a
++/// SELF-AUTHORED marker whose digest matches — and `verify_cached_bb` would accept it, bypassing the
++/// download-time verification entirely. No resolvable home ⇒ no trusted cache location ⇒ refuse.
++pub fn versions_base_dir() -> Option<PathBuf> {
++    dirs::home_dir().map(|h| h.join(".aztec-accelerator").join("versions"))
+ }
+ 
++/// Error returned by the security-critical paths when [`versions_base_dir`] yields `None`.
++const NO_TRUSTED_CACHE_ROOT: &str =
++    "SECURITY: home directory unresolved; refusing to trust any cache location";
++
+ /// The bb binary filename on the current platform (`bb.exe` on Windows, `bb` elsewhere).
+ pub fn bb_binary_name() -> &'static str {
+     if cfg!(target_os = "windows") {
+@@ -24,28 +34,189 @@ pub fn bb_binary_name() -> &'static str {
+ /// Returns the path to a cached bb binary for a given version.
+ /// q7e3-F-08: takes the validated `&AztecVersion` — an unvalidated string can no longer reach this
+ /// path-building sink (the #99 traversal guard holds by construction).
+-pub fn version_bb_path(version: &AztecVersion) -> PathBuf {
+-    versions_base_dir()
+-        .join(version.as_str())
+-        .join(bb_binary_name())
++pub fn version_bb_path(version: &AztecVersion) -> Option<PathBuf> {
++    versions_base_dir().map(|b| b.join(version.as_str()).join(bb_binary_name()))
+ }
+ 
+-/// List all cached bb versions by scanning `versions_base_dir()`.
++/// List all cached bb versions by scanning `versions_base_dir()`. An unresolvable home ⇒ no trusted
++/// cache ⇒ empty inventory (fail closed: nothing is advertised as cached).
+ pub fn list_cached_versions() -> Vec<String> {
+-    let base = versions_base_dir();
++    versions_base_dir()
++        .map(|b| list_cached_versions_in(&b))
++        .unwrap_or_default()
++}
++
++/// Inner, base-dir-parameterized for testing. A directory counts as a cached version ONLY if its name
++/// is a VALID version (skips dot-prefixed `.{v}.tmp.<rand>` staging dirs + junk) AND it holds BOTH the
++/// binary and its integrity marker. Cheap stat only — NEVER rehashes: this feeds the hot inventory
++/// (`/health` + tray), so it must not read binary bytes. Execution paths rehash via `verify_cached_bb`
++/// (F-007).
++pub(crate) fn list_cached_versions_in(base: &Path) -> Vec<String> {
+     let mut versions = Vec::new();
+-    if let Ok(entries) = std::fs::read_dir(&base) {
++    if let Ok(entries) = std::fs::read_dir(base) {
+         for entry in entries.flatten() {
+-            if entry.path().join(bb_binary_name()).exists() {
+-                if let Some(name) = entry.file_name().to_str() {
+-                    versions.push(name.to_string());
+-                }
++            let Ok(name) = entry.file_name().into_string() else {
++                continue;
++            };
++            // Exclude staging dirs (leading dot) and any non-version-named directory.
++            if name.starts_with('.') || AztecVersion::parse(&name).is_none() {
++                continue;
++            }
++            let dir = entry.path();
++            if dir.join(bb_binary_name()).exists() && dir.join(MARKER_NAME).exists() {
++                versions.push(name);
+             }
+         }
+     }
+     versions.sort();
+     versions
+ }
++
++// ---------------------------------------------------------------------------
++// F-007 integrity marker: every cached bb carries a `bb.sha256.json` recording the verified archive
++// digest + the FINAL-binary digest (post macOS codesign). The runtime rehashes the cached binary
++// against this marker on every use (`verify_cached_bb`); a missing/malformed/mismatched marker fails
++// closed and triggers a verified re-download.
++// ---------------------------------------------------------------------------
++
++/// Marker filename, colocated with `bb` in each version dir.
++pub(crate) const MARKER_NAME: &str = "bb.sha256.json";
++/// Marker schema tag — `read_bb_marker` rejects anything else (forward-compatible evolution).
++pub(crate) const MARKER_SCHEMA: &str = "aztec-accelerator/bb-cache-marker@1";
++
++/// Path to a cached version's integrity marker. `None` when home is unresolved (fail closed).
++pub(crate) fn version_bb_marker_path(version: &AztecVersion) -> Option<PathBuf> {
++    versions_base_dir().map(|b| b.join(version.as_str()).join(MARKER_NAME))
++}
++
++fn is_hex64(s: &str) -> bool {
++    s.len() == 64
++        && s.bytes()
++            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
++}
++
++/// Streamed SHA-256 of a file (never loads the whole binary into memory).
++pub(crate) fn sha256_file(path: &Path) -> std::io::Result<String> {
++    use sha2::{Digest, Sha256};
++    use std::io::Read;
++    let mut file = std::fs::File::open(path)?;
++    let mut hasher = Sha256::new();
++    let mut buf = [0u8; 64 * 1024];
++    loop {
++        let n = file.read(&mut buf)?;
++        if n == 0 {
++            break;
++        }
++        hasher.update(&buf[..n]);
++    }
++    Ok(hex::encode(hasher.finalize()))
++}
++
++/// Write the marker at mode `0600`-at-creation (Unix) into `dir` (the staging dir, pre-publish). Both
++/// digests are recorded (archive = provenance; binary = what the runtime re-verifies).
++pub(crate) fn write_bb_marker(
++    dir: &Path,
++    version: &str,
++    archive_sha256: &str,
++    binary_sha256: &str,
++) -> std::io::Result<()> {
++    use std::io::Write;
++    let body = serde_json::json!({
++        "schema": MARKER_SCHEMA,
++        "version": version,
++        "platform": current_platform(),
++        "archive_sha256": archive_sha256,
++        "binary_sha256": binary_sha256,
++    })
++    .to_string();
++
++    let mut opts = std::fs::OpenOptions::new();
++    opts.write(true).create(true).truncate(true);
++    #[cfg(unix)]
++    {
++        use std::os::unix::fs::OpenOptionsExt;
++        opts.mode(0o600);
++    }
++    let mut file = opts.open(dir.join(MARKER_NAME))?;
++    file.write_all(body.as_bytes())
++}
++
++/// Read + structurally validate a marker file, returning the verified binary digest. Fail-closed:
++/// missing, oversized, malformed, unknown-schema, version/platform-mismatch, or noncanonical-hex ⇒
++/// `Err`. Path-parameterized so it is unit-testable without the home-bound cache dir. (Archive digest
++/// is validated as canonical hex but not returned — the runtime re-verifies the binary; the archive
++/// digest is provenance recorded in the file.)
++fn read_bb_marker_at(
++    marker_path: &Path,
++    expect_version: &str,
++    expect_platform: &str,
++) -> Result<String, String> {
++    let meta = std::fs::metadata(marker_path).map_err(|e| format!("marker missing: {e}"))?;
++    if meta.len() > 4096 {
++        return Err(format!(
++            "marker is implausibly large ({} bytes)",
++            meta.len()
++        ));
++    }
++    let raw = std::fs::read_to_string(marker_path).map_err(|e| format!("marker read: {e}"))?;
++    let v: serde_json::Value =
++        serde_json::from_str(&raw).map_err(|e| format!("marker parse: {e}"))?;
++
++    let field = |k: &str| v.get(k).and_then(|x| x.as_str());
++    if field("schema") != Some(MARKER_SCHEMA) {
++        return Err("marker has an unknown schema".to_string());
++    }
++    if field("version") != Some(expect_version) {
++        return Err(format!("marker version does not match {expect_version}"));
++    }
++    if field("platform") != Some(expect_platform) {
++        return Err(format!("marker platform does not match {expect_platform}"));
++    }
++    let archive = field("archive_sha256").unwrap_or_default();
++    let binary = field("binary_sha256").unwrap_or_default();
++    if !is_hex64(archive) || !is_hex64(binary) {
++        return Err("marker has non-canonical digest(s)".to_string());
++    }
++    Ok(binary.to_string())
++}
++
++/// Fail-closed integrity check for a bb at explicit paths: the binary must be a present regular file
++/// whose streamed SHA-256 matches its valid marker's `binary_sha256`. Path-parameterized for testing.
++fn verify_bb_entry(
++    bb_path: &Path,
++    marker_path: &Path,
++    expect_version: &str,
++    expect_platform: &str,
++) -> Result<(), String> {
++    let meta =
++        std::fs::symlink_metadata(bb_path).map_err(|e| format!("cached bb unreadable: {e}"))?;
++    if !meta.file_type().is_file() {
++        return Err("cached bb is not a regular file".to_string());
++    }
++    let expected = read_bb_marker_at(marker_path, expect_version, expect_platform)?;
++    let actual = sha256_file(bb_path).map_err(|e| format!("hash cached bb: {e}"))?;
++    if actual != expected {
++        return Err(format!(
++            "SECURITY: cached bb {expect_version} failed integrity check (marker {expected}, actual {actual})"
++        ));
++    }
++    Ok(())
++}
++
++/// Fail-closed integrity check for a cached bb: the binary must be a present regular file whose streamed
++/// SHA-256 matches its valid marker's `binary_sha256`. Returns the verified path on success. This is the
++/// SINGLE authority the runtime trusts before executing a cached bb over the witness (F-007).
++pub fn verify_cached_bb(version: &AztecVersion) -> Result<PathBuf, String> {
++    // codex #4: resolve the trusted cache root first — a `None` home fails closed here rather than
++    // silently trusting a CWD-rooted (attacker-preseedable) path.
++    let bb_path =
++        version_bb_path(version).ok_or_else(|| format!("bb {version}: {NO_TRUSTED_CACHE_ROOT}"))?;
++    let marker_path = version_bb_marker_path(version)
++        .ok_or_else(|| format!("bb {version}: {NO_TRUSTED_CACHE_ROOT}"))?;
++    verify_bb_entry(&bb_path, &marker_path, version.as_str(), current_platform())
++        .map_err(|e| format!("bb {version}: {e}"))?;
++    Ok(bb_path)
++}
+ #[cfg(test)]
+ mod tests {
+     use super::*;
+@@ -53,7 +224,7 @@ mod tests {
+     #[test]
+     fn version_bb_path_format() {
+         let version = AztecVersion::parse("5.0.0-nightly.20260307").unwrap();
+-        let path = version_bb_path(&version);
++        let path = version_bb_path(&version).expect("home resolvable in the test environment");
+         // Separator-agnostic: compare path components, and use the platform's bb name.
+         let tail: std::path::PathBuf = [
+             ".aztec-accelerator",
+@@ -91,4 +262,166 @@ mod tests {
+         assert!(v2_dir.join("bb").exists());
+         assert!(!v3_dir.join("bb").exists());
+     }
++
++    // ----- F-007 marker + inventory ---------------------------------------------------------------
++
++    /// Write a `{ bb, marker }` cache entry into `base/<version>`; returns the version dir.
++    fn write_entry(base: &std::path::Path, version: &str, bb_bytes: &[u8]) -> PathBuf {
++        let dir = base.join(version);
++        std::fs::create_dir_all(&dir).unwrap();
++        std::fs::write(dir.join(bb_binary_name()), bb_bytes).unwrap();
++        let bin = super::sha256_file(&dir.join(bb_binary_name())).unwrap();
++        // archive digest is arbitrary provenance for the test (a valid 64-hex).
++        write_bb_marker(&dir, version, &"a".repeat(64), &bin).unwrap();
++        dir
++    }
++
++    #[test]
++    fn verify_bb_entry_accepts_a_matching_marker() {
++        let tmp = tempfile::tempdir().unwrap();
++        let dir = write_entry(tmp.path(), "5.0.0-rc.2", b"the-bb-bytes");
++        assert!(verify_bb_entry(
++            &dir.join(bb_binary_name()),
++            &dir.join(MARKER_NAME),
++            "5.0.0-rc.2",
++            current_platform(),
++        )
++        .is_ok());
++    }
++
++    #[test]
++    fn verify_bb_entry_is_fail_closed() {
++        let tmp = tempfile::tempdir().unwrap();
++        let dir = write_entry(tmp.path(), "5.0.0-rc.2", b"original");
++        let bb = dir.join(bb_binary_name());
++        let marker = dir.join(MARKER_NAME);
++        let plat = current_platform();
++
++        // Tampered binary ⇒ hash mismatch.
++        std::fs::write(&bb, b"tampered").unwrap();
++        assert!(verify_bb_entry(&bb, &marker, "5.0.0-rc.2", plat).is_err());
++        std::fs::write(&bb, b"original").unwrap(); // restore for the remaining checks
++
++        // Version / platform mismatch.
++        assert!(verify_bb_entry(&bb, &marker, "9.9.9", plat).is_err());
++        assert!(verify_bb_entry(&bb, &marker, "5.0.0-rc.2", "arm64-solaris").is_err());
++
++        // Missing marker.
++        assert!(verify_bb_entry(&bb, &tmp.path().join("nope.json"), "5.0.0-rc.2", plat).is_err());
++
++        // Unknown schema / noncanonical hex.
++        std::fs::write(&marker, r#"{"schema":"other@9"}"#).unwrap();
++        assert!(read_bb_marker_at(&marker, "5.0.0-rc.2", plat).is_err());
++        std::fs::write(
++            &marker,
++            format!(
++                r#"{{"schema":"{MARKER_SCHEMA}","version":"5.0.0-rc.2","platform":"{plat}","archive_sha256":"NOTHEX","binary_sha256":"{}"}}"#,
++                "b".repeat(64)
++            ),
++        )
++        .unwrap();
++        assert!(read_bb_marker_at(&marker, "5.0.0-rc.2", plat).is_err());
++
++        // Oversized marker.
++        std::fs::write(&marker, " ".repeat(5000)).unwrap();
++        assert!(read_bb_marker_at(&marker, "5.0.0-rc.2", plat).is_err());
++    }
++
++    #[test]
++    fn verify_bb_entry_rejects_a_symlink_binary() {
++        #[cfg(unix)]
++        {
++            let tmp = tempfile::tempdir().unwrap();
++            let dir = tmp.path().join("5.0.0-rc.2");
++            std::fs::create_dir_all(&dir).unwrap();
++            std::os::unix::fs::symlink("/etc/passwd", dir.join(bb_binary_name())).unwrap();
++            write_bb_marker(&dir, "5.0.0-rc.2", &"a".repeat(64), &"b".repeat(64)).unwrap();
++            assert!(verify_bb_entry(
++                &dir.join(bb_binary_name()),
++                &dir.join(MARKER_NAME),
++                "5.0.0-rc.2",
++                current_platform(),
++            )
++            .is_err());
++        }
++    }
++
++    #[test]
++    fn list_cached_versions_in_excludes_stages_unmarked_and_junk() {
++        let base = tempfile::tempdir().unwrap();
++        // A valid, marked entry — listed.
++        write_entry(base.path(), "5.0.0-rc.2", b"x");
++        // Unmarked (bb but no marker) — NOT listed.
++        let unmarked = base.path().join("5.0.0-rc.3");
++        std::fs::create_dir_all(&unmarked).unwrap();
++        std::fs::write(unmarked.join(bb_binary_name()), b"y").unwrap();
++        // A crash-stale staging dir (dot-prefixed) WITH a marker — NOT listed.
++        let stage = base.path().join(".5.0.0-rc.9.tmp.1234-5-0");
++        std::fs::create_dir_all(&stage).unwrap();
++        std::fs::write(stage.join(bb_binary_name()), b"z").unwrap();
++        write_bb_marker(&stage, "5.0.0-rc.9", &"a".repeat(64), &"b".repeat(64)).unwrap();
++        // A junk-named dir — NOT listed.
++        std::fs::create_dir_all(base.path().join("not a version!")).unwrap();
++
++        assert_eq!(
++            list_cached_versions_in(base.path()),
++            vec!["5.0.0-rc.2".to_string()]
++        );
++    }
++
++    #[cfg(unix)]
++    #[test]
++    fn marker_is_written_owner_only() {
++        use std::os::unix::fs::PermissionsExt;
++        let tmp = tempfile::tempdir().unwrap();
++        write_bb_marker(tmp.path(), "5.0.0-rc.2", &"a".repeat(64), &"b".repeat(64)).unwrap();
++        let mode = std::fs::metadata(tmp.path().join(MARKER_NAME))
++            .unwrap()
++            .permissions()
++            .mode()
++            & 0o777;
++        assert_eq!(mode, 0o600, "marker must be owner-only");
++    }
++
++    /// Cross-language contract: the committed fixture the TS suite also loads must parse under the Rust
++    /// marker schema (schema tag + canonical-hex digest fields).
++    #[test]
++    fn shared_fixture_marker_matches_schema() {
++        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
++            .join("../../../scripts/__fixtures__/bb-cache-marker.json");
++        let raw = std::fs::read_to_string(&path).expect("fixture bb-cache-marker.json present");
++        let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
++        assert_eq!(v["schema"].as_str(), Some(MARKER_SCHEMA));
++        for f in ["archive_sha256", "binary_sha256"] {
++            assert!(is_hex64(v[f].as_str().unwrap()), "{f} must be 64-lc-hex");
++        }
++        // read_bb_marker_at accepts it when told the fixture's own version + platform.
++        let (ver, plat) = (
++            v["version"].as_str().unwrap(),
++            v["platform"].as_str().unwrap(),
++        );
++        assert!(read_bb_marker_at(&path, ver, plat).is_ok());
++    }
++
++    /// Cross-language contract: the release-metadata fixture the TS suite loads must expose each asset's
++    /// digest as `sha256:<64-lc-hex>` and survive the `sha256:` strip → canonical-hex check that both
++    /// `fetch_github_asset_digest` (Rust) and `fetchAssetDigest` (TS) apply.
++    #[test]
++    fn shared_fixture_release_metadata_has_canonical_digests() {
++        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
++            .join("../../../scripts/__fixtures__/github-release-metadata.json");
++        let raw =
++            std::fs::read_to_string(&path).expect("fixture github-release-metadata.json present");
++        let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
++        let assets = v["assets"].as_array().expect("assets array");
++        assert!(!assets.is_empty());
++        for asset in assets {
++            let digest = asset["digest"].as_str().expect("asset digest");
++            let hex = digest.strip_prefix("sha256:").expect("sha256: prefix");
++            assert!(
++                is_hex64(hex),
++                "asset digest must strip to 64-lc-hex: {digest}"
++            );
++        }
++    }
+ }
+diff --git a/packages/accelerator/core/src/versions/downloader.rs b/packages/accelerator/core/src/versions/downloader.rs
+index b5a6814..8174bd7 100644
+--- a/packages/accelerator/core/src/versions/downloader.rs
++++ b/packages/accelerator/core/src/versions/downloader.rs
+@@ -5,13 +5,16 @@
+ //! that was bolted onto the otherwise cross-platform flow (now its own `finalize_downloaded_binary`).
+ //! The smaller identity/platform/layout/cache concerns stay in the `versions` module root.
+ 
+-use super::cache_layout::{bb_binary_name, version_bb_path, versions_base_dir};
++use super::cache_layout::{
++    bb_binary_name, sha256_file, verify_cached_bb, versions_base_dir, write_bb_marker,
++};
+ use super::release_metadata::{
+     current_platform, download_url, fetch_github_asset_digest, http_client, sha256_hex,
+ };
+ use super::version_policy::AztecVersion;
+ use std::error::Error;
+-use std::path::PathBuf;
++use std::path::{Path, PathBuf};
++use std::sync::atomic::{AtomicU64, Ordering};
+ 
+ pub async fn download_bb(version: &AztecVersion) -> Result<PathBuf, Box<dyn Error + Send + Sync>> {
+     // The `&AztecVersion` parameter IS the #99 traversal guard: a value of this type can only have
+@@ -20,9 +23,10 @@ pub async fn download_bb(version: &AztecVersion) -> Result<PathBuf, Box<dyn Erro
+     // against is now structurally impossible. q7e3-F-08: the path/URL sinks now take `&AztecVersion`
+     // themselves; deref to `&str` only for the log/digest sites (byte-identical strings).
+     let version_str: &str = version;
+-    let bb_path = version_bb_path(version);
+-    if bb_path.exists() {
+-        tracing::info!(version = version_str, "bb already cached");
++    // F-007: skip only when the cache entry is present AND marker-verified. A missing/tampered/legacy
++    // entry falls through to a fresh verified download that atomically REPLACES it (not `exists()`).
++    if let Ok(bb_path) = verify_cached_bb(version) {
++        tracing::info!(version = version_str, "bb already cached (verified)");
+         return Ok(bb_path);
+     }
+ 
+@@ -35,27 +39,22 @@ pub async fn download_bb(version: &AztecVersion) -> Result<PathBuf, Box<dyn Erro
+         bytes = bytes.len(),
+         "Download complete, verifying integrity"
+     );
+-    verify_digest(version_str, &bytes).await?;
+-
+-    // Extract into the version's cache dir via temp dir + atomic rename (Q11: extracted to
+-    // `install_version_dir` so the cleanup/rename is unit-testable without the network).
+-    let version_dir = versions_base_dir().join(version.as_str());
+-    install_version_dir(&version_dir, &bytes)?;
+-
+-    let final_path = version_dir.join(bb_binary_name());
+-    #[cfg(unix)]
+-    {
+-        use std::os::unix::fs::PermissionsExt;
+-        std::fs::set_permissions(&final_path, std::fs::Permissions::from_mode(0o755))?;
+-    }
+-
+-    // macOS: clear quarantine xattrs + ad-hoc re-sign so Gatekeeper doesn't SIGKILL the chmod'd
+-    // binary. Extracted to `finalize_downloaded_binary` (a no-op off macOS) — F-04 folds the
+-    // "macOS tail bolted onto the cross-platform flow" sub-finding.
+-    finalize_downloaded_binary(&final_path, &version_dir, version_str)?;
++    let archive_digest = verify_digest(version_str, &bytes).await?;
++
++    // F-007: stage privately, finalize (chmod + macOS codesign), fingerprint the FINAL binary, write
++    // the marker, THEN publish fail-closed — so the live dir only ever appears with a codesigned binary
++    // + a matching marker.
++    // codex #4: install ONLY into the trusted home-rooted cache; never fall back to CWD (which an
++    // attacker could pre-own). No resolvable home ⇒ refuse to write a downloaded binary anywhere.
++    let version_dir = versions_base_dir()
++        .ok_or(
++            "SECURITY: home directory unresolved; refusing to install bb to an untrusted location",
++        )?
++        .join(version.as_str());
++    install_version_dir(&version_dir, &bytes, version_str, &archive_digest)?;
+ 
+     tracing::info!(version = version_str, "bb cached successfully");
+-    Ok(final_path)
++    Ok(version_dir.join(bb_binary_name()))
+ }
+ 
+ /// macOS: clear extended attributes (quarantine, provenance) and ad-hoc re-sign the binary so
+@@ -150,11 +149,14 @@ async fn download_tarball(version: &AztecVersion) -> Result<Vec<u8>, Box<dyn Err
+     Ok(bytes)
+ }
+ 
+-/// Verify the downloaded `bytes` against the GitHub release asset's published SHA-256 digest.
++/// Verify the downloaded `bytes` against the GitHub release asset's published SHA-256 digest, returning
++/// the verified hex (recorded as the marker's `archive_sha256` provenance field).
+ /// **Fail-closed:** a missing digest (`Ok(None)`) or a fetch error is an error, not a skip — we never
+-/// install unverified code. The bundled sidecar path never reaches here. Byte-identical to the
+-/// pre-Q11 inline block.
+-async fn verify_digest(version: &str, bytes: &[u8]) -> Result<(), Box<dyn Error + Send + Sync>> {
++/// install unverified code. The bundled sidecar path never reaches here.
++async fn verify_digest(
++    version: &str,
++    bytes: &[u8],
++) -> Result<String, Box<dyn Error + Send + Sync>> {
+     let asset_name = format!("barretenberg-{}.tar.gz", current_platform());
+     match fetch_github_asset_digest(version, &asset_name).await {
+         Ok(Some(expected)) => {
+@@ -166,7 +168,7 @@ async fn verify_digest(version: &str, bytes: &[u8]) -> Result<(), Box<dyn Error
+                 .into());
+             }
+             tracing::info!(version, digest = %actual, "Download integrity verified");
+-            Ok(())
++            Ok(actual)
+         }
+         Ok(None) => {
+             Err(format!("Cannot verify bb v{version}: no digest available from GitHub API").into())
+@@ -175,41 +177,117 @@ async fn verify_digest(version: &str, bytes: &[u8]) -> Result<(), Box<dyn Error
+     }
+ }
+ 
+-/// Install an extracted bb tarball into `version_dir` via a temp dir + atomic rename.
+-///
+-/// Cleans up any stale partial-download temp dir, extracts into it, then removes any pre-existing
+-/// `version_dir` and renames the temp dir into place — so the cache swap is atomic and a previously
+-/// corrupt entry is replaced wholesale. The temp dir is a sibling named `.{name}.tmp` (derived from
+-/// `version_dir`'s file name), matching the pre-Q11 inline behavior byte-for-byte.
+-///
+-/// Private + single-caller by design: `download_bb` passes `versions_base_dir().join(version)` where
+-/// `version` came from a validated `AztecVersion`, so the `remove_dir_all` here never sees an
+-/// attacker-derived path. Pinned by `install_version_dir_replaces_stale_and_extracts_atomically`.
+-pub(crate) fn install_version_dir(
+-    version_dir: &std::path::Path,
+-    bytes: &[u8],
+-) -> Result<(), Box<dyn Error + Send + Sync>> {
++/// Monotonic sequence making each staging dir name unique within a process; combined with the PID +
++/// a nanosecond stamp it is unique across concurrent Rust/TS publishers and across crash-restart.
++static STAGING_SEQ: AtomicU64 = AtomicU64::new(0);
++
++/// A per-run-UNIQUE, dot-prefixed staging sibling: `.{name}.tmp.{pid}-{nanos}-{seq}`. Dot-prefixed +
++/// non-version-named so `list_cached_versions` never surfaces an in-flight or crash-stale stage; unique
++/// so a concurrent publisher never shares (and stomps) one stage.
++fn unique_staging_dir(version_dir: &Path) -> Result<PathBuf, Box<dyn Error + Send + Sync>> {
+     let name = version_dir
+         .file_name()
+         .and_then(|n| n.to_str())
+         .ok_or("invalid version dir (no file name)")?;
+-    let tmp_dir = version_dir.with_file_name(format!(".{name}.tmp"));
++    let nanos = std::time::SystemTime::now()
++        .duration_since(std::time::UNIX_EPOCH)
++        .map(|d| d.as_nanos())
++        .unwrap_or(0);
++    let seq = STAGING_SEQ.fetch_add(1, Ordering::Relaxed);
++    Ok(version_dir.with_file_name(format!(".{name}.tmp.{}-{nanos}-{seq}", std::process::id())))
++}
+ 
+-    // Clean up any leftover partial download
+-    if tmp_dir.exists() {
+-        std::fs::remove_dir_all(&tmp_dir)?;
++/// Remove crash-stale staging siblings for this version (`.{name}.tmp.*`) before a fresh install, so a
++/// crashed prior run can't accumulate hidden cache data. Best-effort: errors are ignored.
++fn reap_stale_stages(version_dir: &Path) {
++    let (Some(parent), Some(name)) = (
++        version_dir.parent(),
++        version_dir.file_name().and_then(|n| n.to_str()),
++    ) else {
++        return;
++    };
++    let prefix = format!(".{name}.tmp.");
++    if let Ok(entries) = std::fs::read_dir(parent) {
++        for entry in entries.flatten() {
++            if entry
++                .file_name()
++                .to_str()
++                .is_some_and(|n| n.starts_with(&prefix))
++            {
++                let _ = std::fs::remove_dir_all(entry.path());
++            }
++        }
++    }
++}
++
++/// Stage a verified bb tarball privately, finalize it (chmod + macOS codesign), fingerprint the FINAL
++/// binary, write the integrity marker, THEN publish fail-closed into `version_dir` (F-007).
++///
++/// Ordering matters: the marker digest is taken AFTER codesign (which mutates the binary on macOS), and
++/// the marker is written BEFORE the publish rename — so the live dir only ever appears holding a
++/// codesigned `bb` + a matching marker. Publish is delete-then-rename: initial publish into an empty
++/// slot is atomic; REPLACEMENT is deliberately NOT atomic (a crash between leaves no live entry ⇒
++/// verified re-download next use). The staging dir is unique per run, so concurrent publishers never
++/// collide; a torn/last-loser publish is caught by `verify_cached_bb` on next use.
++///
++/// Private + single-caller: `download_bb` passes `versions_base_dir().join(version)` where `version`
++/// came from a validated `AztecVersion`, so the `remove_dir_all` here never sees an attacker path.
++pub(crate) fn install_version_dir(
++    version_dir: &Path,
++    bytes: &[u8],
++    version: &str,
++    archive_digest: &str,
++) -> Result<(), Box<dyn Error + Send + Sync>> {
++    if let Some(parent) = version_dir.parent() {
++        std::fs::create_dir_all(parent)?;
+     }
+-    std::fs::create_dir_all(&tmp_dir)?;
++    reap_stale_stages(version_dir);
++    let staging = unique_staging_dir(version_dir)?;
++    create_owner_only_dir(&staging)?;
++
++    // Everything happens in staging; on ANY failure the whole stage is removed (never a partial live).
++    let staged = (|| -> Result<(), Box<dyn Error + Send + Sync>> {
++        extract_bb_from_tarball(bytes, &staging)?;
++        let staged_bb = staging.join(bb_binary_name());
++        #[cfg(unix)]
++        {
++            use std::os::unix::fs::PermissionsExt;
++            std::fs::set_permissions(&staged_bb, std::fs::Permissions::from_mode(0o755))?;
++        }
++        // macOS ad-hoc re-sign in staging (a no-op off macOS). Codesign failure removes the stage and
++        // errors — we never publish an unsignable binary.
++        finalize_downloaded_binary(&staged_bb, &staging, version)?;
+ 
+-    extract_bb_from_tarball(bytes, &tmp_dir)?;
++        let binary_digest = sha256_file(&staged_bb)?;
++        write_bb_marker(&staging, version, archive_digest, &binary_digest)?;
+ 
+-    // Atomic rename — replace any pre-existing cache entry wholesale
+-    if version_dir.exists() {
+-        std::fs::remove_dir_all(version_dir)?;
++        // Fail-closed publish: drop any live entry, then rename the stage into place.
++        if version_dir.exists() {
++            std::fs::remove_dir_all(version_dir)?;
++        }
++        std::fs::rename(&staging, version_dir)?;
++        Ok(())
++    })();
++
++    if staged.is_err() {
++        let _ = std::fs::remove_dir_all(&staging);
+     }
+-    std::fs::rename(&tmp_dir, version_dir)?;
++    staged
++}
+ 
+-    Ok(())
++/// Create a staging dir owner-only (`0700`) at the creation syscall on Unix — never create-then-chmod,
++/// so the in-flight binary never has a world-traversable window. `create_dir` (not `_all`) so a
++/// name collision fails closed.
++fn create_owner_only_dir(dir: &Path) -> std::io::Result<()> {
++    #[cfg(unix)]
++    {
++        use std::os::unix::fs::DirBuilderExt;
++        std::fs::DirBuilder::new().mode(0o700).create(dir)
++    }
++    #[cfg(not(unix))]
++    {
++        std::fs::create_dir(dir)
++    }
+ }
+ 
+ /// Extract the `bb` binary from a gzipped tarball.
+@@ -302,6 +380,7 @@ fn extract_bb_from_tarball_capped(
+ 
+ #[cfg(test)]
+ mod tests {
++    use super::super::cache_layout::version_bb_path;
+     use super::*;
+     use std::io::Write;
+ 
+@@ -392,15 +471,14 @@ mod tests {
+         assert!(contents.contains("echo hello"));
+     }
+ 
+-    /// Q11 atomic-rename-cleanup: `install_version_dir` extracts into a sibling temp dir then renames
+-    /// it into place, replacing any stale cache entry wholesale and leaving no temp dir behind. Pins
+-    /// the behavior the pre-Q11 inline block in `download_bb` had, now that it's a testable unit.
++    /// F-007 staged verified install: `install_version_dir` extracts + finalizes + writes the marker in
++    /// a unique staging dir, then publishes fail-closed — replacing any stale entry wholesale, leaving
++    /// no staging dir, and producing a marker whose `binary_sha256` matches the FINAL published binary.
+     #[test]
+-    fn install_version_dir_replaces_stale_and_extracts_atomically() {
++    fn install_version_dir_stages_marks_and_publishes() {
+         use flate2::write::GzEncoder;
+         use flate2::Compression;
+ 
+-        // Minimal valid tarball containing the platform bb binary name.
+         let bb_content = b"#!/bin/sh\necho fake-bb\n";
+         let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
+         {
+@@ -415,34 +493,59 @@ mod tests {
+             builder.finish().unwrap();
+         }
+         let tarball = encoder.finish().unwrap();
++        let archive_digest = sha256_hex(&tarball);
+ 
+         let base = tempfile::tempdir().unwrap();
+         let version_dir = base.path().join("5.0.0-test");
+ 
+-        // Fresh install → bb present.
+-        install_version_dir(&version_dir, &tarball).unwrap();
++        // A crash-stale staging sibling from a prior run must be reaped by the next install.
++        let stale = base.path().join(".5.0.0-test.tmp.999-0-0");
++        std::fs::create_dir_all(&stale).unwrap();
++        std::fs::write(stale.join("junk"), b"stale").unwrap();
++
++        // Fresh install → bb + marker present, marker binds the published binary bytes (post-finalize).
++        install_version_dir(&version_dir, &tarball, "5.0.0-test", &archive_digest).unwrap();
+         assert!(
+-            version_dir.join(bb_binary_name()).exists(),
+-            "bb extracted on fresh install"
++            !stale.exists(),
++            "crash-stale staging dir reaped on next install"
++        );
++        let bb = version_dir.join(bb_binary_name());
++        assert!(bb.exists(), "bb published");
++        let marker_path = version_dir.join("bb.sha256.json");
++        assert!(marker_path.exists(), "marker published");
++        let marker: serde_json::Value =
++            serde_json::from_str(&std::fs::read_to_string(&marker_path).unwrap()).unwrap();
++        assert_eq!(
++            marker["schema"].as_str(),
++            Some("aztec-accelerator/bb-cache-marker@1")
++        );
++        assert_eq!(marker["version"].as_str(), Some("5.0.0-test"));
++        assert_eq!(
++            marker["archive_sha256"].as_str(),
++            Some(archive_digest.as_str())
++        );
++        assert_eq!(
++            marker["binary_sha256"].as_str().unwrap(),
++            sha256_file(&bb).unwrap(),
++            "marker binary digest matches the FINAL published binary (post-finalize)"
+         );
+ 
+-        // A stale cache entry (junk file) is replaced wholesale by the atomic rename.
++        // A stale cache entry (junk file) is replaced wholesale.
+         std::fs::write(version_dir.join("STALE_JUNK"), b"old").unwrap();
+-        install_version_dir(&version_dir, &tarball).unwrap();
+-        assert!(
+-            version_dir.join(bb_binary_name()).exists(),
+-            "bb re-extracted after replace"
+-        );
++        install_version_dir(&version_dir, &tarball, "5.0.0-test", &archive_digest).unwrap();
++        assert!(bb.exists(), "bb re-published after replace");
+         assert!(
+             !version_dir.join("STALE_JUNK").exists(),
+-            "stale entry removed by atomic replace"
++            "stale entry removed by fail-closed replace"
+         );
+ 
+-        // No leftover temp dir after the rename.
+-        assert!(
+-            !version_dir.with_file_name(".5.0.0-test.tmp").exists(),
+-            "temp dir cleaned up after rename"
+-        );
++        // No leftover staging dir (.5.0.0-test.tmp.*) after publish.
++        let leftover = std::fs::read_dir(base.path()).unwrap().flatten().any(|e| {
++            e.file_name()
++                .to_string_lossy()
++                .starts_with(".5.0.0-test.tmp.")
++        });
++        assert!(!leftover, "staging dir cleaned up after publish");
+     }
+ 
+     #[test]
+@@ -595,11 +698,16 @@ mod tests {
+         let av = AztecVersion::parse(&version).expect("bundled version is valid");
+ 
+         // Delete cached version to force a fresh download
+-        let cached_dir = versions_base_dir().join(&version);
++        let cached_dir = versions_base_dir()
++            .expect("home resolvable in the test environment")
++            .join(&version);
+         if cached_dir.exists() {
+             std::fs::remove_dir_all(&cached_dir).unwrap();
+         }
+-        assert!(!version_bb_path(&av).exists(), "cache should be cleared");
++        assert!(
++            !version_bb_path(&av).expect("home resolvable").exists(),
++            "cache should be cleared"
++        );
+ 
+         // Download — exercises the full pipeline: HTTP GET → SHA-256 → extract → codesign
+         let bb_path = download_bb(&av)
+@@ -607,7 +715,7 @@ mod tests {
+             .unwrap_or_else(|e| panic!("download_bb({version}) failed: {e}"));
+ 
+         // Verify the binary was cached in the right location
+-        assert_eq!(bb_path, version_bb_path(&av));
++        assert_eq!(bb_path, version_bb_path(&av).expect("home resolvable"));
+         assert!(bb_path.exists(), "bb binary should exist after download");
+ 
+         // Verify it's a real file (not a directory or symlink)
+diff --git a/packages/accelerator/core/src/versions/mod.rs b/packages/accelerator/core/src/versions/mod.rs
+index 7b6b0cd..1cab333 100644
+--- a/packages/accelerator/core/src/versions/mod.rs
++++ b/packages/accelerator/core/src/versions/mod.rs
+@@ -10,9 +10,12 @@ mod downloader;
+ mod release_metadata;
+ mod version_policy;
+ 
+-pub use cache_layout::{bb_binary_name, list_cached_versions, version_bb_path, versions_base_dir};
++pub use cache_layout::{
++    bb_binary_name, list_cached_versions, verify_cached_bb, version_bb_path, versions_base_dir,
++};
+ pub use downloader::download_bb;
+ pub use release_metadata::{current_platform, download_url};
+ pub use version_policy::{
+-    cleanup_old_versions, is_valid_version, versions_to_evict, AztecVersion, NetworkTier,
++    check_version_selectable, cleanup_old_versions, is_valid_version, versions_to_evict,
++    AztecVersion, NetworkTier, VersionRejection,
+ };
+diff --git a/packages/accelerator/core/src/versions/version_policy.rs b/packages/accelerator/core/src/versions/version_policy.rs
+index 7772975..33dd40f 100644
+--- a/packages/accelerator/core/src/versions/version_policy.rs
++++ b/packages/accelerator/core/src/versions/version_policy.rs
+@@ -180,6 +180,85 @@ pub fn versions_to_evict(
+     to_evict
+ }
+ 
++/// Aztec versions whose bundled `bb` is KNOWN to be vulnerable — a REVOCATION list, **EMPTY by default**.
++///
++/// `x-aztec-version` carries the **Aztec** version (the SDK's `@aztec/stdlib` dependency version), NOT a
++/// barretenberg/`bb` version — and many Aztec releases ship the *same* `bb`. So a "newer-is-safer" floor
++/// keyed on this string would wrongly reject a legitimate older-but-compatible dApp (e.g. an Aztec 5.0.1
++/// app talking to a 5.1.0-bundled accelerator). Instead this is a targeted denylist: the app owner adds a
++/// version string here ONLY if a security defect is found in the `bb` shipped with that Aztec release,
++/// and a remote request for it is then refused (403). Empty ⇒ no restriction — any version the dApp
++/// requests is allowed, and it is still digest-verified against Aztec's published hash on download (so it
++/// is always an AUTHENTIC Aztec `bb`). COMPILE-TIME so a remote dApp cannot change it. Entries must be the
++/// exact wire version string the SDK sends.
++pub const KNOWN_VULNERABLE_VERSIONS: &[&str] = &[];
++
++/// Why a remote-requested version was refused by [`check_version_selectable`]. Carried into the 403
++/// body + a `warn!` so a legitimate integrator sees WHY their pin was rejected.
++#[derive(Debug, Clone, Copy, PartialEq, Eq)]
++pub enum VersionRejection {
++    /// Passed the `is_valid_version` charset gate but is not a canonical strict semver — a syntactic
++    /// alias (`latest`, `5`, `5.0`) or a non-canonical spelling. Rejected so only well-formed versions
++    /// are ever fetched or exact-matched against the revocation list (codex denylist-review #2).
++    NotSemver,
++    /// Carries `+build` metadata. Two builds with equal SemVer precedence are distinct release
++    /// identities we can't reason about — refuse them.
++    HasBuildMetadata,
++    /// The requested Aztec version is on the [`KNOWN_VULNERABLE_VERSIONS`] revocation list.
++    KnownVulnerable,
++}
++
++impl VersionRejection {
++    /// Short, stable reason string for logs + the error body.
++    pub fn reason(self) -> &'static str {
++        match self {
++            Self::NotSemver => "not a canonical strict semver version",
++            Self::HasBuildMetadata => "carries build metadata (ambiguous release identity)",
++            Self::KnownVulnerable => "on the known-vulnerable revocation list",
++        }
++    }
++}
++
++/// Gate a REMOTE `x-aztec-version` request.
++///
++/// The header is the **Aztec** version, not a `bb` version, and the accelerator downloads the `bb`
++/// tarball attached to the Aztec release of that exact version. We therefore CANNOT impose a
++/// "newer-is-safer" floor here — many Aztec versions share one `bb`, so a floor would break a legitimate
++/// older-but-compatible dApp (this was the over-blocking bug this function replaces). Every download is
++/// already digest-verified against Aztec's published hash, so a requested version is always an authentic
++/// Aztec `bb`. The only residual risk — an approved dApp pinning an Aztec version whose bundled `bb` is
++/// *later* found vulnerable — is handled REACTIVELY via the [`KNOWN_VULNERABLE_VERSIONS`] revocation list
++/// (empty by default). Everything not on that list is allowed.
++///
++/// Well-formedness is STILL enforced (codex denylist-review #2): the request must be canonical strict
++/// semver with no build metadata. This rejects aliases (`latest`) the looser `is_valid_version` charset
++/// gate lets through, and keeps the exact-string revocation match meaningful.
++///
++/// (A precise FUTURE gate could run `bb --version` on the downloaded binary to obtain the true
++/// barretenberg build id — distinct from the Aztec/npm version — and denylist on THAT, or ship a signed
++/// updateable revocation manifest. Larger cross-package changes, tracked separately.)
++pub fn check_version_selectable(requested: &str) -> Result<(), VersionRejection> {
++    check_version_against(requested, KNOWN_VULNERABLE_VERSIONS)
++}
++
++/// Inner, denylist-parameterized core of [`check_version_selectable`] — unit-testable against an
++/// arbitrary revocation list (the production const is empty). Validates well-formedness FIRST, then the
++/// revocation match.
++fn check_version_against(requested: &str, denylist: &[&str]) -> Result<(), VersionRejection> {
++    // Canonical strict semver, no build metadata — same well-formedness the earlier gate enforced.
++    let v = semver::Version::parse(requested).map_err(|_| VersionRejection::NotSemver)?;
++    if v.to_string() != requested {
++        return Err(VersionRejection::NotSemver); // non-canonical spelling
++    }
++    if !v.build.is_empty() {
++        return Err(VersionRejection::HasBuildMetadata);
++    }
++    if denylist.contains(&requested) {
++        return Err(VersionRejection::KnownVulnerable);
++    }
++    Ok(())
++}
++
+ /// Validate a version string before it is used to build cache paths or download URLs. THE single
+ /// source of truth for both the HTTP ingress (`server::prove::resolve_version`) and the `download_bb`
+ /// sink. Rejects path-traversal + injection: non-empty, `<= 128` chars, ASCII alnum/`.`/`-`/`_`,
+@@ -198,23 +277,44 @@ pub fn is_valid_version(version: &str) -> bool {
+ /// Clean up old cached versions per the retention policy.
+ /// q7e3-F-08: takes the validated `&AztecVersion` (callers parse; an unparseable bundled skips
+ /// cleanup at the call site — same defensive outcome as the old internal parse-else-return).
+-pub async fn cleanup_old_versions(bundled: &AztecVersion) {
++pub async fn cleanup_old_versions(bundled: &AztecVersion, in_use: Option<&AztecVersion>) {
+     // Parse the cached dir names into validated versions. An unparseable dir name is skipped — same
+     // net outcome as before (the old code classified it Mainnet → retention `None` → never evicted).
+     let cached: Vec<AztecVersion> = list_cached_versions()
+         .iter()
+         .filter_map(|s| AztecVersion::parse(s))
+         .collect();
+-    let to_evict = versions_to_evict(&cached, bundled);
+-
+-    for version in &to_evict {
+-        let dir = versions_base_dir().join(version.as_str());
++    // codex #4: no resolvable home ⇒ no trusted cache root ⇒ nothing to evict (and never join onto a
++    // CWD fallback). `list_cached_versions` is already empty in this case, but guard the base dir too.
++    let Some(base) = versions_base_dir() else {
++        return;
++    };
++    for version in evictions(&cached, bundled, in_use) {
++        let dir = base.join(version.as_str());
+         match std::fs::remove_dir_all(&dir) {
+             Ok(()) => tracing::info!(version = %version, "Evicted old bb version"),
+             Err(e) => tracing::warn!(version = %version, error = %e, "Failed to evict bb version"),
+         }
+     }
+ }
++
++/// The versions to actually delete: the retention-policy evictions MINUS the in-use version.
++///
++/// F-007 race guard: `cleanup_old_versions` is spawned (detached) right after a download and races
++/// `bb::prove`. Without this, a freshly-downloaded old nightly (the oldest excess in its tier) could be
++/// deleted before it executes, turning the now-fail-closed `find_bb` into a spurious hard error. Keeping
++/// the in-use version one round over the limit is harmless — the next cleanup (when it is no longer in
++/// use) evicts it.
++fn evictions(
++    cached: &[AztecVersion],
++    bundled: &AztecVersion,
++    in_use: Option<&AztecVersion>,
++) -> Vec<AztecVersion> {
++    versions_to_evict(cached, bundled)
++        .into_iter()
++        .filter(|v| !in_use.is_some_and(|u| u.as_str() == v.as_str()))
++        .collect()
++}
+ #[cfg(test)]
+ mod tests {
+     use super::*;
+@@ -378,6 +478,36 @@ mod tests {
+         assert!(evicted.contains(&av("5.0.0-nightly.20260302")));
+     }
+ 
++    #[test]
++    fn evictions_exempt_the_in_use_version() {
++        // F-007: the version being proved right now must never be evicted by the cleanup that races it.
++        let cached = vec![
++            av("5.0.0-nightly.20260301"),
++            av("5.0.0-nightly.20260302"),
++            av("5.0.0-nightly.20260303"),
++            av("5.0.0-nightly.20260304"),
++        ];
++        let bundled = av("4.2.0-aztecnr-rc.2"); // not in this tier
++
++        // No protection: the two oldest are evicted (retention keeps 2).
++        let unprotected = evictions(&cached, &bundled, None);
++        assert!(unprotected.contains(&av("5.0.0-nightly.20260301")));
++        assert!(unprotected.contains(&av("5.0.0-nightly.20260302")));
++
++        // Protecting the OLDEST (the just-downloaded, in-use version): it is exempted, while the next
++        // non-protected version is still evicted.
++        let in_use = av("5.0.0-nightly.20260301");
++        let protected = evictions(&cached, &bundled, Some(&in_use));
++        assert!(
++            !protected.contains(&in_use),
++            "the in-use version must be exempted from eviction"
++        );
++        assert!(
++            protected.contains(&av("5.0.0-nightly.20260302")),
++            "a non-protected excess version is still evicted"
++        );
++    }
++
+     #[test]
+     fn bundled_version_never_evicted() {
+         let cached = vec![
+@@ -441,6 +571,77 @@ mod tests {
+         assert!(evicted.contains(&av("5.0.0-nightly.20260301")));
+     }
+ 
++    // ─── remote version selection: known-vulnerable revocation denylist ─────────
++
++    #[test]
++    fn version_policy_allows_everything_by_default() {
++        // The header is the Aztec version (not a bb version), and many Aztec releases share one bb, so
++        // there is NO floor: any well-formed version a dApp requests is allowed — including OLDER ones —
++        // so a legitimate older-but-compatible app is never broken. Default (empty) production denylist.
++        for v in [
++            "5.0.0",
++            "5.1.0",
++            "5.0.1", // older than a 5.1.0 bundle — MUST still be allowed (the bug this replaces)
++            "5.0.0-rc.1", // older rc
++            "5.0.0-nightly.20260307",
++            "4.2.0-aztecnr-rc.2",
++        ] {
++            assert_eq!(check_version_selectable(v), Ok(()), "{v} must be allowed");
++        }
++    }
++
++    #[test]
++    fn version_policy_refuses_a_denylisted_version() {
++        // Exercise the REAL implementation (check_version_against) with a simulated revocation list —
++        // the production const is empty, so this is how we cover the refusal path (codex review #3).
++        let deny = &["5.0.7", "5.1.3-rc.1"];
++        assert_eq!(
++            check_version_against("5.0.7", deny),
++            Err(VersionRejection::KnownVulnerable)
++        );
++        assert_eq!(
++            check_version_against("5.1.3-rc.1", deny),
++            Err(VersionRejection::KnownVulnerable)
++        );
++        // Neighbouring versions are unaffected — the denylist is exact, not a range.
++        assert_eq!(check_version_against("5.0.8", deny), Ok(()));
++        assert_eq!(check_version_against("5.0.6", deny), Ok(()));
++    }
++
++    #[test]
++    fn version_policy_rejects_aliases_and_build_metadata() {
++        // Well-formedness is still enforced (codex review #2): aliases the charset gate lets through, a
++        // non-canonical spelling, and build metadata are all rejected BEFORE any download / revocation
++        // match — regardless of the denylist.
++        for alias in ["latest", "5", "5.0", "5.0.0-alpha_beta"] {
++            assert_eq!(
++                check_version_selectable(alias),
++                Err(VersionRejection::NotSemver),
++                "alias {alias:?} must be rejected"
++            );
++        }
++        assert_eq!(
++            check_version_selectable("5.1.0+build9"),
++            Err(VersionRejection::HasBuildMetadata)
++        );
++    }
++
++    #[test]
++    fn version_policy_denylist_entries_are_wellformed_if_present() {
++        // If the owner ever populates the list, each entry must be a canonical strict semver so it
++        // matches the exact wire version the SDK sends. Does NOT assert emptiness (codex review #4: an
++        // emptiness assertion would break CI exactly when an emergency revocation is added).
++        for v in KNOWN_VULNERABLE_VERSIONS {
++            let parsed = semver::Version::parse(v)
++                .unwrap_or_else(|_| panic!("KNOWN_VULNERABLE_VERSIONS entry {v:?} must be semver"));
++            assert_eq!(
++                &parsed.to_string(),
++                v,
++                "KNOWN_VULNERABLE_VERSIONS entry {v:?} must be canonical"
++            );
++        }
++    }
++
+     /// CHARACTERIZATION (quality-refactor Phase 0 — Q3 guard). Edge cases the AztecVersion refactor
+     /// (Q3 changes `versions_to_evict`'s signature `&[String]` → `&[AztecVersion]`) must preserve.
+     #[test]
+diff --git a/packages/accelerator/core/tests/fixtures/updater/latest.json b/packages/accelerator/core/tests/fixtures/updater/latest.json
+new file mode 100644
+index 0000000..311de23
+--- /dev/null
++++ b/packages/accelerator/core/tests/fixtures/updater/latest.json
+@@ -0,0 +1,10 @@
++{
++  "version": "1.0.8",
++  "notes": "test fixture",
++  "pub_date": "2026-07-14T00:00:00Z",
++  "platforms": {
++    "linux-x86_64": { "url": "https://example.test/app.AppImage", "size": 12345, "signature": "ARTIFACT_SIG_PLACEHOLDER" }
++  },
++  "manifest": "eyJzY2hlbWEiOiJhenRlYy1hY2NlbGVyYXRvci11cGRhdGUtbWFuaWZlc3QtdjEiLCJ2ZXJzaW9uIjoiMS4wLjgiLCJwdWJfZGF0ZSI6IjIwMjYtMDctMTRUMDA6MDA6MDBaIiwicGxhdGZvcm1zIjp7ImxpbnV4LXg4Nl82NCI6eyJ1cmwiOiJodHRwczovL2V4YW1wbGUudGVzdC9hcHAuQXBwSW1hZ2UiLCJzaXplIjoxMjM0NSwic2lnbmF0dXJlIjoiQVJUSUZBQ1RfU0lHX1BMQUNFSE9MREVSIn19fQ==",
++  "manifest_sig": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVROEIyMW9udEtXRi9aUWxDNUcrWG5jcEdPSWF5U0hBUXB4ZnhkSUk2VGVDR3Y5VVNjVGJrL0MxN0dTUjZGZEg4UUtkbUdKRU9wbTFqektGWHRZQzFOUDJkYXBBQ0xjTkFBPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgzOTk0MzY1CWZpbGU6ZW52ZWxvcGUuanNvbgpFWEVjTXZWSVA0dlREclREQXdUbm54VFdoMTA2S2xxcHlYR3ZEaElva2h3OVNqREt6Q1h0Wk5FWFozaHQrWTlHUWVZVUQwUFhQV2Y5NDI5ZVVBNC9EUT09Cg=="
++}
+diff --git a/packages/accelerator/core/tests/fixtures/updater/pubkey.b64 b/packages/accelerator/core/tests/fixtures/updater/pubkey.b64
+new file mode 100644
+index 0000000..e853c09
+--- /dev/null
++++ b/packages/accelerator/core/tests/fixtures/updater/pubkey.b64
+@@ -0,0 +1 @@
++dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDE3OTZEMjlFNjg2RDA3M0MKUldROEIyMW9udEtXRnozWFdYWTJQOFdaZGg1UCtYek5xN0tGSkcyL3RGVDQyQm9vbzFmcG1ISlIK
+\ No newline at end of file

--- a/implementations-plan/security-hardening/full-audit-2026-07-24/chunks/C-acl-recovery-certs.diff
+++ b/implementations-plan/security-hardening/full-audit-2026-07-24/chunks/C-acl-recovery-certs.diff
@@ -1,0 +1,1137 @@
+diff --git a/packages/accelerator/core/src/win_acl.rs b/packages/accelerator/core/src/win_acl.rs
+new file mode 100644
+index 0000000..f9a4c4e
+--- /dev/null
++++ b/packages/accelerator/core/src/win_acl.rs
+@@ -0,0 +1,402 @@
++//! F-003 Windows tail: owner-only ACLs on the private prove workspace (+ witness), the leaf TLS key, and
++//! `config.json`. On Unix these paths are already `0o700`/`0o600` at creation; on Windows the mode bits are
++//! a no-op, so without this a file inherits its parent's (potentially group-readable) ACL.
++//!
++//! Design (folds the dual-audit + codex-final FFI conditions):
++//! - **Reparse-safe + existence-atomic**: objects are created with `CREATE_NEW` / `CreateDirectoryW`, which
++//!   FAIL if anything already exists at the path — so a pre-planted symlink/junction can't be adopted.
++//! - **PROTECTED DACL**: the ACL is applied to the OPEN HANDLE via `SetSecurityInfo` with
++//!   `PROTECTED_DACL_SECURITY_INFORMATION`, which strips inherited parent ACEs (handle-based does NOT follow
++//!   names, unlike `SetNamedSecurityInfoW`). The narrow window between create and apply carries only the
++//!   default per-user `%LOCALAPPDATA%` ACL (owner+SYSTEM+Admins, never world).
++//! - **Fail-closed readback**: after applying, the effective DACL is read back off the handle and asserted
++//!   owner-only; a FAT/exFAT/network volume that silently no-ops ACL calls therefore returns an error rather
++//!   than a falsely-"secured" path.
++//! - **Memory hygiene**: the token handle is `CloseHandle`d; the `SetEntriesInAclW` ACL and every
++//!   `GetSecurityInfo` security descriptor are `LocalFree`d exactly once on every path (RAII guards); the
++//!   SID is copied out of the token buffer (never aliased/freed separately).
++#![cfg(windows)]
++
++use std::io;
++use std::os::windows::ffi::OsStrExt;
++use std::os::windows::io::FromRawHandle;
++use std::path::Path;
++
++use windows_sys::Win32::Foundation::{
++    CloseHandle, GetLastError, LocalFree, ERROR_ALREADY_EXISTS, GENERIC_WRITE, HANDLE,
++    INVALID_HANDLE_VALUE,
++};
++use windows_sys::Win32::Security::Authorization::{
++    GetSecurityInfo, SetEntriesInAclW, SetSecurityInfo, EXPLICIT_ACCESS_W, SET_ACCESS,
++    SE_FILE_OBJECT, TRUSTEE_IS_SID, TRUSTEE_IS_USER, TRUSTEE_W,
++};
++use windows_sys::Win32::Security::{
++    CopySid, EqualSid, GetAce, GetLengthSid, GetTokenInformation, IsWellKnownSid, TokenUser,
++    WinBuiltinUsersSid, WinWorldSid, ACCESS_ALLOWED_ACE, ACE_HEADER, ACL,
++    DACL_SECURITY_INFORMATION, NO_INHERITANCE, OWNER_SECURITY_INFORMATION,
++    PROTECTED_DACL_SECURITY_INFORMATION, PSID, SUB_CONTAINERS_AND_OBJECTS_INHERIT, TOKEN_QUERY,
++    TOKEN_USER,
++};
++
++/// `ACCESS_ALLOWED_ACE_TYPE` (winnt.h `0x0`) — not re-exported by windows-sys under this path, so pinned
++/// to its documented value. Only this ACE type has the `SidStart` layout `verify_owner_only` reads.
++const ACCESS_ALLOWED_ACE_TYPE: u8 = 0;
++use windows_sys::Win32::Storage::FileSystem::{
++    CreateDirectoryW, CreateFileW, GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION,
++    CREATE_NEW, FILE_ALL_ACCESS, FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_BACKUP_SEMANTICS,
++    FILE_FLAG_OPEN_REPARSE_POINT, OPEN_EXISTING, WRITE_OWNER,
++};
++use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
++
++/// RAII: close a kernel handle exactly once.
++struct HandleGuard(HANDLE);
++impl Drop for HandleGuard {
++    fn drop(&mut self) {
++        if !self.0.is_null() && self.0 != INVALID_HANDLE_VALUE {
++            unsafe { CloseHandle(self.0) };
++        }
++    }
++}
++
++/// RAII: `LocalFree` a `LocalAlloc`-owned pointer (SetEntriesInAclW ACL, GetSecurityInfo descriptor).
++struct LocalFreeGuard(*mut core::ffi::c_void);
++impl Drop for LocalFreeGuard {
++    fn drop(&mut self) {
++        if !self.0.is_null() {
++            unsafe { LocalFree(self.0) };
++        }
++    }
++}
++
++fn last_err() -> io::Error {
++    io::Error::from_raw_os_error(unsafe { GetLastError() } as i32)
++}
++
++/// Reject a handle that refers to a reparse point (junction/symlink). Closes the create→open TOCTOU on
++/// `secure_create_dir` + `harden_existing`: a path swapped for a junction between create and open is opened
++/// as the link itself (FILE_FLAG_OPEN_REPARSE_POINT), so its handle carries FILE_ATTRIBUTE_REPARSE_POINT.
++unsafe fn reject_if_reparse(handle: HANDLE) -> io::Result<()> {
++    let mut info: BY_HANDLE_FILE_INFORMATION = std::mem::zeroed();
++    if GetFileInformationByHandle(handle, &mut info) == 0 {
++        return Err(last_err());
++    }
++    if info.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
++        return Err(io::Error::new(
++            io::ErrorKind::PermissionDenied,
++            "path is a reparse point (junction/symlink) — refusing to apply an owner-only ACL",
++        ));
++    }
++    Ok(())
++}
++
++/// Wide-encode a path with a trailing NUL for the `*W` Win32 APIs.
++fn wide(path: &Path) -> Vec<u16> {
++    path.as_os_str()
++        .encode_wide()
++        .chain(std::iter::once(0))
++        .collect()
++}
++
++/// The current process user's SID, copied into an owned buffer (so it outlives the token buffer it was
++/// read from — the SID inside `TOKEN_USER` is a pointer INTO that buffer).
++fn current_user_sid() -> io::Result<Vec<u8>> {
++    unsafe {
++        let mut token: HANDLE = std::ptr::null_mut();
++        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) == 0 {
++            return Err(last_err());
++        }
++        let _tguard = HandleGuard(token);
++
++        // Two-call sizing.
++        let mut len: u32 = 0;
++        GetTokenInformation(token, TokenUser, std::ptr::null_mut(), 0, &mut len);
++        if len == 0 {
++            return Err(last_err());
++        }
++        let mut buf = vec![0u8; len as usize];
++        if GetTokenInformation(token, TokenUser, buf.as_mut_ptr() as *mut _, len, &mut len) == 0 {
++            return Err(last_err());
++        }
++        // `buf` is a `Vec<u8>` (align 1) but `TOKEN_USER` contains a pointer (align 8) — taking a
++        // `&TOKEN_USER` reference to a possibly-misaligned address is UB. Read the `User.Sid` pointer field
++        // via `addr_of!` + `read_unaligned` (no reference is ever formed). (codex post-impl #1)
++        let tu = buf.as_ptr() as *const TOKEN_USER;
++        let sid_ptr: PSID = std::ptr::addr_of!((*tu).User.Sid).read_unaligned();
++        let sid_len = GetLengthSid(sid_ptr);
++        let mut sid = vec![0u8; sid_len as usize];
++        if CopySid(sid_len, sid.as_mut_ptr() as PSID, sid_ptr) == 0 {
++            return Err(last_err());
++        }
++        Ok(sid)
++    }
++}
++
++/// Apply an owner-only PROTECTED DACL (current user, full control) to an open handle, then read it back and
++/// assert it took effect. `inheritable` adds container/object inheritance (for directories, so children are
++/// private at creation).
++unsafe fn apply_and_verify_owner_only(handle: HANDLE, inheritable: bool) -> io::Result<()> {
++    // Close the create/open TOCTOU (codex post-impl #3): if the path was swapped for a junction between
++    // creation and this open, the handle (opened FILE_FLAG_OPEN_REPARSE_POINT) is a reparse point — refuse
++    // rather than secure the link while real accesses follow it to a non-owner-only target.
++    reject_if_reparse(handle)?;
++    let mut sid = current_user_sid()?;
++
++    // One EXPLICIT_ACCESS: grant full control to the current user, inheritance per `inheritable`.
++    let mut ea: EXPLICIT_ACCESS_W = std::mem::zeroed();
++    ea.grfAccessPermissions = FILE_ALL_ACCESS;
++    ea.grfAccessMode = SET_ACCESS;
++    ea.grfInheritance = if inheritable {
++        SUB_CONTAINERS_AND_OBJECTS_INHERIT
++    } else {
++        NO_INHERITANCE
++    };
++    ea.Trustee = std::mem::zeroed::<TRUSTEE_W>();
++    ea.Trustee.TrusteeForm = TRUSTEE_IS_SID;
++    ea.Trustee.TrusteeType = TRUSTEE_IS_USER;
++    ea.Trustee.ptstrName = sid.as_mut_ptr() as *mut u16;
++
++    let mut acl: *mut ACL = std::ptr::null_mut();
++    let rc = SetEntriesInAclW(1, &ea, std::ptr::null_mut(), &mut acl);
++    if rc != 0 {
++        return Err(io::Error::from_raw_os_error(rc as i32));
++    }
++    let _acl_guard = LocalFreeGuard(acl as *mut _);
++
++    // PROTECTED_DACL strips inherited ACEs; handle-based SetSecurityInfo does not follow the name.
++    // codex #6 / F-003: ALSO set the OWNER to the current user. The Windows owner ALWAYS holds implicit
++    // READ_CONTROL + WRITE_DAC, so a foreign owner (e.g. Administrators as the default owner for an
++    // elevated creator) could rewrite our owner-only DACL regardless of the ACEs — set + verify the owner
++    // to close that bypass. Setting the owner to our own token SID needs WRITE_OWNER (requested at open).
++    let rc = SetSecurityInfo(
++        handle,
++        SE_FILE_OBJECT,
++        OWNER_SECURITY_INFORMATION
++            | DACL_SECURITY_INFORMATION
++            | PROTECTED_DACL_SECURITY_INFORMATION,
++        sid.as_mut_ptr() as PSID,
++        std::ptr::null_mut(),
++        acl,
++        std::ptr::null_mut(),
++    );
++    if rc != 0 {
++        return Err(io::Error::from_raw_os_error(rc as i32));
++    }
++
++    // Fail-closed readback: catches FAT/exFAT / network volumes that silently ignore ACLs, AND a foreign
++    // owner that would retain WRITE_DAC over our DACL.
++    verify_owner_only(handle, &sid)?;
++    verify_owner_sid(handle, &sid)
++}
++
++/// Read the OWNER back off the handle and assert it is the current user. The Windows owner ALWAYS has
++/// implicit `READ_CONTROL` + `WRITE_DAC`, so a non-owner-only DACL is meaningless if a foreign principal
++/// owns the object — it can simply rewrite the DACL. Fail-closed if the owner is absent or foreign
++/// (codex audit #6).
++unsafe fn verify_owner_sid(handle: HANDLE, sid: &[u8]) -> io::Result<()> {
++    let mut owner: PSID = std::ptr::null_mut();
++    let mut sd: *mut core::ffi::c_void = std::ptr::null_mut();
++    let rc = GetSecurityInfo(
++        handle,
++        SE_FILE_OBJECT,
++        OWNER_SECURITY_INFORMATION,
++        &mut owner,
++        std::ptr::null_mut(),
++        std::ptr::null_mut(),
++        std::ptr::null_mut(),
++        &mut sd,
++    );
++    if rc != 0 {
++        return Err(io::Error::from_raw_os_error(rc as i32));
++    }
++    let _sd_guard = LocalFreeGuard(sd);
++    if owner.is_null() {
++        return Err(io::Error::new(
++            io::ErrorKind::PermissionDenied,
++            "object has no owner after applying owner-only ACL",
++        ));
++    }
++    if EqualSid(owner, sid.as_ptr() as PSID) == 0 {
++        return Err(io::Error::new(
++            io::ErrorKind::PermissionDenied,
++            "object owner is not the current user (foreign owner retains WRITE_DAC)",
++        ));
++    }
++    Ok(())
++}
++
++/// Read the effective DACL back off the handle and assert it grants EXACTLY the given SID — no
++/// `BUILTIN\Users`, no `Everyone`. Errors (fail-closed) if the DACL is absent or any ACE is foreign.
++unsafe fn verify_owner_only(handle: HANDLE, sid: &[u8]) -> io::Result<()> {
++    let mut dacl: *mut ACL = std::ptr::null_mut();
++    let mut sd: *mut core::ffi::c_void = std::ptr::null_mut();
++    let rc = GetSecurityInfo(
++        handle,
++        SE_FILE_OBJECT,
++        DACL_SECURITY_INFORMATION,
++        std::ptr::null_mut(),
++        std::ptr::null_mut(),
++        &mut dacl,
++        std::ptr::null_mut(),
++        &mut sd,
++    );
++    if rc != 0 {
++        return Err(io::Error::from_raw_os_error(rc as i32));
++    }
++    let _sd_guard = LocalFreeGuard(sd);
++    if dacl.is_null() {
++        // A null DACL means "everyone full access" — the FAT/exFAT no-op case. Fail closed.
++        return Err(io::Error::new(
++            io::ErrorKind::PermissionDenied,
++            "owner-only ACL not applied (null DACL — unsupported filesystem?)",
++        ));
++    }
++    let ace_count = (*dacl).AceCount as u32;
++    if ace_count == 0 {
++        return Err(io::Error::new(
++            io::ErrorKind::PermissionDenied,
++            "owner-only ACL not applied (empty DACL)",
++        ));
++    }
++    let want: PSID = sid.as_ptr() as PSID;
++    for i in 0..ace_count {
++        let mut ace: *mut core::ffi::c_void = std::ptr::null_mut();
++        if GetAce(dacl, i, &mut ace) == 0 {
++            return Err(last_err());
++        }
++        // Verify the ACE TYPE before casting: only ACCESS_ALLOWED_ACE has the SidStart layout we read.
++        // Anything else (a DENY/AUDIT/OBJECT ACE we never set) means the DACL isn't the owner-only ACL we
++        // applied → fail closed rather than misparse a foreign ACE's bytes as a SID.
++        let header = &*(ace as *const ACE_HEADER);
++        if header.AceType != ACCESS_ALLOWED_ACE_TYPE {
++            return Err(io::Error::new(
++                io::ErrorKind::PermissionDenied,
++                "unexpected ACE type after applying owner-only ACL",
++            ));
++        }
++        let allowed = &*(ace as *const ACCESS_ALLOWED_ACE);
++        let ace_sid = &allowed.SidStart as *const u32 as PSID;
++        if EqualSid(ace_sid, want) == 0 {
++            // Reject a foreign ACE — especially well-known world/users SIDs.
++            if IsWellKnownSid(ace_sid, WinWorldSid) != 0
++                || IsWellKnownSid(ace_sid, WinBuiltinUsersSid) != 0
++            {
++                return Err(io::Error::new(
++                    io::ErrorKind::PermissionDenied,
++                    "world/users ACE present after applying owner-only ACL",
++                ));
++            }
++            return Err(io::Error::new(
++                io::ErrorKind::PermissionDenied,
++                "foreign ACE present after applying owner-only ACL",
++            ));
++        }
++        // Our ACE must grant FULL control — verify the access mask, not just the SID. (codex post-impl #2)
++        if allowed.Mask & FILE_ALL_ACCESS != FILE_ALL_ACCESS {
++            return Err(io::Error::new(
++                io::ErrorKind::PermissionDenied,
++                "owner ACE does not grant full control after applying owner-only ACL",
++            ));
++        }
++    }
++    Ok(())
++}
++
++/// Create a directory with an owner-only PROTECTED, INHERITABLE DACL. Fails if the path already exists
++/// (reparse/symlink pre-plant defense).
++pub fn secure_create_dir(path: &Path) -> io::Result<()> {
++    let w = wide(path);
++    unsafe {
++        if CreateDirectoryW(w.as_ptr(), std::ptr::null_mut()) == 0 {
++            let e = GetLastError();
++            // ERROR_ALREADY_EXISTS ⇒ something is already at the path; fail closed.
++            return Err(io::Error::from_raw_os_error(e as i32));
++        }
++        // Open a handle to the just-created directory to apply the DACL + owner (WRITE_OWNER, codex #6).
++        let handle = CreateFileW(
++            w.as_ptr(),
++            windows_sys::Win32::Storage::FileSystem::WRITE_DAC
++                | windows_sys::Win32::Storage::FileSystem::READ_CONTROL
++                | WRITE_OWNER,
++            0,
++            std::ptr::null_mut(),
++            OPEN_EXISTING,
++            FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
++            std::ptr::null_mut(),
++        );
++        if handle == INVALID_HANDLE_VALUE {
++            return Err(last_err());
++        }
++        let _hg = HandleGuard(handle);
++        apply_and_verify_owner_only(handle, true)
++    }
++}
++
++/// Create a NEW file with an owner-only PROTECTED DACL and return it (ready to write). `CREATE_NEW` fails
++/// if the path exists, so a pre-planted file/symlink is rejected; the ACL is applied to the empty file
++/// BEFORE any content is written.
++pub fn secure_create_file(path: &Path) -> io::Result<std::fs::File> {
++    let w = wide(path);
++    unsafe {
++        let handle = CreateFileW(
++            w.as_ptr(),
++            GENERIC_WRITE
++                | windows_sys::Win32::Storage::FileSystem::WRITE_DAC
++                | windows_sys::Win32::Storage::FileSystem::READ_CONTROL
++                | WRITE_OWNER,
++            0, // no sharing
++            std::ptr::null_mut(),
++            CREATE_NEW,
++            FILE_FLAG_OPEN_REPARSE_POINT,
++            std::ptr::null_mut(),
++        );
++        if handle == INVALID_HANDLE_VALUE {
++            let e = GetLastError();
++            let _ = ERROR_ALREADY_EXISTS; // documented reason: CREATE_NEW fails if it exists
++            return Err(io::Error::from_raw_os_error(e as i32));
++        }
++        // Do NOT put this handle in a guard: on success we hand it to std::fs::File which owns/closes it.
++        if let Err(e) = apply_and_verify_owner_only(handle, false) {
++            CloseHandle(handle);
++            return Err(e);
++        }
++        Ok(std::fs::File::from_raw_handle(handle as *mut _))
++    }
++}
++
++/// Harden an EXISTING file we did not create atomically (e.g. `config.json`'s temp file written by std,
++/// before its rename). Opens with reparse-open (does not traverse a reparse), applies the owner-only DACL.
++pub fn harden_existing_file(path: &Path) -> io::Result<()> {
++    harden_existing(path, false)
++}
++
++/// Harden an EXISTING directory (e.g. the persistent `prove-tmp` parent, or a `tempfile`-created child that
++/// already inherits owner-only from its hardened parent). Inheritable so children stay private.
++pub fn harden_existing_dir(path: &Path) -> io::Result<()> {
++    harden_existing(path, true)
++}
++
++fn harden_existing(path: &Path, is_dir: bool) -> io::Result<()> {
++    let w = wide(path);
++    let mut flags = FILE_FLAG_OPEN_REPARSE_POINT;
++    if is_dir {
++        flags |= FILE_FLAG_BACKUP_SEMANTICS; // required to obtain a directory handle
++    }
++    unsafe {
++        let handle = CreateFileW(
++            w.as_ptr(),
++            windows_sys::Win32::Storage::FileSystem::WRITE_DAC
++                | windows_sys::Win32::Storage::FileSystem::READ_CONTROL
++                | WRITE_OWNER,
++            0,
++            std::ptr::null_mut(),
++            OPEN_EXISTING,
++            flags,
++            std::ptr::null_mut(),
++        );
++        if handle == INVALID_HANDLE_VALUE {
++            return Err(last_err());
++        }
++        let _hg = HandleGuard(handle);
++        apply_and_verify_owner_only(handle, is_dir)
++    }
++}
+diff --git a/packages/accelerator/src-tauri/src/certs.rs b/packages/accelerator/src-tauri/src/certs.rs
+index 9df1990..fc42f92 100644
+--- a/packages/accelerator/src-tauri/src/certs.rs
++++ b/packages/accelerator/src-tauri/src/certs.rs
+@@ -8,6 +8,7 @@ use std::path::PathBuf;
+ use std::sync::Arc;
+ use time::OffsetDateTime;
+ use tokio_rustls::rustls;
++use zeroize::Zeroizing;
+ 
+ /// Returns `~/.aztec-accelerator/certs/`.
+ pub fn certs_dir() -> PathBuf {
+@@ -135,20 +136,28 @@ pub fn certs_exist() -> bool {
+ }
+ 
+ /// Generate a CA + leaf and write the CA cert + leaf cert + leaf key to the three given paths.
+-/// The CA private key is generated in memory, signs the leaf, and is dropped at function end —
+-/// **never written to disk.** Writing to caller-chosen paths lets rotation stage a new set
++/// The CA private key is generated in memory (`Zeroizing`), signs the leaf, and is dropped+scrubbed
++/// EARLY — right after signing, before the file writes (F-016) — and is **never written to disk.**
++/// Writing to caller-chosen paths lets rotation stage a new set
+ /// (`*.new`) and atomically swap it in only after the new anchor is trusted.
+ fn write_new_cert_set(paths: &CertPaths) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+     let now = OffsetDateTime::now_utc();
+-    let ca_key = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256)?;
++    // F-016: wrap the CA signing key in `Zeroizing` so rcgen scrubs its serialized-DER copy on drop (a
++    // plain drop scrubs nothing), and drop it as EARLY as possible — right after it signs the leaf, before
++    // the fallible file writes.
++    let ca_key = Zeroizing::new(KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256)?);
+     let ca_cert = ca_params(now).self_signed(&ca_key)?;
+     let leaf_key = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256)?;
+     let leaf_cert = leaf_params(now)?.signed_by(&leaf_key, &ca_cert, &ca_key)?;
++    // Scrub rcgen's serialized-DER CA key now. RESIDUAL (F-016): `Zeroizing` wipes ONLY that `Vec` — the
++    // ring backend's ECDSA scalar/nonce, key-generation temporaries, swap pages, and any core dump are NOT
++    // scrubbed, so this is best-effort post-use reduction, not a guarantee the CA key is unrecoverable. The
++    // CA key is never written to disk; the leaf key is persisted at 0600 by design.
++    drop(ca_key);
+ 
+     write_pem_file(&paths.ca_cert, &ca_cert.pem())?;
+     write_pem_file(&paths.leaf_cert, &leaf_cert.pem())?;
+     write_pem_file(&paths.leaf_key, &leaf_key.serialize_pem())?;
+-    // `ca_key` drops here — the only copy of the CA signing key is gone.
+     Ok(())
+ }
+ 
+@@ -239,7 +248,15 @@ fn write_pem_file(
+                 .mode(0o600)
+                 .open(&tmp)?
+         };
+-        #[cfg(not(unix))]
++        // F-003 Windows tail: the leaf TLS key (localhost.key) is a real private key — write the temp with
++        // an owner-only DACL (the SD travels with the same-volume rename). Clear any stale temp for
++        // CREATE_NEW. Applies to the cert siblings too (harmless — they're per-user files).
++        #[cfg(windows)]
++        let mut file = {
++            let _ = std::fs::remove_file(&tmp);
++            accelerator_core::win_acl::secure_create_file(&tmp)?
++        };
++        #[cfg(all(not(unix), not(windows)))]
+         let mut file = std::fs::File::create(&tmp)?;
+         file.write_all(contents.as_bytes())?;
+         file.sync_all()?;
+diff --git a/packages/accelerator/src-tauri/src/crash_recovery.rs b/packages/accelerator/src-tauri/src/crash_recovery.rs
+index d8a5f53..5e1e237 100644
+--- a/packages/accelerator/src-tauri/src/crash_recovery.rs
++++ b/packages/accelerator/src-tauri/src/crash_recovery.rs
+@@ -14,13 +14,19 @@
+ /// result on Windows (where the updater MUST know the always-armed task is gone before NSIS mutates
+ /// files).
+ pub trait CrashRecovery {
+-    fn enable(&self);
++    /// Arm crash recovery. C8: returns `Err` if the ARMING genuinely failed (so a caller mid-transaction
++    /// can roll back) and `Ok` for an idempotent already-armed state — see each `enable_impl`'s per-exit
++    /// classification in `implementations-plan/security-hardening/closeout-followups/lessons/phase-1.md`.
++    fn enable(&self) -> Result<(), String>;
+     fn disable(&self) -> bool;
+ }
+ 
+ /// Enable crash recovery for the current platform (thin dispatch to the platform `CrashRecovery`).
+-pub fn enable_crash_recovery() {
+-    PlatformRecovery.enable();
++/// C8: `Err` on a real arming failure — callers that arm as part of a transaction (`set_autostart`)
++/// roll back on it; the log-and-continue callers (`main.rs` startup rearm, `updater.rs` post-update
++/// rearm) must NOT abort on it.
++pub fn enable_crash_recovery() -> Result<(), String> {
++    PlatformRecovery.enable()
+ }
+ 
+ /// Disable crash recovery. See [`CrashRecovery::disable`] for the `bool` contract — callers that must
+@@ -35,14 +41,88 @@ pub fn disable_crash_recovery() -> bool {
+ pub struct PlatformRecovery;
+ 
+ impl CrashRecovery for PlatformRecovery {
+-    fn enable(&self) {
+-        enable_impl();
++    fn enable(&self) -> Result<(), String> {
++        enable_impl()
+     }
+     fn disable(&self) -> bool {
+         disable_impl()
+     }
+ }
+ 
++/// C8 (D13/D20): run the autostart-enable transaction with rollback, generic over injected closures so
++/// the ordering + completeness + failure modes are unit-testable on Linux CI without a real `AppHandle`.
++///
++/// Forward: `plugin_enable` (the tauri-plugin-autostart launcher entry) then `crash_arm`
++/// (`enable_crash_recovery`). On ANY forward failure, roll back **failure-observably**:
++/// - run BOTH `crash_disarm` and (only if we changed it — i.e. `!prior_enabled`) `plugin_disable`,
++///   executing both even if one fails (no short-circuit),
++/// - do NOT unconditionally disable: if `prior_enabled` the launcher was already on before this call, so
++///   leave it (restore prior state) rather than clobbering it,
++/// - return a combined `Err` naming the failing step and every rollback sub-result.
++pub fn enable_transaction<E, A, D, R>(
++    prior_enabled: bool,
++    plugin_enable: E,
++    crash_arm: A,
++    plugin_disable: D,
++    crash_disarm: R,
++) -> Result<(), String>
++where
++    E: FnOnce() -> Result<(), String>,
++    A: FnOnce() -> Result<(), String>,
++    D: FnOnce() -> Result<(), String>,
++    R: FnOnce() -> bool,
++{
++    // Step 1 — plugin launcher entry, ONLY when not already enabled. codex r2 #3: re-running the plugin
++    // enable when it is ALREADY on is not merely redundant — on macOS the pinned autostart plugin
++    // RECREATES the LaunchAgent plist, stripping the existing `KeepAlive` (crash-recovery) keys. A
++    // re-enable that then failed at `crash_arm` would therefore destroy the user's recovery even though
++    // we "kept" the plugin. Skipping it when already on leaves the prior plist (and its KeepAlive) intact,
++    // and `crash_arm` below is idempotent for an already-armed recovery. If this fails on a FRESH enable
++    // the plugin state is unchanged; disarm any partial recovery and surface the failure.
++    if !prior_enabled {
++        if let Err(e) = plugin_enable() {
++            let disarmed = crash_disarm();
++            return Err(format!(
++                "autostart enable failed at plugin step: {e}; rollback: crash_disarm={}",
++                disarm_word(disarmed, false)
++            ));
++        }
++    }
++    // Step 2 — arm crash recovery. On failure, roll back to the PRIOR state:
++    // - plugin: disable it only if we turned it on (`!prior_enabled`); if it was already on, keep it.
++    // - crash recovery: codex #7 — do NOT disarm when `prior_enabled`. If autostart was already on before
++    //   this call, crash recovery was armed as part of that prior state, and a failed *idempotent re-arm*
++    //   must RESTORE the prior recovery, not destroy the user's existing recovery path. Only disarm the
++    //   partial recovery we were creating on a fresh enable.
++    // Both sub-rollbacks run regardless of either's outcome (no short-circuit).
++    if let Err(e) = crash_arm() {
++        let disarmed = if prior_enabled { true } else { crash_disarm() };
++        let plugin_rolled = if prior_enabled {
++            "kept (was already enabled — never re-run; plist + KeepAlive intact)".to_string()
++        } else {
++            match plugin_disable() {
++                Ok(()) => "disabled".to_string(),
++                Err(de) => format!("FAILED ({de}) — autostart may still be active"),
++            }
++        };
++        return Err(format!(
++            "autostart enable failed at crash-recovery step: {e}; rollback: crash_disarm={}, plugin={plugin_rolled}",
++            disarm_word(disarmed, prior_enabled)
++        ));
++    }
++    Ok(())
++}
++
++fn disarm_word(disarmed: bool, skipped_because_prior: bool) -> &'static str {
++    if skipped_because_prior {
++        "skipped (prior enabled)"
++    } else if disarmed {
++        "confirmed"
++    } else {
++        "NOT confirmed"
++    }
++}
++
+ /// Must match `productName` in tauri.conf.json — the auto-launch crate uses this
+ /// (not the identifier) as the LaunchAgent plist filename.
+ #[cfg(target_os = "macos")]
+@@ -59,34 +139,27 @@ const SYSTEMD_NAME: &str = "aztec-accelerator";
+ /// Previous implementation used `.replace("</dict>", ...)` which replaced ALL occurrences
+ /// and could corrupt plists with nested dicts.
+ #[cfg(target_os = "macos")]
+-fn enable_impl() {
++fn enable_impl() -> Result<(), String> {
+     let plist_path = macos_plist_path();
+-    match std::fs::read_to_string(&plist_path) {
+-        Ok(content) => {
+-            if content.contains("<key>KeepAlive</key>") {
+-                tracing::debug!("LaunchAgent already has KeepAlive");
+-                return;
+-            }
+-            match patch_plist_with_keepalive(&content) {
+-                Some(patched) => {
+-                    if let Err(e) = std::fs::write(&plist_path, &patched) {
+-                        tracing::warn!("Failed to write patched LaunchAgent plist: {e}");
+-                    } else {
+-                        tracing::info!("LaunchAgent patched with KeepAlive (crash recovery)");
+-                    }
+-                }
+-                None => {
+-                    tracing::warn!("Could not find closing </dict> in LaunchAgent plist");
+-                }
+-            }
+-        }
+-        Err(e) => {
+-            tracing::warn!(
+-                path = %plist_path.display(),
+-                "Cannot read LaunchAgent plist (not yet enabled?): {e}"
+-            );
+-        }
++    // read failure ⇒ the plugin's plist isn't where we expect ⇒ arming did NOT happen ⇒ Err.
++    let content = std::fs::read_to_string(&plist_path).map_err(|e| {
++        format!(
++            "cannot read LaunchAgent plist {}: {e}",
++            plist_path.display()
++        )
++    })?;
++    if content.contains("<key>KeepAlive</key>") {
++        tracing::debug!("LaunchAgent already has KeepAlive");
++        return Ok(()); // idempotent already-armed ⇒ success, NOT a failure (must not trigger rollback).
+     }
++    // no closing </dict> ⇒ patch impossible ⇒ arming failed ⇒ Err.
++    let patched = patch_plist_with_keepalive(&content)
++        .ok_or_else(|| "could not find closing </dict> in LaunchAgent plist".to_string())?;
++    // write failure ⇒ arming failed ⇒ Err.
++    std::fs::write(&plist_path, &patched)
++        .map_err(|e| format!("failed to write patched LaunchAgent plist: {e}"))?;
++    tracing::info!("LaunchAgent patched with KeepAlive (crash recovery)");
++    Ok(())
+ }
+ 
+ /// Insert KeepAlive and ThrottleInterval keys before the last `</dict>` in a plist string.
+@@ -127,31 +200,72 @@ fn macos_plist_path() -> std::path::PathBuf {
+         .join(format!("{APP_NAME}.plist"))
+ }
+ 
++/// F-010: conservative cross-platform preflight for enabling autostart. Rejects a path whose bytes could
++/// INJECT into any OS launcher serializer (systemd unit / `.desktop` / plist XML / Windows Run-key): a
++/// non-absolute path, non-UTF-8 (systemd rejects it; the plugin serializes it lossily), or any control /
++/// newline / DEL byte (the injection vector for line/element-based unit + plist formats). Platform-specific
++/// NON-injection formatting quirks in the third-party `auto-launch` crate (e.g. space-splitting in a raw
++/// `.desktop` `Exec=` / Run-key) are a documented ROBUSTNESS residual, not a same-process injection we can
++/// close without patching that crate. `set_autostart` calls this BEFORE invoking the plugin, refusing (and
++/// disabling) rather than letting an unsafe path be serialized.
++pub fn autostart_path_is_safe(exe: &std::path::Path) -> bool {
++    match exe.to_str() {
++        None => false, // non-UTF-8
++        Some(s) => exe.is_absolute() && !s.bytes().any(|b| b < 0x20 || b == 0x7f),
++    }
++}
++
++/// F-010: serialize an absolute executable path into a safe systemd `ExecStart` value, or `None` if the
++/// path is not representable. systemd's `string_is_safe` REJECTS a decoded executable containing controls,
++/// `\`, `"`, `'`, or a glob introducer (`*`/`?`/`[`), and requires valid UTF-8 — those are not escapable, so
++/// we fail closed. The returned value uses the `:` prefix (disables systemd `$`-environment expansion) INSIDE
++/// the quoted first token, and doubles `%` (systemd specifier). No `\`/`"` escaping is needed because they
++/// are rejected. Result form: `":/path/with %% doubled"`.
++#[cfg(target_os = "linux")]
++fn systemd_exec_start(exe: &std::path::Path) -> Option<String> {
++    let s = exe.to_str()?; // None ⇒ non-UTF-8
++    if !exe.is_absolute() || s.ends_with('/') {
++        return None; // must be an absolute file path, not a directory shape
++    }
++    if s.bytes().any(|b| b < 0x20 || b == 0x7f) {
++        return None; // controls / newline / DEL
++    }
++    if s.chars()
++        .any(|c| matches!(c, '\\' | '"' | '\'' | '*' | '?' | '['))
++    {
++        return None; // systemd `string_is_safe` forbids these in the executable path
++    }
++    Some(format!("\":{}\"", s.replace('%', "%%")))
++}
++
+ /// Create and enable a systemd user service with `Restart=on-failure`.
+ /// Call this after `manager.enable()`.
+ #[cfg(target_os = "linux")]
+-fn enable_impl() {
+-    let exe = match std::env::current_exe() {
+-        Ok(p) => p,
+-        Err(e) => {
+-            tracing::warn!("Cannot determine executable path for systemd service: {e}");
+-            return;
+-        }
+-    };
+-
+-    let service_dir = match dirs::config_dir() {
+-        Some(d) => d.join("systemd/user"),
++fn enable_impl() -> Result<(), String> {
++    let exe = std::env::current_exe()
++        .map_err(|e| format!("cannot determine executable path for systemd service: {e}"))?;
++
++    let service_dir = dirs::config_dir()
++        .ok_or_else(|| "cannot determine config dir for systemd service".to_string())?
++        .join("systemd/user");
++
++    std::fs::create_dir_all(&service_dir)
++        .map_err(|e| format!("cannot create systemd user dir: {e}"))?;
++
++    // F-010: build a systemd-escaped ExecStart. An unsafe path (systemd would reject or it could inject
++    // a directive) fails CLOSED — remove any stale unit and report the failure (Err), never write a
++    // corrupt/injected unit.
++    let exec_start = match systemd_exec_start(&exe) {
++        Some(v) => v,
+         None => {
+-            tracing::warn!("Cannot determine config dir for systemd service");
+-            return;
++            disable_impl();
++            return Err(
++                "executable path is not representable as a safe systemd ExecStart; removed any stale unit"
++                    .to_string(),
++            );
+         }
+     };
+ 
+-    if let Err(e) = std::fs::create_dir_all(&service_dir) {
+-        tracing::warn!("Cannot create systemd user dir: {e}");
+-        return;
+-    }
+-
+     let service_path = service_dir.join(format!("{SYSTEMD_NAME}.service"));
+     let service_content = format!(
+         "[Unit]\n\
+@@ -160,20 +274,17 @@ fn enable_impl() {
+          \n\
+          [Service]\n\
+          Type=simple\n\
+-         ExecStart=\"{exe}\"\n\
++         ExecStart={exec_start}\n\
+          Restart=on-failure\n\
+          RestartSec=5\n\
+          StartLimitBurst=5\n\
+          \n\
+          [Install]\n\
+          WantedBy=default.target\n",
+-        exe = exe.display()
+     );
+ 
+-    if let Err(e) = std::fs::write(&service_path, &service_content) {
+-        tracing::warn!("Failed to write systemd service: {e}");
+-        return;
+-    }
++    std::fs::write(&service_path, &service_content)
++        .map_err(|e| format!("failed to write systemd service: {e}"))?;
+ 
+     // Reload and enable
+     let _ = std::process::Command::new("systemctl")
+@@ -186,14 +297,14 @@ fn enable_impl() {
+     match result {
+         Ok(output) if output.status.success() => {
+             tracing::info!("systemd user service enabled (crash recovery)");
++            Ok(())
+         }
+-        Ok(output) => {
+-            let stderr = String::from_utf8_lossy(&output.stderr);
+-            tracing::warn!("systemctl enable failed: {stderr}");
+-        }
+-        Err(e) => {
+-            tracing::warn!("Failed to run systemctl: {e}");
+-        }
++        // `systemctl enable` is the actual arming step — a failure here is Err (D16/cond.3).
++        Ok(output) => Err(format!(
++            "systemctl enable failed: {}",
++            String::from_utf8_lossy(&output.stderr)
++        )),
++        Err(e) => Err(format!("failed to run systemctl: {e}")),
+     }
+ }
+ 
+@@ -204,17 +315,30 @@ fn disable_impl() -> bool {
+     let _ = std::process::Command::new("systemctl")
+         .args(["--user", "disable", SYSTEMD_NAME])
+         .output();
+-    let _ = std::process::Command::new("systemctl")
+-        .args(["--user", "daemon-reload"])
+-        .output();
+ 
++    // F-010: remove the unit file BEFORE the final daemon-reload (so the reload reflects the removal), and
++    // report whether disarm is CONFIRMED — a missing file is success; a file that cannot be removed is not.
++    let mut removed = true;
+     if let Some(config_dir) = dirs::config_dir() {
+         let service_path = config_dir.join(format!("systemd/user/{SYSTEMD_NAME}.service"));
+-        let _ = std::fs::remove_file(&service_path);
++        if let Err(e) = std::fs::remove_file(&service_path) {
++            if service_path.exists() {
++                tracing::warn!(
++                    "Failed to remove systemd unit (crash recovery not confirmed disarmed): {e}"
++                );
++                removed = false;
++            }
++        }
+     }
+ 
+-    tracing::info!("systemd user service disabled (crash recovery)");
+-    true
++    let _ = std::process::Command::new("systemctl")
++        .args(["--user", "daemon-reload"])
++        .output();
++
++    if removed {
++        tracing::info!("systemd user service disabled (crash recovery)");
++    }
++    removed
+ }
+ 
+ // ── Windows ──────────────────────────────────────────────────────────────────
+@@ -254,16 +378,11 @@ fn schtasks_exe() -> std::path::PathBuf {
+ 
+ /// Register the Task Scheduler crash-recovery task. Call after `manager.enable()`.
+ #[cfg(target_os = "windows")]
+-fn enable_impl() {
++fn enable_impl() -> Result<(), String> {
+     use std::io::Write;
+ 
+-    let exe = match std::env::current_exe() {
+-        Ok(p) => p,
+-        Err(e) => {
+-            tracing::warn!("Cannot determine executable path for Task Scheduler: {e}");
+-            return;
+-        }
+-    };
++    let exe = std::env::current_exe()
++        .map_err(|e| format!("cannot determine executable path for Task Scheduler: {e}"))?;
+ 
+     // schtasks /XML expects UTF-16LE with a BOM.
+     let mut bytes = vec![0xFFu8, 0xFE];
+@@ -274,25 +393,15 @@ fn enable_impl() {
+     // Random temp filename (not a predictable %TEMP% path a local user could pre-create or
+     // symlink), written + closed before schtasks reads it, auto-deleted when it drops.
+     let xml_path = {
+-        let mut tmp = match tempfile::Builder::new()
++        let mut tmp = tempfile::Builder::new()
+             .prefix("aztec-accel-recovery-")
+             .suffix(".xml")
+             .tempfile()
+-        {
+-            Ok(f) => f,
+-            Err(e) => {
+-                tracing::warn!("Failed to create Task Scheduler XML temp file: {e}");
+-                return;
+-            }
+-        };
+-        if let Err(e) = tmp.write_all(&bytes) {
+-            tracing::warn!("Failed to write Task Scheduler XML: {e}");
+-            return;
+-        }
+-        if let Err(e) = tmp.flush() {
+-            tracing::warn!("Failed to flush Task Scheduler XML: {e}");
+-            return;
+-        }
++            .map_err(|e| format!("failed to create Task Scheduler XML temp file: {e}"))?;
++        tmp.write_all(&bytes)
++            .map_err(|e| format!("failed to write Task Scheduler XML: {e}"))?;
++        tmp.flush()
++            .map_err(|e| format!("failed to flush Task Scheduler XML: {e}"))?;
+         // Close our handle so schtasks can open it; the file persists until this drops.
+         tmp.into_temp_path()
+     };
+@@ -306,12 +415,13 @@ fn enable_impl() {
+     match result {
+         Ok(output) if output.status.success() => {
+             tracing::info!("Task Scheduler crash-recovery task registered");
++            Ok(())
+         }
+-        Ok(output) => {
+-            let stderr = String::from_utf8_lossy(&output.stderr);
+-            tracing::warn!("schtasks /Create failed: {stderr}");
+-        }
+-        Err(e) => tracing::warn!("Failed to run schtasks: {e}"),
++        Ok(output) => Err(format!(
++            "schtasks /Create failed: {}",
++            String::from_utf8_lossy(&output.stderr)
++        )),
++        Err(e) => Err(format!("failed to run schtasks: {e}")),
+     }
+ }
+ 
+@@ -401,6 +511,249 @@ fn xml_escape(s: &str) -> String {
+ 
+ #[cfg(test)]
+ mod tests {
++    #[allow(unused_imports)]
++    use std::path::Path;
++
++    use super::enable_transaction;
++    use std::cell::Cell;
++
++    // C8 (D13/D20): the enable transaction's rollback ordering + completeness + failure-observability,
++    // exercised with injected closures — no real AppHandle / OS calls, so it runs on every platform's CI.
++
++    #[test]
++    fn enable_transaction_happy_path_no_rollback() {
++        let disable_called = Cell::new(false);
++        let disarm_called = Cell::new(false);
++        let r = enable_transaction(
++            false,
++            || Ok(()),
++            || Ok(()),
++            || {
++                disable_called.set(true);
++                Ok(())
++            },
++            || {
++                disarm_called.set(true);
++                true
++            },
++        );
++        assert!(r.is_ok());
++        assert!(!disable_called.get(), "no rollback on success");
++        assert!(!disarm_called.get(), "no rollback on success");
++    }
++
++    #[test]
++    fn enable_transaction_arm_fails_prior_disabled_rolls_back_both() {
++        let disable_called = Cell::new(false);
++        let disarm_called = Cell::new(false);
++        let r = enable_transaction(
++            false, // prior disabled
++            || Ok(()),
++            || Err("arm boom".to_string()),
++            || {
++                disable_called.set(true);
++                Ok(())
++            },
++            || {
++                disarm_called.set(true);
++                true
++            },
++        );
++        let msg = r.unwrap_err();
++        assert!(
++            disable_called.get(),
++            "prior-disabled ⇒ plugin_disable rolls back the enable"
++        );
++        assert!(disarm_called.get(), "crash_disarm always runs on rollback");
++        assert!(
++            msg.contains("arm boom") && msg.contains("plugin=disabled"),
++            "combined error: {msg}"
++        );
++    }
++
++    #[test]
++    fn enable_transaction_arm_fails_prior_enabled_keeps_plugin_and_recovery() {
++        let enable_called = Cell::new(false);
++        let disable_called = Cell::new(false);
++        let disarm_called = Cell::new(false);
++        let r = enable_transaction(
++            true, // prior ENABLED (autostart + crash recovery were both already on)
++            || {
++                enable_called.set(true);
++                Ok(())
++            },
++            || Err("arm boom".to_string()),
++            || {
++                disable_called.set(true);
++                Ok(())
++            },
++            || {
++                disarm_called.set(true);
++                true
++            },
++        );
++        let msg = r.unwrap_err();
++        // codex r2 #3: never RE-RUN the plugin enable when already on — on macOS it recreates the
++        // LaunchAgent plist and strips the existing KeepAlive (destroying recovery before crash_arm).
++        assert!(
++            !enable_called.get(),
++            "prior-enabled ⇒ do NOT re-run plugin_enable (would strip the plist's KeepAlive on macOS)"
++        );
++        assert!(
++            !disable_called.get(),
++            "prior-enabled ⇒ do NOT disable (restore prior state)"
++        );
++        // codex #7: the key regression guard — a failed idempotent re-arm must NOT destroy the
++        // pre-existing crash recovery that was armed as part of the prior enabled state.
++        assert!(
++            !disarm_called.get(),
++            "prior-enabled ⇒ do NOT disarm the user's pre-existing crash recovery"
++        );
++        assert!(
++            msg.contains("kept") && msg.contains("skipped (prior enabled)"),
++            "error notes plugin kept + disarm skipped: {msg}"
++        );
++    }
++
++    #[test]
++    fn enable_transaction_plugin_enable_fails_no_arm_no_disable() {
++        let arm_called = Cell::new(false);
++        let disable_called = Cell::new(false);
++        let disarm_called = Cell::new(false);
++        let r = enable_transaction(
++            false,
++            || Err("plugin boom".to_string()),
++            || {
++                arm_called.set(true);
++                Ok(())
++            },
++            || {
++                disable_called.set(true);
++                Ok(())
++            },
++            || {
++                disarm_called.set(true);
++                true
++            },
++        );
++        let msg = r.unwrap_err();
++        assert!(
++            !arm_called.get(),
++            "crash_arm never runs if the launcher didn't enable"
++        );
++        assert!(
++            !disable_called.get(),
++            "nothing to disable — the enable failed"
++        );
++        assert!(
++            disarm_called.get(),
++            "defensively disarm any stale recovery on a fresh-enable attempt"
++        );
++        assert!(
++            msg.contains("plugin boom") && msg.contains("plugin step"),
++            "error: {msg}"
++        );
++    }
++
++    #[test]
++    fn enable_transaction_rollback_disable_failure_is_surfaced() {
++        let r = enable_transaction(
++            false,
++            || Ok(()),
++            || Err("arm boom".to_string()),
++            || Err("disable boom".to_string()), // rollback disable ALSO fails
++            || false,                           // and disarm not confirmed
++        );
++        let msg = r.unwrap_err();
++        assert!(
++            msg.contains("disable boom"),
++            "rollback disable failure surfaced: {msg}"
++        );
++        assert!(
++            msg.contains("autostart may still be active"),
++            "warns state may be unclean: {msg}"
++        );
++        assert!(
++            msg.contains("NOT confirmed"),
++            "disarm-not-confirmed surfaced: {msg}"
++        );
++    }
++
++    /// F-010: reproduce systemd's ExecStart decode (unquote → strip `:` prefix → specifier-expand `%%`→`%`)
++    /// to prove the serializer round-trips exactly to the intended path — i.e. no injection, exact argv0.
++    #[cfg(target_os = "linux")]
++    fn decode_systemd_exec_start(value: &str) -> String {
++        // Our serializer always emits `":<...>"` — one double-quoted token.
++        let inner = value
++            .strip_prefix('"')
++            .and_then(|s| s.strip_suffix('"'))
++            .expect("quoted token");
++        let after_prefix = inner.strip_prefix(':').expect(": prefix"); // strip the exec prefix
++        after_prefix.replace("%%", "%") // specifier expansion (only %% appears)
++    }
++
++    #[cfg(target_os = "linux")]
++    #[test]
++    fn systemd_exec_start_serializes_and_round_trips() {
++        // Plain path.
++        let v = super::systemd_exec_start(Path::new("/usr/bin/aztec-accelerator")).unwrap();
++        assert_eq!(v, "\":/usr/bin/aztec-accelerator\"");
++        assert_eq!(decode_systemd_exec_start(&v), "/usr/bin/aztec-accelerator");
++        // The serialized value can NEVER contain a newline (the unit-injection vector) for any accepted path.
++        assert!(!v.contains('\n'));
++        // A `%`, a space, and a `$` all survive as literals (— `%` doubled, `:` disables `$` expansion).
++        let v = super::systemd_exec_start(Path::new("/opt/my app/100% $HOME/bb")).unwrap();
++        assert_eq!(v, "\":/opt/my app/100%% $HOME/bb\"");
++        assert_eq!(decode_systemd_exec_start(&v), "/opt/my app/100% $HOME/bb");
++    }
++
++    #[cfg(target_os = "linux")]
++    #[test]
++    fn systemd_exec_start_rejects_unrepresentable_paths() {
++        for bad in [
++            "relative/bb",                 // not absolute
++            "/dir/",                       // directory shape
++            "/x/\nExecStartPre=/bin/evil", // newline injection
++            "/x/\tbb",                     // control
++            "/x/a\"b",                     // quote (systemd rejects)
++            "/x/a\\b",                     // backslash
++            "/x/a'b",                      // single quote
++            "/x/a*b",                      // glob
++            "/x/a?b",
++            "/x/a[b",
++        ] {
++            assert!(
++                super::systemd_exec_start(Path::new(bad)).is_none(),
++                "should reject {bad:?}"
++            );
++        }
++    }
++
++    #[test]
++    fn autostart_preflight_rejects_injection_and_accepts_normal_paths() {
++        // A PLATFORM-absolute path is accepted (Windows `is_absolute` needs a drive prefix, so `/usr/...`
++        // is NOT absolute there — the test binary runs on Windows CI too).
++        #[cfg(unix)]
++        let (ok1, ok2, inj_nl, inj_del) = (
++            "/usr/bin/aztec-accelerator",
++            "/opt/my app/aztec",
++            "/x/\nInject",
++            "/x/\u{7f}bb",
++        );
++        #[cfg(windows)]
++        let (ok1, ok2, inj_nl, inj_del) = (
++            r"C:\Program Files\Aztec\aztec.exe",
++            r"C:\my app\aztec.exe", // space + backslash are fine (formatting), not injection
++            "C:\\x\\\nInject",
++            "C:\\x\\\u{7f}bb",
++        );
++        assert!(super::autostart_path_is_safe(Path::new(ok1)));
++        assert!(super::autostart_path_is_safe(Path::new(ok2)));
++        assert!(!super::autostart_path_is_safe(Path::new("relative/bb"))); // not absolute (both platforms)
++        assert!(!super::autostart_path_is_safe(Path::new(inj_nl))); // newline injection
++        assert!(!super::autostart_path_is_safe(Path::new(inj_del))); // DEL control
++    }
++
+     #[test]
+     #[cfg(target_os = "windows")]
+     fn task_xml_uses_repeating_trigger_and_escapes_exe() {

--- a/implementations-plan/security-hardening/full-audit-2026-07-24/chunks/D-updater.diff
+++ b/implementations-plan/security-hardening/full-audit-2026-07-24/chunks/D-updater.diff
@@ -1,0 +1,1484 @@
+diff --git a/packages/accelerator/core/examples/update-manifest.rs b/packages/accelerator/core/examples/update-manifest.rs
+new file mode 100644
+index 0000000..4a930ca
+--- /dev/null
++++ b/packages/accelerator/core/examples/update-manifest.rs
+@@ -0,0 +1,122 @@
++//! F-004 release-pipeline tool: assemble, splice, and verify the signed update-manifest envelope.
++//!
++//! The Tauri signer (`tauri signer sign`) does the actual minisign signing with the release key; this
++//! tool only assembles the exact bytes to sign and, afterwards, embeds + verifies them — reusing the
++//! SAME `accelerator_core::update_manifest` code the app runs, so the published feed is gated by the
++//! production verifier before it ever reaches a user.
++//!
++//! Pipeline (see release-accelerator.yml):
++//!   1. `update-manifest envelope --feed latest.json > envelope.json`
++//!   2. `tauri signer sign envelope.json`            # → envelope.json.sig (base64 of the minisign doc)
++//!   3. `update-manifest splice --feed latest.json --envelope envelope.json --sig envelope.json.sig \
++//!         > latest.signed.json`
++//!   4. `update-manifest verify --feed latest.signed.json --pubkey pubkey.b64`   # exit 0 ⇒ publishable
++//!
++//! Encoding contract (kept in lockstep with `verify_manifest`):
++//!   - `manifest` = base64(envelope.json bytes); verify base64-decodes it then verifies the sig.
++//!   - `manifest_sig` = the `.sig` file content VERBATIM. Tauri already writes it as base64(minisign
++//!     doc), which is exactly what verify base64-decodes back into the minisign document.
++
++use std::process::ExitCode;
++
++use accelerator_core::update_manifest::{build_signed_envelope, verify_manifest};
++use base64::Engine as _;
++
++fn die(msg: String) -> ! {
++    eprintln!("update-manifest: {msg}");
++    std::process::exit(2);
++}
++
++fn read_to_string(path: &str) -> String {
++    std::fs::read_to_string(path).unwrap_or_else(|e| die(format!("read {path}: {e}")))
++}
++
++fn read_json(path: &str) -> serde_json::Value {
++    serde_json::from_str(&read_to_string(path))
++        .unwrap_or_else(|e| die(format!("parse {path}: {e}")))
++}
++
++/// Value of `--flag <value>` from argv, or exit with a usage error.
++fn flag(args: &[String], name: &str) -> String {
++    args.iter()
++        .position(|a| a == name)
++        .and_then(|i| args.get(i + 1))
++        .cloned()
++        .unwrap_or_else(|| die(format!("missing required {name}")))
++}
++
++fn main() -> ExitCode {
++    let args: Vec<String> = std::env::args().skip(1).collect();
++    match args.first().map(String::as_str) {
++        Some("envelope") => {
++            // Emit the canonical envelope bytes to sign, to stdout (binary-exact — no trailing newline).
++            let feed = read_json(&flag(&args, "--feed"));
++            match build_signed_envelope(&feed) {
++                Ok(bytes) => {
++                    use std::io::Write as _;
++                    if let Err(e) = std::io::stdout().write_all(&bytes) {
++                        die(format!("write stdout: {e}"));
++                    }
++                    ExitCode::SUCCESS
++                }
++                Err(e) => {
++                    eprintln!("envelope assembly failed: {e}");
++                    ExitCode::from(1)
++                }
++            }
++        }
++        Some("splice") => {
++            // Embed manifest + manifest_sig into the feed and print the result.
++            let mut feed = read_json(&flag(&args, "--feed"));
++            let env_bytes = std::fs::read(flag(&args, "--envelope"))
++                .unwrap_or_else(|e| die(format!("read envelope: {e}")));
++            let sig = read_to_string(&flag(&args, "--sig"));
++            let b64 = base64::engine::general_purpose::STANDARD;
++            feed["manifest"] = serde_json::Value::String(b64.encode(&env_bytes));
++            // Verbatim: the .sig content is already base64(minisign doc), which is exactly what
++            // verify base64-decodes. Re-encoding here would double-encode and fail verification.
++            feed["manifest_sig"] = serde_json::Value::String(sig.trim().to_string());
++            println!("{}", serde_json::to_string_pretty(&feed).unwrap());
++            ExitCode::SUCCESS
++        }
++        Some("verify") => {
++            // Gate: EVERY platform in the feed must bind through the production verifier.
++            let feed = read_json(&flag(&args, "--feed"));
++            let pubkey = read_to_string(&flag(&args, "--pubkey"));
++            let version = feed["version"]
++                .as_str()
++                .unwrap_or_else(|| die("feed has no string `version`".into()));
++            let platforms = feed["platforms"]
++                .as_object()
++                .unwrap_or_else(|| die("feed has no `platforms` object".into()));
++            if platforms.is_empty() {
++                die("feed has no platforms to verify".into());
++            }
++            let mut all_ok = true;
++            for (target, p) in platforms {
++                let url = p["url"].as_str().unwrap_or_default();
++                let sig = p["signature"].as_str().unwrap_or_default();
++                match verify_manifest(&feed, pubkey.trim(), version, url, sig) {
++                    Ok(v) => println!("OK  {target}: v{} ({} bytes)", v.version, v.size),
++                    Err(e) => {
++                        eprintln!("FAIL {target}: {e}");
++                        all_ok = false;
++                    }
++                }
++            }
++            if all_ok {
++                println!(
++                    "verify: all {} platform(s) bound to the signed envelope",
++                    platforms.len()
++                );
++                ExitCode::SUCCESS
++            } else {
++                ExitCode::from(1)
++            }
++        }
++        _ => {
++            eprintln!("usage: update-manifest <envelope|splice|verify> [--flags]");
++            ExitCode::from(2)
++        }
++    }
++}
+diff --git a/packages/accelerator/core/src/update_manifest.rs b/packages/accelerator/core/src/update_manifest.rs
+new file mode 100644
+index 0000000..d8e6437
+--- /dev/null
++++ b/packages/accelerator/core/src/update_manifest.rs
+@@ -0,0 +1,385 @@
++//! F-004 Layer A: in-app verification of a signed update-manifest envelope.
++//!
++//! `tauri-plugin-updater` verifies each downloaded ARTIFACT's minisign signature against the
++//! pinned pubkey, but it decides "is this newer?" from the UNSIGNED feed `version` field. A
++//! feed-writer can therefore advertise a high `version` while pointing `url`/`signature` at an
++//! OLD, still-validly-signed artifact → a silent downgrade to a vulnerable build (F-004).
++//!
++//! This module closes that by binding the version to the exact signed artifacts. The feed embeds:
++//!   - `manifest`     : base64 of the EXACT envelope JSON bytes that were signed, and
++//!   - `manifest_sig` : base64 of the minisign `.sig` document over those bytes.
++//!
++//! We base64-decode `manifest` and verify the signature over those VERBATIM bytes — no JSON
++//! re-serialization, so there is zero canonicalization drift (the base64 string survives the
++//! plugin's parse of `raw_json` intact). We then require the outer feed's `version`, `pub_date`,
++//! and `platforms` projection — and the specific artifact the plugin selected — to equal the
++//! signed envelope EXACTLY. Any mismatch is fail-closed. The signing key is the existing updater
++//! key (the threat is a feed-writer, not key theft), so no new secret is introduced.
++
++use std::collections::BTreeMap;
++
++use base64::Engine as _;
++use serde::{Deserialize, Serialize};
++
++/// Max base64 length of the embedded `manifest` field, checked BEFORE decoding (DoS guard).
++const MANIFEST_B64_MAX: usize = 64 * 1024;
++/// Max base64 length of the `manifest_sig` field (a minisign `.sig` is tiny).
++const MANIFEST_SIG_B64_MAX: usize = 4 * 1024;
++
++/// The decoded, signed envelope. `deny_unknown_fields` so an attacker cannot smuggle extra keys.
++/// `Serialize` so the release pipeline assembles the exact bytes it signs via [`build_signed_envelope`]
++/// — the same struct produces and consumes the envelope, so there is no shape drift.
++#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
++#[serde(deny_unknown_fields)]
++struct SignedEnvelope {
++    /// Envelope schema discriminator — domain-separates this signature from artifact signatures.
++    schema: String,
++    version: String,
++    pub_date: String,
++    platforms: BTreeMap<String, PlatformEntry>,
++}
++
++#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
++#[serde(deny_unknown_fields)]
++struct PlatformEntry {
++    url: String,
++    /// Mandatory — the signed byte size. Also makes the SEC-03 pre-flight cap trustworthy.
++    size: u64,
++    signature: String,
++}
++
++/// Fixed schema string the signer must use; a different value fails closed.
++pub const ENVELOPE_SCHEMA: &str = "aztec-accelerator-update-manifest-v1";
++
++/// Successful verification result: the SemVer-parsed version and the signed artifact size.
++#[derive(Debug, Clone)]
++pub struct VerifiedManifest {
++    pub version: semver::Version,
++    pub size: u64,
++}
++
++/// Every failure is a distinct variant so the caller can log a `SECURITY:`-prefixed reason. All
++/// are treated identically by the caller (reject the update), but distinct for forensics.
++#[derive(Debug)]
++pub enum ManifestError {
++    MissingField(&'static str),
++    FieldTooLarge(&'static str),
++    Base64(&'static str),
++    Utf8(&'static str),
++    PubkeyDecode,
++    SignatureDecode,
++    /// The minisign signature over the manifest bytes did not verify against the pinned key.
++    SignatureInvalid,
++    EnvelopeParse,
++    BadSchema,
++    /// Envelope `version` is not canonical SemVer (e.g. leading `v`, or non-canonical form).
++    NonCanonicalVersion,
++    /// Outer feed `version`/`pub_date`/`platforms` disagrees with the signed envelope.
++    OuterMismatch(&'static str),
++    /// The claimed `Update.version` does not equal the signed envelope `version`.
++    VersionMismatch,
++    /// Zero or more-than-one platform entry matched the plugin-selected download URL.
++    ArtifactNotUniquelyMatched,
++    /// The selected artifact's signature/size does not equal the signed envelope's.
++    ArtifactMismatch(&'static str),
++}
++
++impl std::fmt::Display for ManifestError {
++    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
++        write!(f, "{self:?}")
++    }
++}
++impl std::error::Error for ManifestError {}
++
++fn b64(s: &str, what: &'static str) -> Result<Vec<u8>, ManifestError> {
++    base64::engine::general_purpose::STANDARD
++        .decode(s.trim())
++        .map_err(|_| ManifestError::Base64(what))
++}
++
++/// Verify the signed manifest envelope embedded in `raw_json` and bind it to the plugin-selected
++/// artifact. `pubkey_b64` is the pinned updater pubkey (base64 of the minisign `.pub` document).
++/// `claimed_version` / `download_url` / `artifact_sig` are the `Update` fields the plugin would act
++/// on. On success the update is cryptographically bound to the exact signed artifact set.
++pub fn verify_manifest(
++    raw_json: &serde_json::Value,
++    pubkey_b64: &str,
++    claimed_version: &str,
++    download_url: &str,
++    artifact_sig: &str,
++) -> Result<VerifiedManifest, ManifestError> {
++    // 1. Extract the embedded fields (base64 strings survive the plugin's JSON parse verbatim).
++    let manifest_b64 = raw_json
++        .get("manifest")
++        .and_then(serde_json::Value::as_str)
++        .ok_or(ManifestError::MissingField("manifest"))?;
++    let manifest_sig_b64 = raw_json
++        .get("manifest_sig")
++        .and_then(serde_json::Value::as_str)
++        .ok_or(ManifestError::MissingField("manifest_sig"))?;
++    if manifest_b64.len() > MANIFEST_B64_MAX {
++        return Err(ManifestError::FieldTooLarge("manifest"));
++    }
++    if manifest_sig_b64.len() > MANIFEST_SIG_B64_MAX {
++        return Err(ManifestError::FieldTooLarge("manifest_sig"));
++    }
++
++    // 2. Decode the EXACT signed bytes + the signature document.
++    let manifest_bytes = b64(manifest_b64, "manifest")?;
++    let sig_doc = b64(manifest_sig_b64, "manifest_sig")?;
++    let sig_doc = String::from_utf8(sig_doc).map_err(|_| ManifestError::Utf8("manifest_sig"))?;
++
++    // 3. Verify the minisign signature over the verbatim manifest bytes with the pinned key.
++    //    allow_legacy=false requires the prehashed format the Tauri 2 signer emits.
++    let pubkey_doc = b64(pubkey_b64, "pubkey")?;
++    let pubkey_doc = String::from_utf8(pubkey_doc).map_err(|_| ManifestError::Utf8("pubkey"))?;
++    let public_key =
++        minisign_verify::PublicKey::decode(&pubkey_doc).map_err(|_| ManifestError::PubkeyDecode)?;
++    let signature =
++        minisign_verify::Signature::decode(&sig_doc).map_err(|_| ManifestError::SignatureDecode)?;
++    public_key
++        .verify(&manifest_bytes, &signature, false)
++        .map_err(|_| ManifestError::SignatureInvalid)?;
++
++    // 4. Parse the now-trusted envelope (strict).
++    let env: SignedEnvelope =
++        serde_json::from_slice(&manifest_bytes).map_err(|_| ManifestError::EnvelopeParse)?;
++    if env.schema != ENVELOPE_SCHEMA {
++        return Err(ManifestError::BadSchema);
++    }
++
++    // 5. Envelope version must be canonical SemVer (reject leading `v` / non-canonical forms even
++    //    though the plugin would accept them) and round-trip to the exact same string.
++    let env_version =
++        semver::Version::parse(&env.version).map_err(|_| ManifestError::NonCanonicalVersion)?;
++    if env_version.to_string() != env.version {
++        return Err(ManifestError::NonCanonicalVersion);
++    }
++
++    // 6. Bind the OUTER feed to the signed envelope (B3): version, pub_date, and the full platforms
++    //    projection must match exactly. `notes` stays unsigned/informational.
++    let outer_version = raw_json.get("version").and_then(serde_json::Value::as_str);
++    if outer_version != Some(env.version.as_str()) {
++        return Err(ManifestError::OuterMismatch("version"));
++    }
++    let outer_pub_date = raw_json.get("pub_date").and_then(serde_json::Value::as_str);
++    if outer_pub_date != Some(env.pub_date.as_str()) {
++        return Err(ManifestError::OuterMismatch("pub_date"));
++    }
++    let outer_platforms = raw_json
++        .get("platforms")
++        .ok_or(ManifestError::OuterMismatch("platforms"))?;
++    let outer_projection: BTreeMap<String, PlatformEntry> =
++        serde_json::from_value(outer_platforms.clone())
++            .map_err(|_| ManifestError::OuterMismatch("platforms"))?;
++    if outer_projection != env.platforms {
++        return Err(ManifestError::OuterMismatch("platforms"));
++    }
++
++    // 7. The claimed Update.version must equal the signed version exactly.
++    if claimed_version != env.version {
++        return Err(ManifestError::VersionMismatch);
++    }
++
++    // 8. Exactly ONE signed platform entry must match the plugin-selected download URL, and its
++    //    signature/size must equal the signed values.
++    let mut matches = env.platforms.values().filter(|p| p.url == download_url);
++    let selected = matches
++        .next()
++        .ok_or(ManifestError::ArtifactNotUniquelyMatched)?;
++    if matches.next().is_some() {
++        return Err(ManifestError::ArtifactNotUniquelyMatched);
++    }
++    if selected.signature != artifact_sig {
++        return Err(ManifestError::ArtifactMismatch("signature"));
++    }
++
++    Ok(VerifiedManifest {
++        version: env_version,
++        size: selected.size,
++    })
++}
++
++/// Assemble the canonical signed-envelope bytes from an (unsigned) feed value — the EXACT bytes the
++/// release pipeline signs. Extracts `version`/`pub_date`/`platforms` from the feed the plugin will
++/// serve, stamps the fixed [`ENVELOPE_SCHEMA`], and serializes. These bytes are what gets signed and
++/// base64-embedded as `manifest`, so there is no canonicalization contract beyond "they round-trip
++/// through [`verify_manifest`]" — which holds by construction, because they are built from the very
++/// fields verify compares back to the outer feed. Mirrors verify's canonical-SemVer rule so the
++/// pipeline never signs a version that verify would reject. Used by the `update-manifest` example tool.
++pub fn build_signed_envelope(feed: &serde_json::Value) -> Result<Vec<u8>, ManifestError> {
++    let version = feed
++        .get("version")
++        .and_then(serde_json::Value::as_str)
++        .ok_or(ManifestError::MissingField("version"))?;
++    let parsed = semver::Version::parse(version).map_err(|_| ManifestError::NonCanonicalVersion)?;
++    if parsed.to_string() != version {
++        return Err(ManifestError::NonCanonicalVersion);
++    }
++    let pub_date = feed
++        .get("pub_date")
++        .and_then(serde_json::Value::as_str)
++        .ok_or(ManifestError::MissingField("pub_date"))?;
++    let platforms_val = feed
++        .get("platforms")
++        .ok_or(ManifestError::MissingField("platforms"))?;
++    // Reuse the strict PlatformEntry parse: an extra/missing field on any platform fails here rather
++    // than producing an envelope verify would later reject.
++    let platforms: BTreeMap<String, PlatformEntry> =
++        serde_json::from_value(platforms_val.clone()).map_err(|_| ManifestError::EnvelopeParse)?;
++    if platforms.is_empty() {
++        return Err(ManifestError::MissingField("platforms"));
++    }
++    let env = SignedEnvelope {
++        schema: ENVELOPE_SCHEMA.to_string(),
++        version: version.to_string(),
++        pub_date: pub_date.to_string(),
++        platforms,
++    };
++    serde_json::to_vec(&env).map_err(|_| ManifestError::EnvelopeParse)
++}
++
++#[cfg(test)]
++mod tests {
++    use super::*;
++    use serde_json::json;
++
++    #[test]
++    fn build_signed_envelope_matches_feed_projection() {
++        // The assembled envelope must carry the fixed schema and reproduce the feed's version,
++        // pub_date, and platforms EXACTLY — that equality is what makes verify's outer==envelope
++        // binding pass once the bytes are signed.
++        let feed = feed();
++        let bytes = build_signed_envelope(&feed).unwrap();
++        let env: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
++        assert_eq!(env["schema"], ENVELOPE_SCHEMA);
++        assert_eq!(env["version"], feed["version"]);
++        assert_eq!(env["pub_date"], feed["pub_date"]);
++        let got: BTreeMap<String, PlatformEntry> =
++            serde_json::from_value(env["platforms"].clone()).unwrap();
++        let want: BTreeMap<String, PlatformEntry> =
++            serde_json::from_value(feed["platforms"].clone()).unwrap();
++        assert_eq!(got, want);
++    }
++
++    #[test]
++    fn build_signed_envelope_rejects_noncanonical_version() {
++        let mut feed = feed();
++        feed["version"] = json!("v1.0.8");
++        assert!(matches!(
++            build_signed_envelope(&feed),
++            Err(ManifestError::NonCanonicalVersion)
++        ));
++    }
++
++    // Fixture signed with a THROWAWAY test key (private key never committed). See
++    // tests/fixtures/updater/ — regenerate via `tauri signer generate/sign` if the schema changes.
++    const PUBKEY_B64: &str = include_str!("../tests/fixtures/updater/pubkey.b64");
++    const LATEST_JSON: &str = include_str!("../tests/fixtures/updater/latest.json");
++    const URL: &str = "https://example.test/app.AppImage";
++    const ART_SIG: &str = "ARTIFACT_SIG_PLACEHOLDER";
++
++    fn feed() -> serde_json::Value {
++        serde_json::from_str(LATEST_JSON).unwrap()
++    }
++    fn pk() -> &'static str {
++        PUBKEY_B64.trim()
++    }
++
++    #[test]
++    fn happy_path_verifies_and_binds() {
++        let v = verify_manifest(&feed(), pk(), "1.0.8", URL, ART_SIG).expect("valid manifest");
++        assert_eq!(v.version, semver::Version::parse("1.0.8").unwrap());
++        assert_eq!(v.size, 12345);
++    }
++
++    #[test]
++    fn splice_high_outer_version_rejected() {
++        // F-004 core attack: attacker bumps the outer/claimed version but cannot re-sign the
++        // envelope (still 1.0.8). Outer≠envelope ⇒ rejected before any download.
++        let mut f = feed();
++        f["version"] = json!("9.9.9");
++        assert!(matches!(
++            verify_manifest(&f, pk(), "9.9.9", URL, ART_SIG),
++            Err(ManifestError::OuterMismatch("version"))
++        ));
++    }
++
++    #[test]
++    fn claimed_version_mismatch_rejected() {
++        // Update.version disagrees with the signed envelope (outer left intact).
++        assert!(matches!(
++            verify_manifest(&feed(), pk(), "2.0.0", URL, ART_SIG),
++            Err(ManifestError::VersionMismatch | ManifestError::OuterMismatch(_))
++        ));
++    }
++
++    #[test]
++    fn tampered_manifest_bytes_fail_signature() {
++        let mut f = feed();
++        let m = f["manifest"].as_str().unwrap().to_string();
++        // flip one char in the base64 → different signed bytes → signature no longer verifies
++        let mut chars: Vec<char> = m.chars().collect();
++        let i = chars.len() / 2;
++        chars[i] = if chars[i] == 'A' { 'B' } else { 'A' };
++        f["manifest"] = json!(chars.into_iter().collect::<String>());
++        assert!(matches!(
++            verify_manifest(&f, pk(), "1.0.8", URL, ART_SIG),
++            Err(ManifestError::SignatureInvalid
++                | ManifestError::EnvelopeParse
++                | ManifestError::Base64(_))
++        ));
++    }
++
++    #[test]
++    fn outer_size_tamper_rejected() {
++        let mut f = feed();
++        f["platforms"]["linux-x86_64"]["size"] = json!(999);
++        assert!(matches!(
++            verify_manifest(&f, pk(), "1.0.8", URL, ART_SIG),
++            Err(ManifestError::OuterMismatch("platforms"))
++        ));
++    }
++
++    #[test]
++    fn missing_envelope_fails_closed() {
++        let mut f = feed();
++        f.as_object_mut().unwrap().remove("manifest");
++        assert!(matches!(
++            verify_manifest(&f, pk(), "1.0.8", URL, ART_SIG),
++            Err(ManifestError::MissingField("manifest"))
++        ));
++    }
++
++    #[test]
++    fn wrong_artifact_sig_rejected() {
++        assert!(matches!(
++            verify_manifest(&feed(), pk(), "1.0.8", URL, "NOT_THE_SIGNED_SIG"),
++            Err(ManifestError::ArtifactMismatch("signature"))
++        ));
++    }
++
++    #[test]
++    fn unmatched_download_url_rejected() {
++        assert!(matches!(
++            verify_manifest(
++                &feed(),
++                pk(),
++                "1.0.8",
++                "https://evil.test/x.AppImage",
++                ART_SIG
++            ),
++            Err(ManifestError::ArtifactNotUniquelyMatched)
++        ));
++    }
++
++    #[test]
++    fn wrong_pubkey_rejected() {
++        // A different (valid-format) key must not verify the signature.
++        let other = "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEIzNzEzODFFMEEzMzU2QTgKUldTb1ZqTUtIamh4czNrcWR3QVZiUmIwdyttSzg5OUhtZXJobURnY05KL2pCZWMydDFPcWkvWFAK";
++        assert!(matches!(
++            verify_manifest(&feed(), other, "1.0.8", URL, ART_SIG),
++            Err(ManifestError::SignatureInvalid)
++        ));
++    }
++}
+diff --git a/packages/accelerator/core/src/updater_state.rs b/packages/accelerator/core/src/updater_state.rs
+new file mode 100644
+index 0000000..6ea2b5f
+--- /dev/null
++++ b/packages/accelerator/core/src/updater_state.rs
+@@ -0,0 +1,396 @@
++//! F-004 Layer B: a monotonic version floor — the rollback ratchet.
++//!
++//! Even if Layer A ([`crate::update_manifest`]) were somehow bypassed, the app must never move
++//! backwards. We persist, in a dedicated owner-only atomically-written state file (NOT `config.json`,
++//! whose load is deliberately fail-OPEN and would silently erase the floor on any parse glitch), two
++//! monotonic high-water marks:
++//!
++//! - **`floor`** — the highest version that has ever SUCCESSFULLY RUN. Advanced only after a new build
++//!   proves it runs (the caller commits post-launch, [`commit_successful_launch`]), so a crashing bad
++//!   update can never ratchet it.
++//! - **`pending`** — the version an install has COMMITTED to (the install INTENT) but that has not yet
++//!   proven healthy ([`record_pending`], written under the updater lock right BEFORE `install()` — see
++//!   that fn for why after-install is wrong on Windows). This closes the restart race: instance A
++//!   commits `3.0.0` and installs/restarts (releasing the lock) before `3.0.0` can commit its floor;
++//!   without `pending`, a racing instance B would still see `floor = 1.0.0` and could install a LOWER
++//!   `2.0.0`, regressing the just-installed higher version. With `pending`, B sees the floor at `3.0.0`.
++//!
++//! An update candidate is accepted only if — by SemVer PRECEDENCE (build metadata ignored) — it is
++//! strictly greater than `max(current_running, floor)` AND not below `pending` (candidate `== pending`
++//! is allowed, so a failed install can be RETRIED with the exact intent without poisoning it; a lower
++//! version stays blocked). A corrupt/unreadable state fails CLOSED (updates disabled) and is never
++//! overwritten, preserving forensic evidence.
++//!
++//! This module is the pure, GUI-agnostic core logic (unit-testable without the Tauri toolchain). The
++//! cross-process `flock` "updater transaction" that serialises check→install→record→commit across
++//! concurrent instances is applied by the desktop caller around these operations; every mutating call
++//! here ([`record_pending`], [`commit_successful_launch`]) MUST run while the caller holds that lock.
++
++use std::io::Write as _;
++use std::path::Path;
++
++use semver::Version;
++use serde::{Deserialize, Serialize};
++
++const SCHEMA: u32 = 1;
++
++/// The persisted state. `deny_unknown_fields` so a tampered file with extra keys is rejected
++/// (→ [`LoadedState::Corrupt`]) rather than silently accepted. `pending` is optional (older files and
++/// the common "nothing installing" case omit it).
++#[derive(Debug, Serialize, Deserialize)]
++#[serde(deny_unknown_fields)]
++struct StateFile {
++    schema: u32,
++    floor: String,
++    #[serde(default, skip_serializing_if = "Option::is_none")]
++    pending: Option<String>,
++}
++
++/// The distinguishable load outcomes. `Corrupt` and `Missing` are NOT the same: `Missing` bootstraps
++/// (first run / pre-floor upgrade), `Corrupt` fails closed and is never overwritten.
++#[derive(Debug, PartialEq, Eq)]
++pub enum LoadedState {
++    /// No state file yet — first run. Effective floor is `current_running` alone.
++    Missing,
++    /// File exists but is unreadable / not our schema / not canonical SemVer. Fail closed.
++    Corrupt,
++    Valid {
++        floor: Version,
++        /// An install committed to but not yet proven healthy — part of the effective floor.
++        pending: Option<Version>,
++    },
++}
++
++/// Parse a stored version string, requiring canonical round-trip so a non-canonical value can't slip
++/// the comparator.
++fn parse_canonical(s: &str) -> Option<Version> {
++    match Version::parse(s) {
++        Ok(v) if v.to_string() == s => Some(v),
++        _ => None,
++    }
++}
++
++/// Load the state. IO errors other than "not found" are treated as `Corrupt` (fail closed) — a
++/// permission or read failure on security state must not be interpreted as "no floor".
++pub fn load_state(path: &Path) -> LoadedState {
++    let contents = match std::fs::read_to_string(path) {
++        Ok(c) => c,
++        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return LoadedState::Missing,
++        Err(_) => return LoadedState::Corrupt,
++    };
++    let parsed: StateFile = match serde_json::from_str(&contents) {
++        Ok(p) => p,
++        Err(_) => return LoadedState::Corrupt,
++    };
++    if parsed.schema != SCHEMA {
++        return LoadedState::Corrupt;
++    }
++    let Some(floor) = parse_canonical(&parsed.floor) else {
++        return LoadedState::Corrupt;
++    };
++    // A present-but-unparseable `pending` is corruption, not "no pending" — fail closed.
++    let pending = match parsed.pending {
++        None => None,
++        Some(ref s) => match parse_canonical(s) {
++            Some(v) => Some(v),
++            None => return LoadedState::Corrupt,
++        },
++    };
++    LoadedState::Valid { floor, pending }
++}
++
++fn gt(a: &Version, b: &Version) -> bool {
++    a.cmp_precedence(b) == std::cmp::Ordering::Greater
++}
++
++/// Is `candidate` acceptable given the running version and the loaded state? Uses SemVer PRECEDENCE
++/// (build metadata ignored, prerelease ordered correctly). A `Corrupt` state rejects everything
++/// (fail closed).
++///
++/// Rules (codex audit #5 — retryable intent semantics):
++/// - strictly above the running version (`current`);
++/// - strictly above the confirmed `floor` (no rollback below a version that ran healthy);
++/// - `>= pending` — i.e. NOT below the pending install intent (a lower still-signed version would
++///   regress the committed install), but candidate `== pending` IS allowed so a failed/interrupted
++///   install can be RETRIED with the exact same version without permanently poisoning it. Recording
++///   the intent BEFORE install (see [`record_pending`]) is what makes this the anti-downgrade floor
++///   even on platforms where `install()` never returns to record it afterwards (Windows exits mid-install).
++pub fn candidate_allowed(candidate: &Version, current: &Version, state: &LoadedState) -> bool {
++    if !gt(candidate, current) {
++        return false;
++    }
++    match state {
++        LoadedState::Corrupt => false,
++        LoadedState::Missing => true,
++        LoadedState::Valid { floor, pending } => {
++            if !gt(candidate, floor) {
++                return false;
++            }
++            match pending {
++                Some(p) => !gt(p, candidate), // candidate >= pending (equal = retry the exact intent)
++                None => true,
++            }
++        }
++    }
++}
++
++/// True iff the running build is BELOW the confirmed FLOOR — a rollback that already happened (someone
++/// installed an older binary out of band). Uses the confirmed `floor` ONLY, never `pending`: being
++/// below `pending` is the NORMAL state while a higher install has committed but not yet launched.
++pub fn running_below_floor(current: &Version, state: &LoadedState) -> bool {
++    matches!(state, LoadedState::Valid { floor, .. } if gt(floor, current))
++}
++
++/// Record that `current` (the running, therefore proven, installer) is COMMITTING to install
++/// `candidate`, which becomes the PENDING intent until a build at that version proves healthy.
++/// Advances `floor` to include `current` and `pending` to include `candidate` (both monotonic by
++/// precedence). MUST be called under the updater lock, and — codex #5 — right BEFORE `install()`
++/// (not after): on Windows `tauri-plugin-updater`'s `install()` dispatches the external installer and
++/// `std::process::exit(0)`s, so anything after it (including this record) never runs. Recording the
++/// intent first is what raises the anti-downgrade floor for a racing instance regardless of platform,
++/// and [`candidate_allowed`] permits re-attempting the exact `candidate` so a failed install does not
++/// poison that version. Refuses a `Corrupt` file.
++pub fn record_pending(path: &Path, current: &Version, candidate: &Version) -> std::io::Result<()> {
++    let (floor, pending) = match load_state(path) {
++        LoadedState::Corrupt => {
++            return Err(std::io::Error::new(
++                std::io::ErrorKind::InvalidData,
++                "refusing to overwrite a corrupt version-floor state",
++            ));
++        }
++        LoadedState::Missing => (current.clone(), Some(candidate.clone())),
++        LoadedState::Valid { floor, pending } => {
++            let new_floor = if gt(current, &floor) {
++                current.clone()
++            } else {
++                floor
++            };
++            let new_pending = match pending {
++                Some(p) if gt(&p, candidate) => Some(p),
++                _ => Some(candidate.clone()),
++            };
++            (new_floor, new_pending)
++        }
++    };
++    write_state(path, &floor, pending.as_ref())
++}
++
++/// Record that `current` launched successfully: advance `floor` to `max(floor, current)` and clear any
++/// `pending` that has now been superseded (i.e. `pending <= current` by precedence — the pending
++/// install has launched, so it graduates into the confirmed floor). Monotonic; never lowers. Refuses a
++/// `Corrupt` file. MUST be called under the updater lock.
++pub fn commit_successful_launch(path: &Path, current: &Version) -> std::io::Result<()> {
++    match load_state(path) {
++        LoadedState::Corrupt => Err(std::io::Error::new(
++            std::io::ErrorKind::InvalidData,
++            "refusing to overwrite a corrupt version-floor state",
++        )),
++        LoadedState::Missing => write_state(path, current, None),
++        LoadedState::Valid { floor, pending } => {
++            let new_floor = if gt(current, &floor) {
++                current.clone()
++            } else {
++                floor
++            };
++            // Drop pending once the running version has caught up to (or passed) it.
++            let new_pending = pending.filter(|p| gt(p, current));
++            write_state(path, &new_floor, new_pending.as_ref())
++        }
++    }
++}
++
++/// Atomically write the state with owner-only perms: random temp name in the SAME dir (via
++/// `tempfile`), explicit `0600`, `fsync` of the file AND the parent dir on Unix, chmod/durability
++/// failures are HARD errors (not ignored — L8).
++fn write_state(path: &Path, floor: &Version, pending: Option<&Version>) -> std::io::Result<()> {
++    let parent = path.parent().ok_or_else(|| {
++        std::io::Error::new(std::io::ErrorKind::InvalidInput, "state path has no parent")
++    })?;
++    std::fs::create_dir_all(parent)?;
++    #[cfg(unix)]
++    {
++        use std::os::unix::fs::PermissionsExt;
++        std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))?;
++    }
++
++    let body = serde_json::to_vec(&StateFile {
++        schema: SCHEMA,
++        floor: floor.to_string(),
++        pending: pending.map(ToString::to_string),
++    })?;
++
++    // Random same-dir temp (owner-only from creation), write, fsync, then atomic rename.
++    let mut tmp = tempfile::Builder::new()
++        .prefix(".updater-state-")
++        .tempfile_in(parent)?;
++    #[cfg(unix)]
++    {
++        use std::os::unix::fs::PermissionsExt;
++        tmp.as_file()
++            .set_permissions(std::fs::Permissions::from_mode(0o600))?;
++    }
++    tmp.write_all(&body)?;
++    tmp.as_file().sync_all()?;
++    tmp.persist(path)
++        .map_err(|e| std::io::Error::other(e.error))?;
++
++    // fsync the directory so the rename is durable. Propagate failures (L8): a swallowed dir-fsync
++    // failure could let a crash restore an older/missing dir entry and lower or erase the floor.
++    #[cfg(unix)]
++    {
++        let dir = std::fs::File::open(parent)?;
++        dir.sync_all()?;
++    }
++    Ok(())
++}
++
++#[cfg(test)]
++mod tests {
++    use super::*;
++
++    fn v(s: &str) -> Version {
++        Version::parse(s).unwrap()
++    }
++    fn tmp() -> tempfile::TempDir {
++        tempfile::tempdir().unwrap()
++    }
++    fn valid(floor: &str, pending: Option<&str>) -> LoadedState {
++        LoadedState::Valid {
++            floor: v(floor),
++            pending: pending.map(v),
++        }
++    }
++
++    #[test]
++    fn missing_bootstraps() {
++        let d = tmp();
++        assert_eq!(load_state(&d.path().join("s.json")), LoadedState::Missing);
++        assert!(candidate_allowed(
++            &v("1.1.0"),
++            &v("1.0.0"),
++            &LoadedState::Missing
++        ));
++        assert!(!candidate_allowed(
++            &v("1.0.0"),
++            &v("1.0.0"),
++            &LoadedState::Missing
++        ));
++    }
++
++    #[test]
++    fn commit_is_monotonic_and_roundtrips() {
++        let d = tmp();
++        let p = d.path().join("s.json");
++        commit_successful_launch(&p, &v("1.0.8")).unwrap();
++        assert_eq!(load_state(&p), valid("1.0.8", None));
++        commit_successful_launch(&p, &v("1.0.5")).unwrap(); // lower never lowers
++        assert_eq!(load_state(&p), valid("1.0.8", None));
++        commit_successful_launch(&p, &v("1.1.0")).unwrap();
++        assert_eq!(load_state(&p), valid("1.1.0", None));
++    }
++
++    #[test]
++    fn floor_blocks_rollback_candidate() {
++        let f = valid("1.0.8", None);
++        assert!(!candidate_allowed(&v("1.0.7"), &v("1.0.6"), &f));
++        assert!(!candidate_allowed(&v("1.0.8"), &v("1.0.6"), &f)); // equal to floor
++        assert!(candidate_allowed(&v("1.0.9"), &v("1.0.6"), &f));
++    }
++
++    #[test]
++    fn pending_blocks_lower_candidate_before_commit() {
++        // H1 restart race: A installed 3.0.0 (recorded pending), floor still 1.0.0. B (current 1.0.0)
++        // must NOT be allowed to install 2.0.0 — the effective floor is now 3.0.0.
++        let d = tmp();
++        let p = d.path().join("s.json");
++        commit_successful_launch(&p, &v("1.0.0")).unwrap();
++        record_pending(&p, &v("1.0.0"), &v("3.0.0")).unwrap();
++        let st = load_state(&p);
++        assert_eq!(st, valid("1.0.0", Some("3.0.0")));
++        assert!(!candidate_allowed(&v("2.0.0"), &v("1.0.0"), &st)); // regression blocked
++        assert!(candidate_allowed(&v("3.0.1"), &v("1.0.0"), &st)); // strictly-higher allowed
++                                                                   // codex #5: retrying the EXACT pending intent is allowed (a failed/interrupted install must not
++                                                                   // poison that version); anything strictly below it stays blocked.
++        assert!(candidate_allowed(&v("3.0.0"), &v("1.0.0"), &st)); // retry the exact intent
++        assert!(!candidate_allowed(&v("2.9.9"), &v("1.0.0"), &st)); // still below intent → blocked
++                                                                    // running below the confirmed FLOOR is false (1.0.0 == floor); pending doesn't count as floor.
++        assert!(!running_below_floor(&v("1.0.0"), &st));
++    }
++
++    #[test]
++    fn commit_promotes_pending_into_floor() {
++        let d = tmp();
++        let p = d.path().join("s.json");
++        commit_successful_launch(&p, &v("1.0.0")).unwrap();
++        record_pending(&p, &v("1.0.0"), &v("2.0.0")).unwrap();
++        assert_eq!(load_state(&p), valid("1.0.0", Some("2.0.0")));
++        // 2.0.0 launches and proves healthy → floor advances to 2.0.0, pending cleared.
++        commit_successful_launch(&p, &v("2.0.0")).unwrap();
++        assert_eq!(load_state(&p), valid("2.0.0", None));
++    }
++
++    #[test]
++    fn record_pending_is_monotonic() {
++        let d = tmp();
++        let p = d.path().join("s.json");
++        record_pending(&p, &v("1.0.0"), &v("2.0.0")).unwrap();
++        record_pending(&p, &v("1.0.0"), &v("1.5.0")).unwrap(); // lower candidate can't lower pending
++        assert_eq!(load_state(&p), valid("1.0.0", Some("2.0.0")));
++    }
++
++    #[test]
++    fn corrupt_fails_closed_and_is_preserved() {
++        let d = tmp();
++        let p = d.path().join("s.json");
++        std::fs::write(&p, b"{ not json").unwrap();
++        assert_eq!(load_state(&p), LoadedState::Corrupt);
++        assert!(!candidate_allowed(
++            &v("9.9.9"),
++            &v("1.0.0"),
++            &LoadedState::Corrupt
++        ));
++        assert!(commit_successful_launch(&p, &v("2.0.0")).is_err());
++        assert!(record_pending(&p, &v("1.0.0"), &v("2.0.0")).is_err());
++        assert_eq!(std::fs::read_to_string(&p).unwrap(), "{ not json"); // untouched
++    }
++
++    #[test]
++    fn wrong_schema_or_bad_pending_is_corrupt() {
++        let d = tmp();
++        let p = d.path().join("s.json");
++        std::fs::write(&p, br#"{"schema":99,"floor":"1.0.0"}"#).unwrap();
++        assert_eq!(load_state(&p), LoadedState::Corrupt);
++        std::fs::write(&p, br#"{"schema":1,"floor":"1.0.0","pending":"notver"}"#).unwrap();
++        assert_eq!(load_state(&p), LoadedState::Corrupt);
++        // Unknown field rejected.
++        std::fs::write(&p, br#"{"schema":1,"floor":"1.0.0","x":1}"#).unwrap();
++        assert_eq!(load_state(&p), LoadedState::Corrupt);
++    }
++
++    #[test]
++    fn prerelease_and_build_metadata_precedence() {
++        let f = valid("1.0.8-rc.2", None);
++        assert!(candidate_allowed(&v("1.0.8-rc.10"), &v("1.0.7"), &f)); // rc.10 > rc.2 numerically
++        assert!(candidate_allowed(&v("1.0.8"), &v("1.0.7"), &f)); // stable > its rc
++        let f2 = valid("1.0.8", None);
++        assert!(!candidate_allowed(&v("1.0.8+build.5"), &v("1.0.0"), &f2)); // build metadata ignored
++    }
++
++    #[test]
++    fn running_below_floor_detects_rollback() {
++        assert!(running_below_floor(&v("1.0.5"), &valid("1.0.8", None)));
++        assert!(!running_below_floor(&v("1.0.8"), &valid("1.0.8", None)));
++        assert!(!running_below_floor(&v("1.0.9"), &valid("1.0.8", None)));
++    }
++
++    #[cfg(unix)]
++    #[test]
++    fn written_file_is_owner_only() {
++        use std::os::unix::fs::MetadataExt;
++        let d = tmp();
++        let p = d.path().join("s.json");
++        commit_successful_launch(&p, &v("1.0.0")).unwrap();
++        assert_eq!(std::fs::metadata(&p).unwrap().mode() & 0o777, 0o600);
++        assert_eq!(std::fs::metadata(d.path()).unwrap().mode() & 0o777, 0o700);
++    }
++}
+diff --git a/packages/accelerator/src-tauri/src/updater.rs b/packages/accelerator/src-tauri/src/updater.rs
+index 6502c2e..17f68ba 100644
+--- a/packages/accelerator/src-tauri/src/updater.rs
++++ b/packages/accelerator/src-tauri/src/updater.rs
+@@ -5,16 +5,199 @@
+ //! calls `perform_update()` directly — no redundant network re-check.
+ 
+ use crate::commands::ConfigState;
++use accelerator_core::{update_manifest, updater_state};
++use semver::Version;
++use std::sync::OnceLock;
+ use tauri::AppHandle;
+ use tauri_plugin_updater::UpdaterExt;
+ 
+-/// Check for updates and act based on the user's auto_update preference.
+-/// Returns the `Update` if one is available and the user hasn't opted into auto-update
+-/// (so the caller can show a prompt or store it for later use).
++/// The pinned updater public key, read ONCE from the bundled `tauri.conf.json` — the exact same key
++/// the plugin uses to verify artifact signatures. Reading it from the config (instead of duplicating
++/// the string) guarantees Layer A verifies against the key the build actually trusts. Panics at first
++/// use only if the config is malformed, which is a build-time invariant, not a runtime input.
++fn updater_pubkey() -> &'static str {
++    static PUBKEY: OnceLock<String> = OnceLock::new();
++    PUBKEY.get_or_init(|| {
++        const CONF: &str = include_str!("../tauri.conf.json");
++        let conf: serde_json::Value =
++            serde_json::from_str(CONF).expect("tauri.conf.json is valid JSON");
++        conf["plugins"]["updater"]["pubkey"]
++            .as_str()
++            .expect("tauri.conf.json plugins.updater.pubkey is present")
++            .to_string()
++    })
++}
++
++/// Absolute path to the monotonic version-floor state file. Lives alongside the app's other private
++/// state under `~/.aztec-accelerator/` (same base as `certs/`), deliberately NOT inside `config.json`
++/// (whose load is fail-open and would silently erase the floor on any parse glitch).
++fn updater_state_path() -> Option<std::path::PathBuf> {
++    dirs::home_dir().map(|h| h.join(".aztec-accelerator").join("updater-state.json"))
++}
++
++/// F-004 B2: acquire the cross-process "updater transaction" lock. Serialises check→install and the
++/// post-launch floor commit across concurrent app instances, so two processes can neither race the
++/// floor file nor install over each other. Best-effort and non-blocking: if another instance holds it,
++/// return `None` and the caller bows out (the periodic poller / next launch retries) rather than
++/// blocking the async runtime. The returned guard (the open, exclusively-locked file) releases the
++/// lock on drop — and, on the no-return `app.restart()` path, the OS releases it at process exit.
++fn acquire_updater_lock() -> Option<std::fs::File> {
++    use fs2::FileExt as _;
++    let parent = updater_state_path()?.parent()?.to_path_buf();
++    let _ = std::fs::create_dir_all(&parent);
++    let file = std::fs::OpenOptions::new()
++        .create(true)
++        .read(true)
++        .write(true)
++        .truncate(false)
++        .open(parent.join("updater.lock"))
++        .ok()?;
++    match file.try_lock_exclusive() {
++        Ok(()) => Some(file),
++        Err(_) => {
++            tracing::info!(
++                "Another instance holds the updater lock; skipping this update transaction"
++            );
++            None
++        }
++    }
++}
++
++/// Record that THIS build launched successfully by advancing the monotonic version floor to the
++/// running version (F-004 Layer B). Called once, after the app has proven it actually runs (see the
++/// launch tracker in main.rs) — so a build that boots but immediately wedges never ratchets the floor
++/// and can't lock itself in as the new minimum.
++///
++/// The updater lock is REQUIRED, not best-effort (audit H2): committing the floor without it can race a
++/// concurrent installer — the installer re-checks the floor before `install()`, so a commit that lands
++/// between that check and the install would let the installer write a version below the just-advanced
++/// floor. If the lock is held by another instance's transaction, defer the commit (the next launch
++/// retries) rather than commit unlocked.
++pub fn commit_launch_floor() {
++    let Some(path) = updater_state_path() else {
++        tracing::warn!("cannot resolve updater-state path; skipping floor commit");
++        return;
++    };
++    let current = match Version::parse(env!("CARGO_PKG_VERSION")) {
++        Ok(v) => v,
++        Err(e) => {
++            tracing::warn!("own version is not SemVer ({e}); skipping floor commit");
++            return;
++        }
++    };
++    let Some(_guard) = acquire_updater_lock() else {
++        tracing::warn!(
++            "could not acquire the updater lock; deferring the floor commit to avoid racing a concurrent install"
++        );
++        return;
++    };
++    match updater_state::commit_successful_launch(&path, &current) {
++        Ok(()) => tracing::info!(version = %current, "Version floor committed for this launch"),
++        Err(e) => tracing::warn!("Floor commit skipped: {e}"),
++    }
++}
++
++/// An update that has cleared BOTH F-004 layers: Layer A (the signed-manifest envelope binds the
++/// advertised version to the exact signed artifact set — [`update_manifest::verify_manifest`]) and
++/// Layer B (the candidate is strictly above `max(current, floor)` — [`updater_state`]). Its fields are
++/// private and the ONLY constructor is [`verify_and_gate`], so a value of this type is a
++/// proof-carrying token: [`perform_update`] accepts nothing else, and the frontend holds no updater
++/// capability (see `capabilities/default.json`). Together those make it impossible to install an
++/// artifact that has not cleared both layers.
++pub struct VerifiedUpdate {
++    update: tauri_plugin_updater::Update,
++    /// The SemVer-parsed, envelope-bound version.
++    version: Version,
++    /// The signed artifact byte size (authoritative — from the signed envelope, so the size cap in
++    /// [`perform_update`] cannot be defeated by a lying feed).
++    signed_size: u64,
++}
++
++impl VerifiedUpdate {
++    /// The verified SemVer version — for logging and the post-launch floor commit.
++    pub fn version(&self) -> &Version {
++        &self.version
++    }
++}
++
++/// F-004 Layer B, fail-closed. Returns `Ok(())` iff `candidate` may be installed given the persisted
++/// state and the running version. Every arm — updater-state path resolution, state load, the
++/// running-below-floor check, and candidate-allowed (which itself rejects a `Corrupt` state) — fails
++/// CLOSED (Err) on any problem. Shared by the check-time gate ([`verify_and_gate`]) and the install-time
++/// re-check ([`perform_update`]) so the two can never diverge (audit M5). `current` is passed in so the
++/// caller parses it once and a parse failure is handled as fail-closed there.
++fn layer_b_gate(candidate: &Version, current: &Version) -> Result<(), String> {
++    let Some(path) = updater_state_path() else {
++        return Err("cannot resolve the updater-state path".to_string());
++    };
++    let state = updater_state::load_state(&path);
++    if updater_state::running_below_floor(current, &state) {
++        return Err(
++            "running build is BELOW the version floor (possible out-of-band rollback); refusing all updates"
++                .to_string(),
++        );
++    }
++    if !updater_state::candidate_allowed(candidate, current, &state) {
++        return Err(format!(
++            "candidate {candidate} is not strictly above max(current {current}, floor, pending)"
++        ));
++    }
++    Ok(())
++}
++
++/// F-004 gate: verify the signed manifest (Layer A) and enforce the monotonic version floor
++/// (Layer B). Returns a proof-carrying [`VerifiedUpdate`] iff BOTH pass; on any failure it logs a
++/// `SECURITY:`-prefixed reason and returns `None` (fail closed — the app stays on its current build).
++fn verify_and_gate(update: tauri_plugin_updater::Update) -> Option<VerifiedUpdate> {
++    let current = match Version::parse(env!("CARGO_PKG_VERSION")) {
++        Ok(v) => v,
++        Err(e) => {
++            tracing::error!(
++                "SECURITY: own version {} is not valid SemVer ({e}); refusing update",
++                env!("CARGO_PKG_VERSION")
++            );
++            return None;
++        }
++    };
++
++    // Layer A — bind the advertised version to the signed artifact set. Closes the F-004 splice: a
++    // feed advertising a high version while pointing url/signature at an old, still-validly-signed
++    // artifact is rejected here, BEFORE any download.
++    let verified = match update_manifest::verify_manifest(
++        &update.raw_json,
++        updater_pubkey(),
++        &update.version,
++        update.download_url.as_str(),
++        &update.signature,
++    ) {
++        Ok(v) => v,
++        Err(e) => {
++            tracing::error!("SECURITY: update-manifest verification failed ({e}); refusing update");
++            return None;
++        }
++    };
++
++    // Layer B — the monotonic anti-rollback floor (shared fail-closed gate).
++    if let Err(reason) = layer_b_gate(&verified.version, &current) {
++        tracing::error!("SECURITY: {reason}; refusing update");
++        return None;
++    }
++
++    Some(VerifiedUpdate {
++        update,
++        version: verified.version,
++        signed_size: verified.size,
++    })
++}
++
++/// Check for updates and act based on the user's auto_update preference. Any available update is put
++/// through the F-004 [`verify_and_gate`] FIRST — an unverified or rolled-back candidate never reaches
++/// the prompt or the auto-install path. Returns the [`VerifiedUpdate`] when one is available and the
++/// user hasn't opted into auto-update (so the caller can show a prompt or store it for later use).
+ pub async fn check_for_update(
+     app: &AppHandle,
+     config_state: &ConfigState,
+-) -> Option<tauri_plugin_updater::Update> {
++) -> Option<VerifiedUpdate> {
+     tracing::info!("Checking for updates...");
+     let updater = match app.updater() {
+         Ok(u) => u,
+@@ -24,6 +207,13 @@ pub async fn check_for_update(
+         }
+     };
+ 
++    // Residual (audit M6): `updater.check()` fetches, BUFFERS, and JSON-parses the whole feed body
++    // BEFORE we ever see `raw_json` — so `verify_manifest`'s 64 KiB manifest-field cap does NOT bound
++    // the feed response itself. A feed writer returning a multi-GB `notes`/`platforms` blob is an
++    // availability-only memory-DoS at check() time. Closing it needs an upstream feed-response byte
++    // limit before JSON parsing, which `tauri-plugin-updater` does not expose (same class as the
++    // artifact-buffer residual #345). Integrity is unaffected: an oversized feed still cannot forge a
++    // valid signed manifest. Documented here so it isn't mistaken for covered by the manifest cap.
+     let update = match updater.check().await {
+         Ok(Some(update)) => update,
+         Ok(None) => {
+@@ -36,9 +226,14 @@ pub async fn check_for_update(
+         }
+     };
+ 
+-    let new_version = update.version.clone();
+-    let current_version = env!("CARGO_PKG_VERSION").to_string();
+-    tracing::info!(current = %current_version, new = %new_version, "Update available");
++    tracing::info!(
++        current = env!("CARGO_PKG_VERSION"),
++        new = %update.version,
++        "Update advertised (pre-verification)"
++    );
++
++    // F-004: verify the signed manifest + enforce the version floor BEFORE acting on the update.
++    let verified = verify_and_gate(update)?;
+ 
+     let auto_update_pref = { config_state.read().auto_update };
+     tracing::info!(?auto_update_pref, "Auto-update preference");
+@@ -46,13 +241,13 @@ pub async fn check_for_update(
+     match auto_update_pref {
+         Some(true) => {
+             tracing::info!("Auto-update enabled, performing update");
+-            perform_update(app, update).await;
++            perform_update(app, verified).await;
+             None
+         }
+         _ => {
+-            // None (never asked) or Some(false) (manual) — return the update
+-            // so the caller can show a prompt or add a tray menu item
+-            Some(update)
++            // None (never asked) or Some(false) (manual) — return the verified update
++            // so the caller can show a prompt or add a tray menu item.
++            Some(verified)
+         }
+     }
+ }
+@@ -61,65 +256,68 @@ pub async fn check_for_update(
+ /// of MB; 500 MB is generous headroom that still stops a multi-GB memory blow-up.
+ const MAX_UPDATE_BYTES: u64 = 500 * 1024 * 1024;
+ 
+-/// Pure size lookup over a `latest.json` value: the `size` of the `platforms.*` entry whose `url`
+-/// matches `download_url`. `None` if absent. Split out from [`advertised_update_size`] so it can be
+-/// unit-tested without constructing a plugin `Update` (which has private fields).
+-fn size_from_feed(raw_json: &serde_json::Value, download_url: &str) -> Option<u64> {
+-    raw_json
+-        .get("platforms")?
+-        .as_object()?
+-        .values()
+-        .find(|p| p.get("url").and_then(|u| u.as_str()) == Some(download_url))
+-        .and_then(|p| p.get("size").and_then(serde_json::Value::as_u64))
+-}
++/// Download, verify Ed25519 signature, install, and restart the app. Accepts ONLY a
++/// [`VerifiedUpdate`] — an artifact that has already cleared both F-004 layers.
++pub async fn perform_update(app: &AppHandle, verified: VerifiedUpdate) {
++    let VerifiedUpdate {
++        update,
++        version,
++        signed_size,
++    } = verified;
++    tracing::info!(version = %version, signed_size, "Downloading verified update");
+ 
+-/// The advertised artifact size for THIS platform, read from the feed JSON (`latest.json`) by matching
+-/// the download URL. `None` if the feed omits `size` (older feeds). The feed is the same JSON the
+-/// plugin will signature-check, so a feed declaring a huge size is rejected before the plugin buffers
+-/// a single byte.
+-fn advertised_update_size(update: &tauri_plugin_updater::Update) -> Option<u64> {
+-    size_from_feed(&update.raw_json, update.download_url.as_str())
+-}
++    // B2: hold the cross-process updater lock across the whole download+install so no other instance
++    // can race the floor or install concurrently. If another instance is mid-update, bow out (the
++    // poller retries). Held until this fn returns / the process restarts.
++    let _txn = match acquire_updater_lock() {
++        Some(f) => f,
++        None => return,
++    };
+ 
+-/// Download, verify Ed25519 signature, install, and restart the app.
+-pub async fn perform_update(app: &AppHandle, update: tauri_plugin_updater::Update) {
+-    tracing::info!(version = %update.version, "Downloading update");
++    // Parse our own version once; a parse failure is fail-closed (can't safely gate → abort). Needed
++    // both for the install-time re-check and for recording the pending version after install.
++    let current = match Version::parse(env!("CARGO_PKG_VERSION")) {
++        Ok(v) => v,
++        Err(e) => {
++            tracing::error!("SECURITY: own version is not SemVer ({e}); aborting install");
++            return;
++        }
++    };
++
++    // TOCTOU: the floor/pending may have advanced since check_for_update (another instance committed a
++    // launch or recorded a pending install). Re-run the SAME fail-closed Layer B gate under the lock,
++    // right before committing to the download — a Corrupt/raced state now aborts the install.
++    if let Err(reason) = layer_b_gate(&version, &current) {
++        tracing::error!(
++            candidate = %version,
++            "SECURITY: {reason} at install time (raced by another instance); aborting"
++        );
++        return;
++    }
+ 
+     // SEC-03: pre-flight size cap. The plugin buffers the WHOLE artifact into memory before it
+-    // verifies the signature, and its progress callback cannot abort that loop — so a tampered feed
+-    // pointing at a multi-GB blob is a memory-DoS. Reject up front when the feed's advertised `size`
+-    // exceeds the ceiling, BEFORE `download()`. This keeps the plugin's verified download path intact
+-    // (no hand-rolled crypto). Availability-only: minisign still rejects tampered *bytes*; this just
+-    // stops the buffer blow-up.
++    // verifies the artifact signature, and its progress callback cannot abort that loop — so a huge
++    // blob is a memory-DoS. Reject up front when the size exceeds the ceiling, BEFORE `download()`.
++    // Unlike the old feed-derived value, `signed_size` comes from the F-004 signed envelope (Layer A
++    // checked outer==envelope), so a feed can no longer OMIT it or LIE about it to slip the cap — the
++    // two ways the previous best-effort cap could be bypassed without the signing key are both closed.
+     //
+-    // Residual (codex post-impl M2 + re-audit, tracked #345): this cap is best-effort and does NOT
+-    // stop a *malicious* feed. Be honest about why — for the *availability* property the signature
+-    // check is NOT the control, because the plugin buffers BEFORE it verifies. The advertised `size`
+-    // lives in the same `raw_json` the (attacker-controlled) feed supplies, so it is NOT an independent
+-    // authority: an attacker who can tamper the manifest defeats the cap either by OMITTING `size` (the
+-    // `None` arm proceeds) OR by declaring a small false `size` while pointing `url` at a huge blob —
+-    // both re-open the memory-DoS WITHOUT the signing key. So "make `size` mandatory" is INSUFFICIENT
+-    // (a present size can lie). The only real fix is an independent bound on bytes actually read in the
+-    // download path (a streaming abort cap), which `tauri-plugin-updater` does not expose — its
+-    // `download()` buffers into an unbounded Vec with a non-aborting callback. Closing it needs either
+-    // upstream plugin support for a streaming cap or replacing the verified download path — and the
+-    // self-managed reqwest+minisign rewrite was rejected in audit R3 (it would make a hand-rolled
+-    // verify the sole authenticity control = signature-bypass risk). Hence deferred, not "flip a flag":
+-    // availability-only, requires feed compromise, integrity still enforced by minisign on the bytes.
+-    match advertised_update_size(&update) {
+-        Some(size) if size > MAX_UPDATE_BYTES => {
+-            tracing::error!(
+-                size,
+-                max = MAX_UPDATE_BYTES,
+-                "Update artifact exceeds the size cap; refusing to download"
+-            );
+-            return;
+-        }
+-        Some(size) => tracing::info!(size, "Update artifact size within cap"),
+-        None => {
+-            tracing::warn!("Update feed omits artifact size; size cap not enforced for this update")
+-        }
++    // Residual (tracked #345): a *malicious* feed that declares a small (correctly signed) size but
++    // serves a genuinely larger blob at that url still forces the plugin to buffer those bytes before
++    // its artifact-signature check rejects them — an availability-only memory-DoS that needs an
++    // upstream streaming abort cap the plugin does not expose (`download()` buffers into an unbounded
++    // Vec with a non-aborting callback). Integrity is unaffected: minisign still rejects the tampered
++    // bytes. The self-managed reqwest+minisign rewrite that could bound bytes-read was rejected in
++    // audit R3 (it would make a hand-rolled verify the sole authenticity control). Hence deferred.
++    if signed_size > MAX_UPDATE_BYTES {
++        tracing::error!(
++            size = signed_size,
++            max = MAX_UPDATE_BYTES,
++            "Update artifact exceeds the size cap; refusing to download"
++        );
++        return;
+     }
++    tracing::info!(size = signed_size, "Signed artifact size within cap");
+ 
+     // Download first (separate from install) so crash-recovery stays armed through the whole
+     // download/verify span — a mid-download crash is still recovered.
+@@ -143,6 +341,35 @@ pub async fn perform_update(app: &AppHandle, update: tauri_plugin_updater::Updat
+         }
+     };
+ 
++    // Defense in depth: the downloaded byte count must equal the SIGNED size. The plugin's own
++    // minisign check already rejects tampered bytes; this additionally rejects a length mismatch
++    // before install. Crash-recovery is still armed here (disarm happens below), so a plain return
++    // is safe.
++    if bytes.len() as u64 != signed_size {
++        tracing::error!(
++            got = bytes.len(),
++            expected = signed_size,
++            "SECURITY: downloaded artifact size does not match the signed size; refusing to install"
++        );
++        return;
++    }
++
++    // codex r3 #5: capture the autostart state ONCE, BEFORE disarming, and drive every re-arm decision
++    // off this value. Re-reading it later (in the guard) could error independently and then wrongly arm
++    // recovery while autostart is actually OFF. If THIS read errors we can't tell → assume enabled: we
++    // are about to disarm, so erring toward "restore it" is the safe default (missing a re-arm leaves the
++    // app unrecoverable; a spurious one is a harmless idempotent write).
++    #[cfg(target_os = "windows")]
++    let was_recovery_enabled = {
++        use tauri_plugin_autostart::ManagerExt;
++        app.autolaunch().is_enabled().unwrap_or_else(|e| {
++            tracing::warn!(
++                "pre-install: autostart state unreadable ({e}); assuming enabled for re-arm safety"
++            );
++            true
++        })
++    };
++
+     // Windows: disarm the always-armed repeating crash-recovery task right before install. A
+     // tick during NSIS file mutation could spawn the exe mid-update (lock the file being
+     // replaced / launch a half-written binary). If we CANNOT verify the task is gone, do NOT
+@@ -156,7 +383,7 @@ pub async fn perform_update(app: &AppHandle, update: tauri_plugin_updater::Updat
+         // The app keeps running on the current version, and disarm may have PARTIALLY succeeded
+         // (/Delete worked but /Query couldn't confirm), so recovery could now be off. Restore it
+         // before bailing out — every path that leaves the app running must end armed.
+-        rearm_crash_recovery_if_enabled(app);
++        rearm_crash_recovery_if_enabled(was_recovery_enabled);
+         return;
+     }
+ 
+@@ -165,31 +392,68 @@ pub async fn perform_update(app: &AppHandle, update: tauri_plugin_updater::Updat
+     // app.restart() never returns (Drop would never fire there). The old per-arm `// must rearm`
+     // comments are now structurally enforced by the guard.
+     #[cfg(target_os = "windows")]
+-    let mut recovery_guard = CrashRecoveryGuard::new(|| rearm_crash_recovery_if_enabled(app));
++    let mut recovery_guard =
++        CrashRecoveryGuard::new(move || rearm_crash_recovery_if_enabled(was_recovery_enabled));
++
++    // H1 / codex #5: record the install INTENT under the lock BEFORE install(), and FAIL CLOSED if it
++    // cannot be recorded. This raises the anti-downgrade floor to `version` for any instance that
++    // acquires the lock next, so a racing older instance cannot install a LOWER (still-signed) version
++    // and regress this build. It MUST precede install(): on Windows tauri-plugin-updater's install()
++    // dispatches the external NSIS/MSI installer and `std::process::exit(0)`s — it never returns — so
++    // the old Ok-branch placement recorded NOTHING on Windows, leaving the downgrade window wide open
++    // there. Because `candidate_allowed` permits re-attempting the EXACT recorded version, recording
++    // before install does not poison the version on a failed install. On Windows the recovery_guard
++    // already exists here, so an abort below re-arms crash recovery via its Drop.
++    match updater_state_path() {
++        Some(path) => {
++            if let Err(e) = updater_state::record_pending(&path, &current, &version) {
++                tracing::error!(
++                    candidate = %version,
++                    "SECURITY: failed to record the install intent before install ({e}); aborting to avoid a downgrade window"
++                );
++                return;
++            }
++        }
++        None => {
++            tracing::error!(
++                "SECURITY: cannot resolve the updater-state path; aborting install (no rollback floor)"
++            );
++            return;
++        }
++    }
+ 
+     match update.install(bytes) {
+         Ok(()) => {
+-            // IgnoreNew + the exit-0-if-healthy guard absorb any brief double-launch with the
+-            // restarted build.
++            // Windows never reaches here — install() dispatched the installer and exited the process.
++            // macOS/Linux: the intent is already recorded above; the restarted build commits its floor
++            // and clears the intent on a healthy launch. IgnoreNew + the exit-0-if-healthy guard absorb
++            // any brief double-launch with the restarted build.
+             #[cfg(target_os = "windows")]
+             recovery_guard.rearm_now();
+             tracing::info!("Update installed, restarting");
+             app.restart();
+         }
+         Err(e) => {
++            // Intent stays recorded — a returned Err is not proof that nothing was mutated (codex #5),
++            // and candidate_allowed lets this exact version be retried, so keeping it can't poison the
++            // version. recovery_guard's Drop re-arms crash recovery on return (Windows, if it was armed).
+             tracing::error!("Update install failed: {e}");
+-            // The app keeps running; recovery_guard's Drop re-arms on return (Windows, only if armed).
+         }
+     }
+ }
+ 
+-/// Re-arm the Windows crash-recovery task iff it should be armed (autostart on). Idempotent —
+-/// `enable_crash_recovery` overwrites any existing task.
++/// Re-arm the Windows crash-recovery task iff it was armed before this update disarmed it. The
++/// decision uses `was_enabled` — the autostart state captured ONCE before the disarm (codex r3 #5) —
++/// NOT a fresh read, so a transient read error can neither silently skip a needed re-arm (r2 #5) nor
++/// spuriously arm recovery while autostart is off (r3 #5). Idempotent: `enable_crash_recovery`
++/// overwrites any existing task.
+ #[cfg(target_os = "windows")]
+-fn rearm_crash_recovery_if_enabled(app: &AppHandle) {
+-    use tauri_plugin_autostart::ManagerExt;
+-    if app.autolaunch().is_enabled().unwrap_or(false) {
+-        crate::crash_recovery::enable_crash_recovery();
++fn rearm_crash_recovery_if_enabled(was_enabled: bool) {
++    if was_enabled {
++        // C8 (D12): log-and-continue — a post-update rearm hiccup must not abort, but is never swallowed.
++        if let Err(e) = crate::crash_recovery::enable_crash_recovery() {
++            tracing::warn!("post-update crash-recovery rearm failed: {e}");
++        }
+     }
+ }
+ 
+@@ -239,48 +503,18 @@ impl<F: FnMut()> Drop for CrashRecoveryGuard<F> {
+ 
+ #[cfg(test)]
+ mod tests {
+-    use super::{size_from_feed, CrashRecoveryGuard};
+-    use serde_json::json;
+-
+-    fn feed(aarch64_size: Option<u64>) -> serde_json::Value {
+-        let mut plat = json!({ "signature": "sig", "url": "https://x.test/app-aarch64.tar.gz" });
+-        if let Some(s) = aarch64_size {
+-            plat["size"] = json!(s);
+-        }
+-        json!({
+-            "version": "1.0.5",
+-            "platforms": {
+-                "darwin-aarch64": plat,
+-                "linux-x86_64": { "signature": "s2", "url": "https://x.test/app-linux", "size": 123 },
+-            }
+-        })
+-    }
+-
+-    #[test]
+-    fn size_from_feed_matches_url() {
+-        let f = feed(Some(42_000_000));
+-        assert_eq!(
+-            size_from_feed(&f, "https://x.test/app-aarch64.tar.gz"),
+-            Some(42_000_000)
+-        );
+-        // A different platform's URL resolves to that platform's size.
+-        assert_eq!(size_from_feed(&f, "https://x.test/app-linux"), Some(123));
+-    }
++    use super::{updater_pubkey, CrashRecoveryGuard};
+ 
+     #[test]
+-    fn size_from_feed_none_when_absent_or_unmatched() {
+-        // Matched platform omits size → None (older feed; cap not enforced for it).
+-        assert_eq!(
+-            size_from_feed(&feed(None), "https://x.test/app-aarch64.tar.gz"),
+-            None
+-        );
+-        // URL matches no platform → None.
+-        assert_eq!(size_from_feed(&feed(Some(10)), "https://x.test/nope"), None);
+-        // No platforms object → None.
+-        assert_eq!(
+-            size_from_feed(&json!({ "version": "1" }), "https://x.test/x"),
+-            None
+-        );
++    fn updater_pubkey_matches_config() {
++        // The pinned key Layer A verifies against MUST be exactly the plugin's configured pubkey.
++        // Read tauri.conf.json independently and assert equality (catches a future edit that changes
++        // one but not the other).
++        let conf: serde_json::Value =
++            serde_json::from_str(include_str!("../tauri.conf.json")).unwrap();
++        let expected = conf["plugins"]["updater"]["pubkey"].as_str().unwrap();
++        assert_eq!(updater_pubkey(), expected);
++        assert!(!updater_pubkey().is_empty());
+     }
+ 
+     // q7e3-F-10 characterization (test-FIRST): the crash-recovery guard's rearm-before-restart +

--- a/implementations-plan/security-hardening/full-audit-2026-07-24/chunks/E-tauri-frontend.diff
+++ b/implementations-plan/security-hardening/full-audit-2026-07-24/chunks/E-tauri-frontend.diff
@@ -1,0 +1,1536 @@
+diff --git a/packages/accelerator/src-tauri/build.rs b/packages/accelerator/src-tauri/build.rs
+index 43dac56..e2047c3 100644
+--- a/packages/accelerator/src-tauri/build.rs
++++ b/packages/accelerator/src-tauri/build.rs
+@@ -1,4 +1,112 @@
++/// SHA-256 over raw bytes → lowercase hex. MUST match `scripts/build-frontend.ts` so the guard compares
++/// like-for-like (GATE-3 codex: strong enough to detect a swapped OUTPUT bundle, not just staleness).
++fn sha256_hex(bytes: &[u8]) -> String {
++    use sha2::{Digest, Sha256};
++    let mut h = Sha256::new();
++    h.update(bytes);
++    hex::encode(h.finalize())
++}
++
++/// Read `path`, compare its SHA-256 to the manifest entry `key`; panic (with `hint`) on missing/mismatch.
++fn verify_hash(
++    path: &str,
++    key: &str,
++    recorded: &serde_json::Map<String, serde_json::Value>,
++    hint: &str,
++) {
++    println!("cargo:rerun-if-changed={path}");
++    let bytes = std::fs::read(path).unwrap_or_else(|e| {
++        panic!("F-012: cannot read `{path}` (manifest key `{key}`): {e} — {hint}")
++    });
++    let expected = recorded
++        .get(key)
++        .and_then(|v| v.as_str())
++        .unwrap_or_else(|| {
++            panic!("F-012: `{key}` missing from the bundle manifest (STALE) — {hint}")
++        });
++    if sha256_hex(&bytes) != expected {
++        panic!("F-012: `{path}` does not match the bundle manifest (`{key}` STALE or SWAPPED) — {hint}");
++    }
++}
++
++/// F-012: the popup frontend ships as gitignored `frontend/assets/*.js` bundled from `frontend-src/` by
++/// `bun run frontend:build`. Those bundles are trusted by `script-src 'self'`, so a Rust build must NEVER
++/// silently embed HTML pointing at MISSING, STALE, or SWAPPED bundles. This fails the build unless the
++/// current sources, the dependency-surface files, AND the emitted bundles all match `.build-manifest.json`.
++fn verify_frontend_bundles() {
++    println!("cargo:rerun-if-changed=frontend-src");
++    println!("cargo:rerun-if-changed=frontend/assets/.build-manifest.json");
++
++    let hint = "run `bun run --cwd packages/accelerator frontend:build` before building the Tauri app \
++                (the bundles are gitignored; tauri's beforeDev/beforeBuildCommand does this automatically)";
++
++    let manifest_path = "frontend/assets/.build-manifest.json";
++    let manifest_raw = std::fs::read_to_string(manifest_path)
++        .unwrap_or_else(|e| panic!("F-012: cannot read {manifest_path}: {e} — {hint}"));
++    let manifest: serde_json::Value = serde_json::from_str(&manifest_raw)
++        .unwrap_or_else(|e| panic!("F-012: {manifest_path} is not valid JSON: {e} — {hint}"));
++    if manifest.get("algo").and_then(|v| v.as_str()) != Some("sha256") {
++        panic!("F-012: {manifest_path} algo is not sha256 — {hint}");
++    }
++    let inputs = manifest
++        .get("inputs")
++        .and_then(|v| v.as_object())
++        .unwrap_or_else(|| panic!("F-012: {manifest_path} has no `inputs` object — {hint}"));
++    let outputs = manifest
++        .get("outputs")
++        .and_then(|v| v.as_object())
++        .unwrap_or_else(|| panic!("F-012: {manifest_path} has no `outputs` object — {hint}"));
++
++    // Emitted bundles: exact set + content match (catches a post-build swap).
++    let bundles = ["authorize.js", "settings.js", "update-prompt.js"];
++    if outputs.len() != bundles.len() {
++        panic!(
++            "F-012: manifest lists {} output bundles, expected {} — {hint}",
++            outputs.len(),
++            bundles.len()
++        );
++    }
++    for bundle in bundles {
++        verify_hash(&format!("frontend/assets/{bundle}"), bundle, outputs, hint);
++    }
++
++    // Dependency-surface inputs (a @tauri-apps/api bump must invalidate the bundles).
++    verify_hash("../package.json", "package.json", inputs, hint);
++    verify_hash("../../../bun.lock", "bun.lock", inputs, hint);
++
++    // Every current frontend source must match; the manifest must reference no phantom sources.
++    for entry in std::fs::read_dir("frontend-src")
++        .unwrap_or_else(|e| panic!("F-012: cannot read frontend-src/: {e}"))
++    {
++        let path = entry.expect("dir entry").path();
++        if path.extension().and_then(|e| e.to_str()) != Some("js") {
++            continue;
++        }
++        let name = path.file_name().and_then(|n| n.to_str()).unwrap();
++        verify_hash(
++            &format!("frontend-src/{name}"),
++            &format!("frontend-src/{name}"),
++            inputs,
++            hint,
++        );
++    }
++    let src_keys = inputs
++        .keys()
++        .filter(|k| k.starts_with("frontend-src/"))
++        .count();
++    let on_disk = std::fs::read_dir("frontend-src")
++        .unwrap()
++        .filter_map(|e| e.ok())
++        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("js"))
++        .count();
++    if src_keys != on_disk {
++        panic!("F-012: manifest lists {src_keys} frontend sources but frontend-src/ has {on_disk} — {hint}");
++    }
++}
++
+ fn main() {
++    verify_frontend_bundles();
++
+     // Re-run when AZTEC_VERSION changes (or is created/deleted)
+     println!("cargo:rerun-if-changed=AZTEC_VERSION");
+ 
+@@ -18,5 +126,32 @@ fn main() {
+     serde_json::from_str::<serde_json::Value>(&vs_contents)
+         .unwrap_or_else(|e| panic!("verified-sites.json is not valid JSON: {e}"));
+ 
+-    tauri_build::build()
++    // F-012: declare the app's IPC command surface. Tauri only enforces the per-window ACL for app-local
++    // commands when an app manifest exists (see tauri `webview/mod.rs`: the invoke gate is
++    // `plugin_command || has_app_acl_manifest`). Declaring these commands sets `has_app_acl` true, which
++    // flips every one of them from framework-default-allow to per-window default-DENY: a window whose
++    // capability does not grant `allow-<command>` is rejected before the handler runs. This is ALL-OR-
++    // NOTHING — every command below MUST be granted by exactly the windows that use it (see
++    // capabilities/*.json), or that flow breaks. Keep this list == the generate_handler! set in main.rs
++    // (the scripts/tauri-trust-boundary.test.ts set-equality guard fails CI on drift).
++    let commands: &[&str] = &[
++        "get_config",
++        "get_autostart_enabled",
++        "set_autostart",
++        "set_speed",
++        "remove_approved_origin",
++        "get_system_info",
++        "get_verified_info",
++        "get_pending_auth",
++        "respond_auth",
++        "enable_safari_support",
++        "disable_safari_support",
++        "set_auto_update",
++        "respond_update_prompt",
++    ];
++    tauri_build::try_build(
++        tauri_build::Attributes::new()
++            .app_manifest(tauri_build::AppManifest::new().commands(commands)),
++    )
++    .expect("failed to run tauri-build");
+ }
+diff --git a/packages/accelerator/src-tauri/capabilities/authorize.json b/packages/accelerator/src-tauri/capabilities/authorize.json
+new file mode 100644
+index 0000000..6a51c18
+--- /dev/null
++++ b/packages/accelerator/src-tauri/capabilities/authorize.json
+@@ -0,0 +1,13 @@
++{
++  "$schema": "../gen/schemas/desktop-schema.json",
++  "identifier": "authorize",
++  "description": "F-012: the authorization popup (label auth-<hash>) may invoke ONLY the two commands its flow needs — reading the verified-site badge and returning the user's decision. It explicitly canNOT reach settings mutators (remove_approved_origin, enable_safari_support) or the updater, which the ungated pre-F-012 surface allowed.",
++  "local": true,
++  "platforms": ["linux", "macOS", "windows"],
++  "windows": ["auth-*"],
++  "permissions": [
++    "allow-get-verified-info",
++    "allow-respond-auth",
++    "allow-get-pending-auth"
++  ]
++}
+diff --git a/packages/accelerator/src-tauri/capabilities/default.json b/packages/accelerator/src-tauri/capabilities/default.json
+deleted file mode 100644
+index efe7ff9..0000000
+--- a/packages/accelerator/src-tauri/capabilities/default.json
++++ /dev/null
+@@ -1,7 +0,0 @@
+-{
+-  "$schema": "../gen/schemas/desktop-schema.json",
+-  "identifier": "default",
+-  "description": "Default capabilities for the accelerator",
+-  "platforms": ["linux", "macOS", "windows"],
+-  "permissions": ["core:default", "autostart:default", "updater:default", "process:default"]
+-}
+diff --git a/packages/accelerator/src-tauri/capabilities/settings.json b/packages/accelerator/src-tauri/capabilities/settings.json
+new file mode 100644
+index 0000000..1c8bb32
+--- /dev/null
++++ b/packages/accelerator/src-tauri/capabilities/settings.json
+@@ -0,0 +1,19 @@
++{
++  "$schema": "../gen/schemas/desktop-schema.json",
++  "identifier": "settings",
++  "description": "F-012: the Settings window may invoke ONLY the settings commands. No core:default / autostart / process / updater plugin grants — the frontend calls Rust wrappers that drive plugins natively, and the window is closed from Rust, so it needs no plugin/core JS API.",
++  "local": true,
++  "platforms": ["linux", "macOS", "windows"],
++  "windows": ["settings"],
++  "permissions": [
++    "allow-get-config",
++    "allow-get-autostart-enabled",
++    "allow-get-system-info",
++    "allow-set-autostart",
++    "allow-set-auto-update",
++    "allow-set-speed",
++    "allow-enable-safari-support",
++    "allow-disable-safari-support",
++    "allow-remove-approved-origin"
++  ]
++}
+diff --git a/packages/accelerator/src-tauri/capabilities/update-prompt.json b/packages/accelerator/src-tauri/capabilities/update-prompt.json
+new file mode 100644
+index 0000000..00110e5
+--- /dev/null
++++ b/packages/accelerator/src-tauri/capabilities/update-prompt.json
+@@ -0,0 +1,9 @@
++{
++  "$schema": "../gen/schemas/desktop-schema.json",
++  "identifier": "update-prompt",
++  "description": "F-012: the update prompt (label update-prompt) may invoke ONLY respond_update_prompt. Preserves F-004: it has NO updater:default / process grants — updates flow through the Rust check/perform path that verifies the signed manifest + monotonic floor.",
++  "local": true,
++  "platforms": ["linux", "macOS", "windows"],
++  "windows": ["update-prompt"],
++  "permissions": ["allow-respond-update-prompt"]
++}
+diff --git a/packages/accelerator/src-tauri/frontend-src/authorize.js b/packages/accelerator/src-tauri/frontend-src/authorize.js
+new file mode 100644
+index 0000000..abe6f2d
+--- /dev/null
++++ b/packages/accelerator/src-tauri/frontend-src/authorize.js
+@@ -0,0 +1,120 @@
++import { invoke, isClickGuardActive, showErrorHint, wireButton } from "./bridge.js";
++
++const params = new URLSearchParams(window.location.search);
++// SEC-06: the opaque request id the server issued for this popup — the ONLY value we trust from the URL.
++// C9 (D8): the ORIGIN is NOT taken from the query param; it is fetched from the server (get_pending_auth)
++// so the popup displays exactly what respond_auth will grant. The query `origin` is display-only legacy.
++const requestId = params.get("requestId") || "";
++
++const originEl = document.getElementById("origin");
++const allowBtn = document.getElementById("allow");
++const denyBtn = document.getElementById("deny");
++const rememberEl = document.getElementById("remember");
++
++let serverOrigin = null; // authoritative origin, once get_pending_auth answers
++let badgeShownFor = null; // origin we've already rendered the verified badge for
++let decided = false; // latched ONLY after respond_auth SUCCEEDS — then the window is closing
++let responding = false; // a respond_auth call is in flight — don't let the poll fight the button state
++let poll = null; // active setTimeout id (self-scheduling; never overlaps)
++
++// Never render the query-param origin as authoritative: show a placeholder + disabled controls until the
++// server answers.
++originEl.textContent = "…";
++// codex r2 #1: defensively CLEAR the checkbox on init. The HTML ships it `disabled` so a pre-JS click
++// can't check it, but if anything (autofill/restore) left it checked, `disabled` alone wouldn't uncheck
++// it — and Allow reads `.checked`. Reset before enabling any control.
++rememberEl.checked = false;
++setControlsEnabled(false);
++
++// C9 (audit fix): the Remember checkbox is a consequential action too — a click-steal can pre-arm
++// persistent authorization before the user later Allows. It is disabled while inactive (below) AND its
++// toggle is refused within the click-steal guard window, exactly like Allow/Deny.
++rememberEl.addEventListener("click", (e) => {
++  if (isClickGuardActive()) e.preventDefault();
++});
++
++function setControlsEnabled(on) {
++  // Don't fight the button state while a decision is in flight or already made.
++  if (decided || responding) return;
++  allowBtn.disabled = !on;
++  denyBtn.disabled = !on;
++  rememberEl.disabled = !on; // C9 (audit fix): gate Remember on active-state too
++}
++
++function renderVerifiedBadge(origin) {
++  if (badgeShownFor === origin) return;
++  badgeShownFor = origin;
++  // C9 (D8): the verified badge is keyed on the SERVER origin, not the query param.
++  invoke("get_verified_info", { origin })
++    .then((info) => {
++      if (!info) return;
++      const recognized = document.getElementById("recognized");
++      recognized.querySelector(".recognized-name").textContent = info.display_name;
++      recognized.hidden = false;
++    })
++    .catch(() => {});
++}
++
++async function refreshPending() {
++  if (decided || responding) return;
++  let info;
++  try {
++    info = await invoke("get_pending_auth", { requestId });
++  } catch {
++    // A2: transient IPC error — keep controls disabled and let the user retry/close.
++    setControlsEnabled(false);
++    showErrorHint(allowBtn, "Couldn't reach the accelerator — retrying…");
++    return;
++  }
++  if (decided || responding) return; // state changed while awaiting — drop this (possibly stale) result
++  if (!info) {
++    // A2: None ⇒ the request is already resolved/expired (this popup is stale) ⇒ close it.
++    stopPolling();
++    window.close();
++    return;
++  }
++  serverOrigin = info.origin;
++  originEl.textContent = info.origin;
++  renderVerifiedBadge(info.origin);
++  // Only the ACTIVE popup is actionable (the server enforces this too via resolve_active; this merely
++  // reflects it so a queued popup's controls are visibly disabled until it is promoted).
++  setControlsEnabled(info.active);
++}
++
++function stopPolling() {
++  if (poll !== null) {
++    clearTimeout(poll);
++    poll = null;
++  }
++}
++
++// C9 (audit fix): self-scheduling poll (setTimeout, not setInterval) so calls NEVER overlap — a delayed
++// older `active:false` can no longer overwrite a newer `active:true`. Re-polls so a QUEUED popup enables
++// when promoted (and closes if the request went away). Stops on decision/close.
++async function pollLoop() {
++  await refreshPending();
++  if (decided || poll === null) return;
++  poll = setTimeout(pollLoop, 1000);
++}
++
++poll = setTimeout(pollLoop, 0);
++window.addEventListener("beforeunload", stopPolling);
++
++async function respond(allowed) {
++  // C9 (audit fix): do NOT latch `decided`/stop polling until respond_auth SUCCEEDS. On failure the poll
++  // must keep running so a resolved/expired request still closes and a promoted one stays truthful, rather
++  // than the popup being left falsely actionable with a stale "try again".
++  responding = true;
++  const remember = rememberEl.checked;
++  try {
++    // Send the server-authoritative origin (respond_auth treats it as diagnostics-only, but keep it honest).
++    await invoke("respond_auth", { requestId, origin: serverOrigin ?? "", allowed, remember });
++    decided = true; // success — the Rust side is closing this window
++    stopPolling();
++  } finally {
++    responding = false;
++  }
++}
++
++wireButton("allow", { disableAlso: "deny", guard: true, onClick: () => respond(true) });
++wireButton("deny", { disableAlso: "allow", guard: true, onClick: () => respond(false) });
+diff --git a/packages/accelerator/src-tauri/frontend-src/bridge.js b/packages/accelerator/src-tauri/frontend-src/bridge.js
+new file mode 100644
+index 0000000..ebd5b6a
+--- /dev/null
++++ b/packages/accelerator/src-tauri/frontend-src/bridge.js
+@@ -0,0 +1,119 @@
++/**
++ * Shared utilities for Tauri IPC in the accelerator frontend pages.
++ *
++ * F-012: this is an ESM module bundled (per page) into `frontend/assets/*.js` by
++ * `scripts/build-frontend.ts`. `invoke` comes from the official `@tauri-apps/api/core`
++ * package — NOT `window.__TAURI__` — so the app runs with `withGlobalTauri: false`
++ * (the global back-door is removed; only `window.__TAURI_INTERNALS__` remains, which
++ * the API's `invoke` delegates to). Loaded via a single `<script type="module">` per page.
++ */
++
++import { invoke } from "@tauri-apps/api/core";
++
++export { invoke };
++
++// C9 (A / D9): click-steal guard. A button wired with `guard: true` ignores activation for GUARD_MS after
++// the window last gained focus — reset on EVERY native focus/show, not just first paint — so a popup
++// popped under the cursor (or promoted into the active slot) can't catch a click meant for another window.
++// Gating at click ENTRY also covers keyboard Enter/Space (which dispatch a click event).
++const DEFAULT_GUARD_MS = 700;
++function guardMs() {
++  // Overridable ONLY for tests (Playwright mock sets it to 0). Production never sets this global, so the
++  // real 700 ms guard always applies. Read dynamically so an init-script override takes effect.
++  return typeof window !== "undefined" && typeof window.__CLICK_GUARD_MS__ === "number"
++    ? window.__CLICK_GUARD_MS__
++    : DEFAULT_GUARD_MS;
++}
++function now() {
++  return typeof performance !== "undefined" ? performance.now() : Date.now();
++}
++let inputArmedAt = now();
++function rearmInputGuard() {
++  inputArmedAt = now();
++}
++if (typeof window !== "undefined") {
++  window.addEventListener("focus", rearmInputGuard);
++  window.addEventListener("pageshow", rearmInputGuard);
++}
++// Exported so consequential non-button controls (e.g. the authorize "Remember" checkbox) can gate on the
++// same click-steal window — Allow/Deny aren't the only stealable actions.
++export function isClickGuardActive() {
++  return now() - inputArmedAt < guardMs();
++}
++
++/**
++ * Show a brief error hint near a control. Disappears after 3 seconds.
++ * @param {HTMLElement} anchor — element to show the error near
++ * @param {string} message
++ */
++export function showErrorHint(anchor, message) {
++  // Remove any existing hint on this anchor
++  const existing = anchor.parentElement?.querySelector(".error-hint");
++  if (existing) existing.remove();
++
++  const hint = document.createElement("span");
++  hint.className = "error-hint";
++  hint.textContent = message;
++  anchor.closest(".row, .speed-section, .popup-container")?.appendChild(hint);
++  setTimeout(() => hint.remove(), 3000);
++}
++
++/**
++ * Wire a checkbox toggle to a Tauri command.
++ * Disables during operation, reverts on error with visible feedback.
++ *
++ * @param {string} id — element ID of the checkbox input
++ * @param {(checked: boolean) => {cmd: string, args?: object}} handler
++ *   Function that returns the command name and args based on checked state.
++ */
++export function wireToggle(id, handler) {
++  document.getElementById(id).addEventListener("change", (e) => {
++    const el = e.target;
++    el.disabled = true;
++    const { cmd, args } = handler(el.checked);
++    invoke(cmd, args)
++      .catch((err) => {
++        el.checked = !el.checked;
++        console.error(`Failed to invoke ${cmd}:`, err);
++        showErrorHint(el, "Failed — try again");
++      })
++      .finally(() => {
++        el.disabled = false;
++      });
++  });
++}
++
++/**
++ * Wire a button to a Tauri command.
++ * Disables the button (and an optional second button) during operation.
++ *
++ * @param {string} id — element ID of the button
++ * @param {object} opts
++ * @param {string} [opts.disableAlso] — ID of another button to disable during operation
++ * @param {string} [opts.loadingText] — text to show while loading (restores original on error)
++ * @param {boolean} [opts.guard] — apply the click-steal guard (ignore activation within GUARD_MS of focus)
++ * @param {() => Promise<void>} opts.onClick — async handler
++ */
++export function wireButton(id, opts) {
++  const btn = document.getElementById(id);
++  btn.addEventListener("click", async () => {
++    // C9 (A): ignore a click that lands within the guard window after focus (click-steal defense).
++    if (opts.guard && isClickGuardActive()) return;
++    btn.disabled = true;
++    const originalText = btn.textContent;
++    if (opts.loadingText) btn.textContent = opts.loadingText;
++
++    const otherBtn = opts.disableAlso ? document.getElementById(opts.disableAlso) : null;
++    if (otherBtn) otherBtn.disabled = true;
++
++    try {
++      await opts.onClick();
++    } catch (err) {
++      console.error(`Button ${id} action failed:`, err);
++      btn.textContent = originalText;
++      btn.disabled = false;
++      if (otherBtn) otherBtn.disabled = false;
++      showErrorHint(btn, "Failed — try again");
++    }
++  });
++}
+diff --git a/packages/accelerator/src-tauri/frontend-src/settings.js b/packages/accelerator/src-tauri/frontend-src/settings.js
+new file mode 100644
+index 0000000..849a664
+--- /dev/null
++++ b/packages/accelerator/src-tauri/frontend-src/settings.js
+@@ -0,0 +1,127 @@
++import { invoke, showErrorHint, wireToggle } from "./bridge.js";
++
++// CPU count comes from the Rust backend (std::thread::available_parallelism),
++// NOT navigator.hardwareConcurrency which WebKit caps for fingerprinting protection.
++let CPUS = 1;
++
++function threadsForLevel(index) {
++  const fractions = [1 / 4, 3 / 8, 1 / 2, 3 / 4, 1];
++  return Math.max(1, Math.floor(CPUS * fractions[index]));
++}
++
++const SPEED_LEVELS = [
++  { value: "low", label: "Low" },
++  { value: "light", label: "Light" },
++  { value: "balanced", label: "Balanced" },
++  { value: "high", label: "High" },
++  { value: "full", label: "Full" },
++];
++
++function descForLevel(index) {
++  const t = threadsForLevel(index);
++  if (index === 4) return `All ${CPUS} cores. Fastest proving.`;
++  return `${t} of ${CPUS} cores. ${
++    index <= 1 ? "Keeps the system responsive." : "Good balance of speed and usability."
++  }`;
++}
++
++function speedToIndex(speed) {
++  const idx = SPEED_LEVELS.findIndex((l) => l.value === speed);
++  return idx >= 0 ? idx : 4;
++}
++
++function updateSpeedUI(index) {
++  const level = SPEED_LEVELS[index];
++  document.getElementById("speed-label").textContent = level.label;
++  document.getElementById("speed-desc").textContent = descForLevel(index);
++  // F-012: the slider fill was `.style.setProperty("--fill", …)` (a CSSOM mutation — not
++  // CSP-governed, but externalized for consistency). `[data-fill="N"]` maps to `--fill:N%`
++  // in style.css (0-4 → 0/25/50/75/100%), so no inline style is written.
++  document.getElementById("speed").dataset.fill = String(index);
++}
++
++async function loadSettings() {
++  const [config, sysInfo] = await Promise.all([invoke("get_config"), invoke("get_system_info")]);
++
++  CPUS = sysInfo.cpu_count;
++
++  // codex r2 #6 / r3 #6: the autostart switch ships DISABLED (settings.html) and stays disabled until
++  // its true state is CONFIRMED — so an unknown state is never presented as an actionable "off", and a
++  // failure of ANY preceding request (which would throw before this block) still leaves it disabled
++  // rather than at a false default. Fetched independently so a read error doesn't fail the whole panel.
++  const autostartEl = document.getElementById("autostart");
++  try {
++    autostartEl.checked = await invoke("get_autostart_enabled");
++    autostartEl.disabled = false; // known → actionable
++  } catch (e) {
++    console.error("Failed to read autostart state:", e);
++    showErrorHint(autostartEl, "Autostart state unavailable — reopen Settings to retry");
++  }
++  document.getElementById("auto-update").checked = config.auto_update === true;
++
++  if (sysInfo.platform === "macos") {
++    // F-012: was `.style.display = ""`; the row is `hidden` in markup + `.row[hidden]` in CSS.
++    document.getElementById("safari-row").hidden = false;
++    document.getElementById("safari").checked = config.safari_support;
++  }
++
++  const idx = speedToIndex(config.speed || "full");
++  document.getElementById("speed").value = idx;
++  updateSpeedUI(idx);
++
++  renderOrigins(config.approved_origins || []);
++}
++
++function renderOrigins(origins) {
++  const list = document.getElementById("origins");
++  const empty = document.getElementById("origins-empty");
++  list.innerHTML = "";
++
++  // F-012: was `.style.display`; `[hidden]` on `.empty-state` resolves via the UA stylesheet.
++  empty.hidden = origins.length !== 0;
++  if (origins.length === 0) return;
++
++  for (const origin of origins) {
++    const li = document.createElement("li");
++    li.className = "origin-item";
++
++    const span = document.createElement("span");
++    span.textContent = origin;
++
++    const btn = document.createElement("button");
++    btn.textContent = "Remove";
++    // btn.onclick is a DOM property assignment from this (allowed, external) module —
++    // NOT a CSP inline-string handler, so `script-src 'self'` permits it.
++    btn.onclick = async () => {
++      await invoke("remove_approved_origin", { origin });
++      await loadSettings();
++    };
++
++    li.appendChild(span);
++    li.appendChild(btn);
++    list.appendChild(li);
++  }
++}
++
++// Toggles — all use wireToggle from the shared bridge.
++wireToggle("autostart", (checked) => ({ cmd: "set_autostart", args: { enabled: checked } }));
++wireToggle("auto-update", (checked) => ({ cmd: "set_auto_update", args: { enabled: checked } }));
++wireToggle("safari", (checked) => ({
++  cmd: checked ? "enable_safari_support" : "disable_safari_support",
++}));
++
++// Speed slider
++const speedSlider = document.getElementById("speed");
++speedSlider.addEventListener("input", (e) => {
++  updateSpeedUI(Number(e.target.value));
++});
++speedSlider.addEventListener("change", (e) => {
++  const level = SPEED_LEVELS[Number(e.target.value)];
++  invoke("set_speed", { speed: level.value }).catch((err) => {
++    console.error("Failed to set speed:", err);
++    showErrorHint(speedSlider, "Failed to save");
++    loadSettings();
++  });
++});
++
++loadSettings().catch((err) => console.error("Failed to load settings:", err));
+diff --git a/packages/accelerator/src-tauri/frontend-src/update-prompt.js b/packages/accelerator/src-tauri/frontend-src/update-prompt.js
+new file mode 100644
+index 0000000..44d5a05
+--- /dev/null
++++ b/packages/accelerator/src-tauri/frontend-src/update-prompt.js
+@@ -0,0 +1,20 @@
++import { invoke, wireButton } from "./bridge.js";
++
++const params = new URLSearchParams(window.location.search);
++const currentVersion = params.get("current") || "unknown";
++const newVersion = params.get("version") || "unknown";
++document.getElementById("version").textContent = `v${currentVersion}  →  v${newVersion}`;
++
++wireButton("update", {
++  disableAlso: "later",
++  loadingText: "Updating…",
++  onClick: () => {
++    const autoUpdate = document.getElementById("auto-update").checked;
++    return invoke("respond_update_prompt", { action: "update", autoUpdate });
++  },
++});
++
++wireButton("later", {
++  disableAlso: "update",
++  onClick: () => invoke("respond_update_prompt", { action: "later", autoUpdate: false }),
++});
+diff --git a/packages/accelerator/src-tauri/src/commands.rs b/packages/accelerator/src-tauri/src/commands.rs
+index de26822..c9ceb61 100644
+--- a/packages/accelerator/src-tauri/src/commands.rs
++++ b/packages/accelerator/src-tauri/src/commands.rs
+@@ -1,4 +1,4 @@
+-use crate::authorization::{AuthDecision, AuthorizationManager};
++use crate::authorization::{AuthDecision, AuthorizationManager, ResolveOutcome};
+ use crate::config::{self, AcceleratorConfig};
+ use crate::verified_sites::VerifiedSitesRegistry;
+ use parking_lot::RwLock;
+@@ -27,48 +27,110 @@ pub type VerifiedSitesState = Arc<VerifiedSitesRegistry>;
+ /// state including auth_manager, config, and show_auth_popup — not a bare Default.
+ pub type SharedAppState = Arc<crate::server::AppState>;
+ 
+-/// Holds a pending update so `respond_update_prompt` can use it directly
+-/// instead of re-checking the network. Managed as Tauri state.
+-pub type PendingUpdate = Arc<parking_lot::Mutex<Option<tauri_plugin_updater::Update>>>;
++/// Holds a pending, already-VERIFIED update so `respond_update_prompt` can use it directly instead of
++/// re-checking the network. Storing a `VerifiedUpdate` (not a raw plugin `Update`) means the prompt
++/// path physically cannot install anything that has not cleared both F-004 layers. Managed as Tauri
++/// state.
++pub type PendingUpdate = Arc<parking_lot::Mutex<Option<crate::updater::VerifiedUpdate>>>;
+ 
+ #[tauri::command]
+-pub fn get_config(config: tauri::State<'_, ConfigState>) -> AcceleratorConfig {
+-    config.read().clone()
++pub fn get_config(
++    window: tauri::WebviewWindow,
++    config: tauri::State<'_, ConfigState>,
++) -> Result<AcceleratorConfig, String> {
++    require_label(window.label(), SETTINGS_LABEL)?;
++    Ok(config.read().clone())
+ }
+ 
+ #[tauri::command]
+-pub fn get_autostart_enabled(app: tauri::AppHandle) -> bool {
++pub fn get_autostart_enabled(
++    window: tauri::WebviewWindow,
++    app: tauri::AppHandle,
++) -> Result<bool, String> {
++    require_label(window.label(), SETTINGS_LABEL)?;
+     use tauri_plugin_autostart::ManagerExt;
+-    app.autolaunch().is_enabled().unwrap_or(false)
++    // codex #7: surface an I/O error rather than reporting `false` (disabled). Reading the launcher entry
++    // can fail (permissions, malformed unit); pretending "off" would mislead the user into thinking
++    // autostart is disabled when its true state is unknown.
++    app.autolaunch()
++        .is_enabled()
++        .map_err(|e| format!("cannot read autostart state: {e}"))
+ }
+ 
+ #[tauri::command]
+-pub fn set_autostart(app: tauri::AppHandle, enabled: bool) -> Result<(), String> {
++pub fn set_autostart(
++    window: tauri::WebviewWindow,
++    app: tauri::AppHandle,
++    enabled: bool,
++) -> Result<(), String> {
++    require_label(window.label(), SETTINGS_LABEL)?;
+     use tauri_plugin_autostart::ManagerExt;
+     let manager = app.autolaunch();
+     if enabled {
+-        manager.enable().map_err(|e| e.to_string())?;
+-        crate::crash_recovery::enable_crash_recovery();
++        // F-010: refuse autostart entirely if this executable's path could inject into ANY OS launcher
++        // serializer (systemd unit / .desktop / plist / Run-key) — BEFORE invoking the plugin (which would
++        // otherwise serialize the unsafe path itself). Fail closed: leave a clean disabled state + surface
++        // the refusal to the UI. (The webview cannot bypass this by calling the raw plugin enable — the
++        // `autostart:allow-enable` capability grant is removed; only this gated command can enable.)
++        let exe =
++            std::env::current_exe().map_err(|e| format!("cannot resolve executable path: {e}"))?;
++        if !crate::crash_recovery::autostart_path_is_safe(&exe) {
++            let _ = manager.disable();
++            crate::crash_recovery::disable_crash_recovery();
++            return Err(
++                "Executable path is unsafe for autostart (control/newline/non-UTF-8); refusing to enable."
++                    .to_string(),
++            );
++        }
++        // C8 (D20): enable the launcher entry + arm crash recovery as ONE transaction. If arming fails
++        // after the launcher went on, roll back (disable the launcher unless it was already on, disarm
++        // any partial recovery) and surface a combined error — never leave a half-enabled state.
++        // codex #7: an unknown current state makes the rollback's "disable unless prior" undecidable
++        // (guess wrong and we either clobber a pre-existing entry or leave a new one on). Fail closed
++        // rather than run the transaction against an unknown baseline.
++        let prior_enabled = manager
++            .is_enabled()
++            .map_err(|e| format!("cannot determine current autostart state: {e}"))?;
++        crate::crash_recovery::enable_transaction(
++            prior_enabled,
++            || manager.enable().map_err(|e| e.to_string()),
++            crate::crash_recovery::enable_crash_recovery,
++            || manager.disable().map_err(|e| e.to_string()),
++            crate::crash_recovery::disable_crash_recovery,
++        )?;
+     } else {
++        // codex #7: disable the launcher, THEN disarm crash recovery — and surface a non-confirmed disarm.
++        // The bool from disable_crash_recovery was previously ignored, so a failed disarm left the app
++        // able to relaunch on next login while the UI showed autostart as off.
+         manager.disable().map_err(|e| e.to_string())?;
+-        crate::crash_recovery::disable_crash_recovery();
++        if !crate::crash_recovery::disable_crash_recovery() {
++            return Err(
++                "Autostart launcher disabled, but crash recovery could not be confirmed disarmed — \
++                 the app may still relaunch on next login. Please retry."
++                    .to_string(),
++            );
++        }
+     }
+     Ok(())
+ }
+ 
+ #[tauri::command]
+ pub fn set_speed(
++    window: tauri::WebviewWindow,
+     config: tauri::State<'_, ConfigState>,
+     speed: config::Speed,
+ ) -> Result<(), String> {
++    require_label(window.label(), SETTINGS_LABEL)?;
+     mutate_config(&config, |cfg| cfg.speed = speed)
+ }
+ 
+ #[tauri::command]
+ pub fn remove_approved_origin(
++    window: tauri::WebviewWindow,
+     config: tauri::State<'_, ConfigState>,
+     origin: String,
+ ) -> Result<(), String> {
++    require_label(window.label(), SETTINGS_LABEL)?;
+     mutate_config(&config, |cfg| {
+         cfg.approved_origins
+             .retain(|o| o.as_str() != origin.as_str())
+@@ -82,13 +144,14 @@ pub struct SystemInfo {
+ }
+ 
+ #[tauri::command]
+-pub fn get_system_info() -> SystemInfo {
+-    SystemInfo {
++pub fn get_system_info(window: tauri::WebviewWindow) -> Result<SystemInfo, String> {
++    require_label(window.label(), SETTINGS_LABEL)?;
++    Ok(SystemInfo {
+         platform: std::env::consts::OS.to_string(),
+         cpu_count: std::thread::available_parallelism()
+             .map(|n| n.get())
+             .unwrap_or(1),
+-    }
++    })
+ }
+ 
+ /// DTO returned to the authorization popup when an origin is on the recognized list.
+@@ -100,52 +163,201 @@ pub struct VerifiedSiteDto {
+ 
+ #[tauri::command]
+ pub fn get_verified_info(
++    window: tauri::WebviewWindow,
+     origin: String,
+     state: tauri::State<'_, VerifiedSitesState>,
+-) -> Option<VerifiedSiteDto> {
+-    state.lookup(&origin).map(|s| VerifiedSiteDto {
++) -> Result<Option<VerifiedSiteDto>, String> {
++    // F-012 (D6): only an authorization popup renders the verified badge.
++    require_auth_window(window.label())?;
++    Ok(state.lookup(&origin).map(|s| VerifiedSiteDto {
+         display_name: s.display_name.clone(),
+-    })
++    }))
+ }
+ 
+ #[tauri::command]
+ pub fn respond_auth(
++    window: tauri::WebviewWindow,
+     app: tauri::AppHandle,
+     auth: tauri::State<'_, AuthState>,
+     request_id: String,
+     origin: String,
+     allowed: bool,
+     remember: bool,
+-) {
++) -> Result<(), String> {
++    // F-012 (D6) + SEC-06 (strengthened): bind the calling window to THIS request_id. windows.rs labels
++    // the popup `auth-{hash(request_id)}`; asserting the caller's label == that means a popup opened for
++    // request A physically cannot resolve request B, even if it forged B's id in the payload. Tauri
++    // resolves `window` from the native IPC message, so the label is unspoofable from JS.
++    let label = format!("{AUTH_LABEL_PREFIX}{}", sanitize_window_label(&request_id));
++    require_label(window.label(), &label)?;
++
+     let decision = if allowed {
+         AuthDecision::Allow { remember }
+     } else {
+         AuthDecision::Deny
+     };
+-    // SEC-06: resolve by the opaque `request_id`, NOT the origin. A tampered/guessed payload with a
+-    // wrong id is a harmless no-op (it can't resolve a *different* concurrent request, and the old
+-    // origin-keyed resolve could); the real request then denies via its 60s timeout.
+-    auth.resolve(&request_id, decision);
+-
+-    // Close the authorization popup window. SEC-06 post-impl (codex L3): the window is labelled by
+-    // `request_id`, NOT origin — origin-keying let a resolved request's stale 60s timeout close the
+-    // *live* window of a newer same-origin request (and respond_auth close the wrong one). `origin` is
+-    // kept on the payload for diagnostics only.
+-    tracing::debug!(origin = %origin, %request_id, allowed, "respond_auth decision");
+-    let label = format!("auth-{}", sanitize_window_label(&request_id));
++    // C9 (D19): SERVER-SIDE arbiter enforcement — only the popup that currently owns the ACTIVE slot may
++    // resolve. A queued (non-actionable) popup's webview cannot decide even if coerced into calling
++    // respond_auth; the frontend button-disable is a reflection of this, not the gate. SEC-06: resolution
++    // is still by the opaque `request_id` (a wrong id can't resolve a different request).
++    match auth.resolve_active(&request_id, decision) {
++        ResolveOutcome::Resolved(promoted) => {
++            // Close this popup (labelled by `request_id`; `origin` is diagnostics-only) and promote the
++            // next queued popup into the active slot.
++            tracing::debug!(origin = %origin, %request_id, allowed, "respond_auth decision");
++            if let Some(window) = app.get_webview_window(&label) {
++                let _ = window.close();
++            }
++            if let Some(next) = promoted {
++                arm_active_popup(&app, auth.inner(), &next);
++            }
++            Ok(())
++        }
++        ResolveOutcome::NotActive => {
++            tracing::warn!(%request_id, "respond_auth rejected: not the active authorization popup");
++            Err("not the active authorization request".to_string())
++        }
++    }
++}
++
++/// DTO for [`get_pending_auth`] — the SERVER-authoritative origin the popup must render (C9 D8), plus
++/// whether this popup currently owns the actionable slot (C9 D15), so a queued popup disables its buttons.
++#[derive(serde::Serialize)]
++pub struct PendingAuthDto {
++    pub origin: String,
++    pub active: bool,
++}
++
++#[tauri::command]
++pub fn get_pending_auth(
++    window: tauri::WebviewWindow,
++    auth: tauri::State<'_, AuthState>,
++    request_id: String,
++) -> Result<Option<PendingAuthDto>, String> {
++    // C9 (D8/D19): bind the caller to ITS OWN request via the SAME exact-label guard respond_auth uses, so
++    // a popup can only peek the origin/active-state of the request it was opened for, never another's.
++    let label = format!("{AUTH_LABEL_PREFIX}{}", sanitize_window_label(&request_id));
++    require_label(window.label(), &label)?;
++    Ok(auth
++        .peek(&request_id)
++        .map(|(origin, active)| PendingAuthDto {
++            origin: origin.to_string(),
++            active,
++        }))
++}
++
++// ── C9 single-active-popup arbiter — window helpers (lib, so both `respond_auth` here and
++//    `windows::show_auth_popup_window` in the bin share one implementation) ──────────────────────────
++
++/// C9 (D14/D18/D19): raise a promoted popup into the ACTIVE slot — topmost + focused — and arm its
++/// activation-relative 60 s auto-deny. Called on every promotion (respond_auth / deny timer / window
++/// close). No-op on the window itself if it was already closed; the arbiter state advanced regardless.
++pub fn arm_active_popup(app: &tauri::AppHandle, auth_manager: &AuthState, request_id: &str) {
++    let label = format!("{AUTH_LABEL_PREFIX}{}", sanitize_window_label(request_id));
+     if let Some(window) = app.get_webview_window(&label) {
+-        let _ = window.close();
++        let _ = window.set_always_on_top(true);
++        let _ = window.set_focus();
+     }
++    spawn_active_deny_timer(app, auth_manager, request_id);
++}
++
++/// Spawn the ACTIVE popup's 60 s auto-deny. On fire: resolve Deny (which promotes the next queued request,
++/// if any), close the window, then arm the promoted one — the chain drains the queue one active 60 s
++/// window at a time. `resolve` is a no-op if the request was already decided (respond_auth / user close).
++pub fn spawn_active_deny_timer(app: &tauri::AppHandle, auth_manager: &AuthState, request_id: &str) {
++    let app = app.clone();
++    let auth_manager = auth_manager.clone();
++    let request_id = request_id.to_string();
++    let label = format!("{AUTH_LABEL_PREFIX}{}", sanitize_window_label(&request_id));
++    tauri::async_runtime::spawn(async move {
++        tokio::time::sleep(crate::server::AUTH_DECISION_TIMEOUT).await;
++        let promoted = auth_manager.resolve(&request_id, AuthDecision::Deny);
++        if let Some(window) = app.get_webview_window(&label) {
++            let _ = window.close();
++        }
++        if let Some(promoted) = promoted {
++            arm_active_popup(&app, &auth_manager, &promoted);
++        }
++    });
++}
++
++/// C9 (D14): resolve-as-Deny + promote-next when the user CLOSES a popup without deciding. Idempotent with
++/// the timer + respond_auth (both resolve first, then close — so the `Destroyed` fired by their own close
++/// is a harmless no-op that promotes nobody).
++pub fn attach_close_deny_listener(
++    app: &tauri::AppHandle,
++    auth_manager: &AuthState,
++    window: &tauri::WebviewWindow,
++    request_id: &str,
++) {
++    let app = app.clone();
++    let auth_manager = auth_manager.clone();
++    let request_id = request_id.to_string();
++    window.on_window_event(move |event| {
++        if matches!(event, tauri::WindowEvent::Destroyed) {
++            if let Some(promoted) = auth_manager.resolve(&request_id, AuthDecision::Deny) {
++                arm_active_popup(&app, &auth_manager, &promoted);
++            }
++        }
++    });
+ }
+ 
+ /// Create a unique, collision-free window label from an arbitrary key (an origin or, for auth
+ /// popups, the opaque `request_id`). Uses a truncated SHA-256 hash to avoid collisions between
+ /// similar keys (e.g. `example.com` vs `example_com` would collide with naive character replacement)
+ /// and to keep the label charset window-system-safe.
++///
++/// F-012 (codex MED-6): 16 bytes = 128 bits of the digest. The label is a security binding
++/// (`respond_auth` asserts the caller's window == `auth-{hash(request_id)}`), so the earlier 6-byte
++/// (48-bit) truncation gave a needlessly small margin; 128 bits makes a collision a non-issue while
++/// staying a valid Tauri window label (lowercase hex).
+ pub fn sanitize_window_label(key: &str) -> String {
+     use sha2::{Digest, Sha256};
+     let hash = Sha256::digest(key.as_bytes());
+-    hex::encode(&hash[..6])
++    hex::encode(&hash[..16])
++}
++
++/// Fixed window labels the caller-label guard checks against (must match `windows.rs`).
++pub const SETTINGS_LABEL: &str = "settings";
++pub const UPDATE_PROMPT_LABEL: &str = "update-prompt";
++const AUTH_LABEL_PREFIX: &str = "auth-";
++
++/// F-012 (D6) — the PRIMARY, framework-independent caller-label check behind the per-window capability
++/// ACL. Even if a capability were ever mis-scoped, a command still refuses to act for the wrong window.
++/// `actual` is the real invoking window's label, which Tauri resolves from the native IPC message — JS
++/// cannot spoof it. On mismatch: log (generic) and return a generic error that leaks no window topology.
++fn require_label(actual: &str, expected: &str) -> Result<(), String> {
++    if actual == expected {
++        Ok(())
++    } else {
++        tracing::warn!(
++            actual,
++            "command invoked from an unexpected window; rejecting"
++        );
++        Err("This command is not available from this window.".to_string())
++    }
++}
++
++/// True iff `label` is a well-formed authorization-popup label: `auth-` + exactly 32 lowercase hex chars
++/// (the 128-bit [`sanitize_window_label`] digest). Used by `get_verified_info`, which — unlike
++/// `respond_auth` — doesn't receive the `request_id`, so it can only assert the caller IS an auth popup.
++fn is_auth_label(label: &str) -> bool {
++    label
++        .strip_prefix(AUTH_LABEL_PREFIX)
++        .is_some_and(|h| h.len() == 32 && h.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f')))
++}
++
++/// Require the caller to be an authorization popup (any `auth-<hash>`). Generic error on mismatch.
++fn require_auth_window(actual: &str) -> Result<(), String> {
++    if is_auth_label(actual) {
++        Ok(())
++    } else {
++        tracing::warn!(
++            actual,
++            "auth command invoked from a non-auth window; rejecting"
++        );
++        Err("This command is not available from this window.".to_string())
++    }
+ }
+ 
+ /// Enable Safari Support: generate certs, install trust, save config, start HTTPS.
+@@ -153,9 +365,11 @@ pub fn sanitize_window_label(key: &str) -> String {
+ #[cfg(target_os = "macos")]
+ #[tauri::command]
+ pub async fn enable_safari_support(
++    window: tauri::WebviewWindow,
+     config: tauri::State<'_, ConfigState>,
+     shared_state: tauri::State<'_, SharedAppState>,
+ ) -> Result<(), String> {
++    require_label(window.label(), SETTINGS_LABEL)?;
+     use crate::certs;
+ 
+     // SEC-08 (post-impl codex M1): the startup path runs this same fail-closed migration before it
+@@ -190,7 +404,11 @@ pub async fn enable_safari_support(
+ /// Disable Safari Support: save config. HTTPS stops on next restart.
+ #[cfg(target_os = "macos")]
+ #[tauri::command]
+-pub fn disable_safari_support(config: tauri::State<'_, ConfigState>) -> Result<(), String> {
++pub fn disable_safari_support(
++    window: tauri::WebviewWindow,
++    config: tauri::State<'_, ConfigState>,
++) -> Result<(), String> {
++    require_label(window.label(), SETTINGS_LABEL)?;
+     mutate_config(&config, |cfg| cfg.safari_support = false)?;
+     tracing::info!("Safari Support disabled via Settings (HTTPS stops on next restart)");
+     Ok(())
+@@ -199,20 +417,27 @@ pub fn disable_safari_support(config: tauri::State<'_, ConfigState>) -> Result<(
+ /// Stub for non-macOS platforms.
+ #[cfg(not(target_os = "macos"))]
+ #[tauri::command]
+-pub async fn enable_safari_support() -> Result<(), String> {
++pub async fn enable_safari_support(window: tauri::WebviewWindow) -> Result<(), String> {
++    require_label(window.label(), SETTINGS_LABEL)?;
+     Err("Safari Support is only available on macOS".to_string())
+ }
+ 
+ /// Stub for non-macOS platforms.
+ #[cfg(not(target_os = "macos"))]
+ #[tauri::command]
+-pub fn disable_safari_support() -> Result<(), String> {
++pub fn disable_safari_support(window: tauri::WebviewWindow) -> Result<(), String> {
++    require_label(window.label(), SETTINGS_LABEL)?;
+     Err("Safari Support is only available on macOS".to_string())
+ }
+ 
+ /// Toggle auto-update preference from Settings.
+ #[tauri::command]
+-pub fn set_auto_update(config: tauri::State<'_, ConfigState>, enabled: bool) -> Result<(), String> {
++pub fn set_auto_update(
++    window: tauri::WebviewWindow,
++    config: tauri::State<'_, ConfigState>,
++    enabled: bool,
++) -> Result<(), String> {
++    require_label(window.label(), SETTINGS_LABEL)?;
+     mutate_config(&config, |cfg| cfg.auto_update = Some(enabled))?;
+     tracing::info!(enabled, "Auto-update preference changed via Settings");
+     Ok(())
+@@ -223,12 +448,14 @@ pub fn set_auto_update(config: tauri::State<'_, ConfigState>, enabled: bool) ->
+ /// - action="later": dismiss, auto_update stays None (prompt returns next launch)
+ #[tauri::command]
+ pub fn respond_update_prompt(
++    window: tauri::WebviewWindow,
+     app: tauri::AppHandle,
+     config: tauri::State<'_, ConfigState>,
+     pending: tauri::State<'_, PendingUpdate>,
+     action: String,
+     auto_update: bool,
+ ) -> Result<(), String> {
++    require_label(window.label(), UPDATE_PROMPT_LABEL)?;
+     match action.as_str() {
+         "update" => {
+             // Save auto-update preference from the checkbox
+@@ -245,7 +472,7 @@ pub fn respond_update_prompt(
+             match update {
+                 Some(update) => {
+                     tracing::info!(
+-                        version = %update.version,
++                        version = %update.version(),
+                         auto_update,
+                         "User clicked Update Now, downloading stored update"
+                     );
+@@ -278,3 +505,51 @@ fn close_update_prompt(app: &tauri::AppHandle) {
+         let _ = window.close();
+     }
+ }
++
++#[cfg(test)]
++mod tests {
++    use super::{is_auth_label, require_auth_window, require_label, sanitize_window_label};
++
++    #[test]
++    fn require_label_matches_exactly() {
++        assert!(require_label("settings", "settings").is_ok());
++        assert!(require_label("auth-abc", "settings").is_err());
++        assert!(require_label("", "settings").is_err());
++        assert!(require_label("settings ", "settings").is_err()); // no trimming
++    }
++
++    #[test]
++    fn auth_label_is_prefix_plus_128bit_lowercase_hex() {
++        // A real label is `auth-` + the 32-hex (16-byte) digest — the width sanitize_window_label emits.
++        let real = format!("auth-{}", sanitize_window_label("some-request-id"));
++        assert_eq!(sanitize_window_label("some-request-id").len(), 32); // 16 bytes -> 32 hex
++        assert!(is_auth_label(&real));
++        assert!(require_auth_window(&real).is_ok());
++
++        // Reject: wrong prefix, uppercase hex, wrong length, non-hex, the settings label.
++        for bad in [
++            "settings",
++            "auth-",
++            "auth-XYZ",
++            "auth-ABCDEF0123456789ABCDEF0123456789", // uppercase
++            "auth-abc",                              // too short
++            "auth-0123456789abcdef0123456789abcdefff", // too long (34)
++            "notauth-0123456789abcdef0123456789abcdef",
++        ] {
++            assert!(!is_auth_label(bad), "{bad} must not be a valid auth label");
++            assert!(require_auth_window(bad).is_err(), "{bad} must be rejected");
++        }
++    }
++
++    #[test]
++    fn sanitize_window_label_is_deterministic_and_collision_resistant() {
++        assert_eq!(sanitize_window_label("a"), sanitize_window_label("a"));
++        assert_ne!(
++            sanitize_window_label("example.com"),
++            sanitize_window_label("example_com")
++        );
++        assert!(sanitize_window_label("x")
++            .bytes()
++            .all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f')));
++    }
++}
+diff --git a/packages/accelerator/src-tauri/src/main.rs b/packages/accelerator/src-tauri/src/main.rs
+index 491e8b2..a8f4537 100644
+--- a/packages/accelerator/src-tauri/src/main.rs
++++ b/packages/accelerator/src-tauri/src/main.rs
+@@ -181,7 +181,7 @@ async fn run_update_check(app: &AppHandle, config_state: &ConfigState) {
+     if let Some(update) = aztec_accelerator::updater::check_for_update(app, config_state).await {
+         let auto_update_pref = { config_state.read().auto_update };
+         let current_version = env!("CARGO_PKG_VERSION").to_string();
+-        let new_version = update.version.clone();
++        let new_version = update.version().to_string();
+ 
+         // Store the update so respond_update_prompt can use it directly
+         if let Some(pending) = app.try_state::<PendingUpdate>() {
+@@ -269,6 +269,46 @@ fn spawn_update_poller(app_handle: AppHandle, config: ConfigState) {
+     });
+ }
+ 
++/// Spawn the F-004 Layer B post-launch floor tracker. Once THIS build's OWN accelerator server has
++/// answered `/health` — as a healthy Aztec reporting OUR exact version — 3 consecutive times, advance
++/// the monotonic version floor to the running version. Two guards matter (audit H3):
++///   - 3 consecutive HEALTHY probes (not merely "process started") means a build that boots but
++///     immediately wedges its server never ratchets the floor;
++///   - the reported `/health.version` must equal `CARGO_PKG_VERSION`. The redundant-instance bow-out
++///     is Windows-only, so on macOS/Linux a broken new build that LOST the `:59833` bind would still
++///     see the healthy INCUMBENT's `/health` and could otherwise commit ITS OWN (never-run) version.
++///     Matching the version proves we are observing our own server (we own the bind).
++///
++/// Runs once; gated off for webdriver builds.
++#[cfg(not(feature = "webdriver"))]
++fn spawn_floor_tracker() {
++    tauri::async_runtime::spawn(async move {
++        let want = env!("CARGO_PKG_VERSION");
++        let mut consecutive = 0u32;
++        // Bounded (~2 min) so a genuinely unhealthy build never commits the floor.
++        for _ in 0..40 {
++            tokio::time::sleep(Duration::from_secs(3)).await;
++            if aztec_accelerator::server::healthy_aztec_version_on_port()
++                .await
++                .as_deref()
++                == Some(want)
++            {
++                consecutive += 1;
++                if consecutive >= 3 {
++                    aztec_accelerator::updater::commit_launch_floor();
++                    return;
++                }
++            } else {
++                consecutive = 0;
++            }
++        }
++        tracing::warn!(
++            version = want,
++            "Launch never reached 3 consecutive healthy version-matched probes; version floor not advanced this run"
++        );
++    });
++}
++
+ // ── Desktop bootstrap (q7e3-F-04) ────────────────────────────────────────
+ // `.setup()` was a ~150-line Long Method closure. These phase helpers carry the capture-heavy
+ // construction; the closure stays a thin, visibly-ordered sequencer because two orderings there are
+@@ -291,8 +331,14 @@ fn build_tray(
+             // → relaunch. Windows-only: mac/linux key on exit code (launchd
+             // SuccessfulExit:false / systemd on-failure), so a clean quit is a
+             // no-op there and the recovery entry must persist across quit.
++            // codex #7: surface (log) a non-confirmed disarm — an unconfirmed disable here means the
++            // Task Scheduler recovery entry may survive and relaunch the app within ~1 min of this quit.
+             #[cfg(target_os = "windows")]
+-            aztec_accelerator::crash_recovery::disable_crash_recovery();
++            if !aztec_accelerator::crash_recovery::disable_crash_recovery() {
++                tracing::warn!(
++                    "quit: crash recovery could not be confirmed disarmed — the app may relaunch shortly"
++                );
++            }
+             app.exit(0);
+         }
+         "show_logs" => open_in_browser(&log_dir()),
+@@ -452,6 +498,7 @@ fn main() {
+             commands::remove_approved_origin,
+             commands::get_system_info,
+             commands::get_verified_info,
++            commands::get_pending_auth,
+             commands::respond_auth,
+             commands::enable_safari_support,
+             commands::disable_safari_support,
+@@ -462,6 +509,7 @@ fn main() {
+             // Hide from Dock — tray-only app
+             #[cfg(target_os = "macos")]
+             app.set_activation_policy(tauri::ActivationPolicy::Accessory);
++
+             let bundled_version = env!("AZTEC_BB_VERSION").to_string();
+ 
+             let status = MenuItemBuilder::with_id("status", "Status: Idle")
+@@ -471,8 +519,20 @@ fn main() {
+             // Check autostart on launch for crash recovery
+             {
+                 use tauri_plugin_autostart::ManagerExt;
+-                if app.autolaunch().is_enabled().unwrap_or(false) {
+-                    aztec_accelerator::crash_recovery::enable_crash_recovery();
++                // C8 (D12): log-and-continue — a rearm hiccup at startup must NEVER abort launch, and it
++                // must NOT be silently swallowed. codex #7: distinguish a READ ERROR from a confirmed
++                // "off". Treating an is_enabled() error as `false` would silently skip re-arming crash
++                // recovery when autostart was in fact on but momentarily unreadable.
++                match app.autolaunch().is_enabled() {
++                    Ok(true) => {
++                        if let Err(e) = aztec_accelerator::crash_recovery::enable_crash_recovery() {
++                            tracing::warn!("startup crash-recovery rearm failed (autostart on): {e}");
++                        }
++                    }
++                    Ok(false) => {}
++                    Err(e) => tracing::warn!(
++                        "could not read autostart state at startup; crash recovery not re-armed: {e}"
++                    ),
+                 }
+             }
+ 
+@@ -543,6 +603,8 @@ fn main() {
+             #[cfg(not(feature = "webdriver"))]
+             if should_poll_for_updates() {
+                 spawn_update_poller(app.handle().clone(), config_state.clone());
++                // F-004 Layer B: advance the monotonic version floor once this build proves it runs.
++                spawn_floor_tracker();
+             }
+ 
+             Ok(())
+diff --git a/packages/accelerator/src-tauri/src/windows.rs b/packages/accelerator/src-tauri/src/windows.rs
+index 20b058d..e618e0b 100644
+--- a/packages/accelerator/src-tauri/src/windows.rs
++++ b/packages/accelerator/src-tauri/src/windows.rs
+@@ -3,7 +3,32 @@
+ use aztec_accelerator::authorization::{AuthDecision, AuthorizationManager};
+ use aztec_accelerator::commands;
+ use std::sync::Arc;
+-use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
++use tauri::webview::NewWindowResponse;
++use tauri::{AppHandle, Manager, Url, WebviewUrl, WebviewWindowBuilder};
++
++/// True iff `url` is the app's OWN local asset origin. Tauri serves the bundled frontend from
++/// `tauri://localhost` (Linux/macOS) or `http://tauri.localhost` (Windows). Every other navigation
++/// target is off-origin. F-012 (codex HIGH-3): the CSP `connect-src` blocks fetch/XHR/WS exfil but NOT
++/// a top-level navigation that smuggles data in the URL, and on Linux the `<meta>`-delivered CSP ignores
++/// `frame-ancestors` — so this Rust guard is the real anti-navigation/anti-exfil control.
++///
++/// GATE-3 (codex MED): match ONLY the current platform's asset origin — accepting `http://tauri.localhost`
++/// on Linux/macOS would permit a real loopback HTTP navigation (e.g. `http://tauri.localhost:59833/?data=…`
++/// hitting a listening server) that is NOT the embedded-asset protocol. Also reject any embedded credentials
++/// or explicit port; the asset origin never has either.
++fn is_local_asset_url(url: &Url) -> bool {
++    if !url.username().is_empty() || url.password().is_some() || url.port().is_some() {
++        return false;
++    }
++    #[cfg(windows)]
++    {
++        url.scheme() == "http" && url.host_str() == Some("tauri.localhost")
++    }
++    #[cfg(not(windows))]
++    {
++        url.scheme() == "tauri" && url.host_str() == Some("localhost")
++    }
++}
+ 
+ /// Focus a newly created window. We stay as Accessory (tray-only) rather than
+ /// switching to Regular activation policy, which would show the app in the Dock
+@@ -27,31 +52,50 @@ struct WindowConfig<'a> {
+     /// Focus an ALREADY-open window with this label? Settings does (user re-clicked "Settings");
+     /// the auth/update popups don't (they just stay put). Preserves prior per-window behavior.
+     focus_if_open: bool,
++    /// Focus a NEWLY-built window? Settings/update/active-auth do; a QUEUED auth popup (C9 D18) does NOT —
++    /// it is built not-topmost + unfocused and only gains focus when promoted to active.
++    focus_on_create: bool,
+ }
+ 
+-/// Open a window with the given config, or handle an already-open one. Returns `true` iff a window
+-/// with `config.label` was ALREADY open (focused first iff `focus_if_open`); `false` if none existed,
+-/// in which case a new one is built + focused. The bool lets callers (auth) do post-build work only
+-/// for a freshly-handled window. Dedups the get-or-build pattern across the 3 windows.
+-fn open_or_focus_window(app: &AppHandle, config: WindowConfig) -> bool {
++/// Open a window with the given config, or handle an already-open one. Returns `Some(window)` for a
++/// FRESHLY-built window (so the caller can do post-build work — attach a close listener, arm a timer),
++/// or `None` if a window with `config.label` was already open (focused first iff `focus_if_open`).
++/// Dedups the get-or-build pattern across the 3 windows.
++fn open_or_focus_window(app: &AppHandle, config: WindowConfig) -> Option<tauri::WebviewWindow> {
+     if let Some(window) = app.get_webview_window(config.label) {
+         if config.focus_if_open {
+             let _ = window.set_focus();
+         }
+-        return true;
++        return None;
+     }
+-    if let Ok(window) =
+-        WebviewWindowBuilder::new(app, config.label, WebviewUrl::App(config.url.into()))
+-            .title(config.title)
+-            .inner_size(config.width, config.height)
+-            .resizable(false)
+-            .center()
+-            .always_on_top(config.always_on_top)
+-            .build()
++    match WebviewWindowBuilder::new(app, config.label, WebviewUrl::App(config.url.into()))
++        .title(config.title)
++        .inner_size(config.width, config.height)
++        .resizable(false)
++        .center()
++        .always_on_top(config.always_on_top)
++        // codex r2 #4: actually BUILD the window (un)focused. `focus_on_create` previously only gated a
++        // post-build `set_focus`, but tao defaults new windows to focused — so a QUEUED auth popup was
++        // built focused and could steal focus before promotion. Pass it to the builder so a queued popup
++        // (focus_on_create=false) is created unfocused; the active one is raised via `arm_active_popup`.
++        .focused(config.focus_on_create)
++        // F-012 (codex HIGH-3): confine the webview to its own local asset origin. Block any attempt
++        // to navigate off-origin (data-exfil / phishing) and deny opening new windows/webviews — the
++        // popups never legitimately do either. (Confirmed NOT the cause of the CI asset-load failure —
++        // that was `tauri dev` injecting a dev-server devUrl → empty embed; fixed by running the binary
++        // directly. These guards allow the real tauri://localhost initial load.)
++        .on_navigation(is_local_asset_url)
++        .on_new_window(|_url, _features| NewWindowResponse::Deny)
++        .build()
+     {
+-        focus_window(&window);
++        Ok(window) => {
++            if config.focus_on_create {
++                focus_window(&window);
++            }
++            Some(window)
++        }
++        Err(_) => None,
+     }
+-    false
+ }
+ 
+ /// Open or focus the Settings window.
+@@ -66,6 +110,7 @@ pub fn open_settings_window(app: &AppHandle) {
+             height: 520.0,
+             always_on_top: false,
+             focus_if_open: true,
++            focus_on_create: true,
+         },
+     );
+ }
+@@ -91,7 +136,15 @@ pub fn show_auth_popup_window(
+         urlencoding::encode(origin),
+         urlencoding::encode(request_id)
+     );
+-    if open_or_focus_window(
++    // C9 (D18/D19, codex #8): BUILD FIRST, unconditionally as NON-active (not topmost, unfocused, no
++    // timer). Whether this request owns the actionable + always-on-top slot is decided AFTER the window
++    // exists (below), never from a peek taken before the build. The old pre-build peek raced promotion:
++    // if the active popup resolved and promoted THIS request during its own build, the build finished
++    // with a stale `is_active=false` (non-topmost, unfocused, no timer) while the resolve path's
++    // `arm_active_popup` had already run against a not-yet-built window — leaving a server-active but
++    // unraised, un-timed popup. Exactly one popup is actionable at a time; `resolve_active` enforces that
++    // server-side regardless of window state.
++    let Some(window) = open_or_focus_window(
+         app,
+         WindowConfig {
+             label: &label,
+@@ -99,32 +152,40 @@ pub fn show_auth_popup_window(
+             title: "Authorize Site",
+             width: 400.0,
+             height: 300.0,
+-            always_on_top: true,
++            always_on_top: false,
+             focus_if_open: false,
++            focus_on_create: false,
+         },
+-    ) {
+-        return; // popup already open for this request — don't spawn a duplicate timeout
+-    }
+-
+-    // Spawn 60s timeout — always resolve with Deny if still pending.
+-    // This handles both: (a) user ignoring the popup, and (b) user closing the
+-    // window without clicking Allow/Deny. In case (b), the window is gone but
+-    // the pending sender is still in the map. resolve() is a no-op if this
+-    // request was already resolved by respond_auth (sender already consumed).
+-    let app_handle = app.clone();
+-    let origin_owned = origin.to_string();
+-    let request_id_owned = request_id.to_string();
+-    let auth_manager = auth_manager.clone();
+-    tauri::async_runtime::spawn(async move {
+-        tokio::time::sleep(aztec_accelerator::server::AUTH_DECISION_TIMEOUT).await;
+-        // Close window if still open
+-        if let Some(window) = app_handle.get_webview_window(&label) {
+-            let _ = window.close();
++    ) else {
++        // A per-request auth label is NEVER "already open", so `None` here means the window FAILED TO
++        // BUILD (code-review: resource exhaustion etc.). Don't leave the arbiter's `active` slot held with
++        // no timer — that would stall the whole auth queue until the 600 s backstop. Resolve this request
++        // Deny to release the slot and promote + raise the next queued popup.
++        if let Some(promoted) = auth_manager.resolve(request_id, AuthDecision::Deny) {
++            commands::arm_active_popup(app, auth_manager, &promoted);
+         }
+-        // SEC-06: resolve by request_id — no-op if respond_auth already consumed it.
+-        auth_manager.resolve(&request_id_owned, AuthDecision::Deny);
+-        tracing::debug!(origin = %origin_owned, "Authorization timeout cleanup");
+-    });
++        return;
++    };
++
++    // C9 (D14): a user closing the popup WITHOUT deciding must resolve it (Deny) + promote the next queued
++    // popup — closing is not a resolution event to the arbiter otherwise. Idempotent with the timer +
++    // respond_auth (a second resolve of the same id is a no-op → returns None → no double-promote). The
++    // arbiter helpers live in `commands` (the lib) so both this (bin) and `respond_auth` (lib) share them.
++    commands::attach_close_deny_listener(app, auth_manager, &window, request_id);
++
++    // C9 (D18, codex #8): now that the window EXISTS, raise + arm it iff it currently owns the active
++    // slot. Re-peeking HERE (post-build) covers both "active from the start" and "promoted during the
++    // build". If promotion happens AFTER this, the resolve path's `arm_active_popup` finds the now-built
++    // window. Arming is idempotent: a second 60 s timer for the same id simply no-ops on fire (the id
++    // resolves exactly once), and a redundant raise is harmless. A still-queued popup is left non-topmost
++    // + un-timed and gains focus + its 60 s clock only when promoted.
++    let is_active = auth_manager
++        .peek(request_id)
++        .map(|(_, active)| active)
++        .unwrap_or(false);
++    if is_active {
++        commands::arm_active_popup(app, auth_manager, request_id);
++    }
+ }
+ 
+ /// Show the update prompt window.
+@@ -148,6 +209,83 @@ pub fn show_update_prompt_window(app: &AppHandle, current_version: &str, new_ver
+             height: 280.0,
+             always_on_top: false,
+             focus_if_open: false,
++            focus_on_create: true,
+         },
+     );
+ }
++
++#[cfg(test)]
++mod tests {
++    use super::is_local_asset_url;
++    use tauri::Url;
++
++    #[test]
++    fn navigation_guard_allows_only_the_local_asset_origin() {
++        // The real initial loads for THIS platform (incl. query params) must be permitted.
++        #[cfg(not(windows))]
++        let ok_forms = [
++            "tauri://localhost/authorize.html?origin=https%3A%2F%2Fx.com&requestId=abc",
++            "tauri://localhost/settings.html",
++        ];
++        #[cfg(windows)]
++        let ok_forms = [
++            "http://tauri.localhost/authorize.html?origin=https%3A%2F%2Fx.com&requestId=abc",
++            "http://tauri.localhost/settings.html",
++        ];
++        for ok in ok_forms {
++            assert!(
++                is_local_asset_url(&Url::parse(ok).unwrap()),
++                "{ok} should be allowed"
++            );
++        }
++
++        // The OTHER platform's origin must be REJECTED here (codex MED: `http://tauri.localhost` on
++        // Linux/macOS is a real loopback HTTP navigation, not the embedded-asset protocol).
++        #[cfg(not(windows))]
++        let other_platform = "http://tauri.localhost/settings.html";
++        #[cfg(windows)]
++        let other_platform = "tauri://localhost/settings.html";
++        assert!(
++            !is_local_asset_url(&Url::parse(other_platform).unwrap()),
++            "{other_platform} (other platform's origin) must be blocked"
++        );
++
++        // Ports and credentials are never part of the asset origin.
++        #[cfg(not(windows))]
++        let ported_credentialed = [
++            "tauri://localhost:59833/settings.html",
++            "tauri://user@localhost/settings.html",
++            "tauri://user:pass@localhost/settings.html",
++        ];
++        #[cfg(windows)]
++        let ported_credentialed = [
++            "http://tauri.localhost:59833/settings.html",
++            "http://user@tauri.localhost/settings.html",
++            "http://user:pass@tauri.localhost/settings.html",
++        ];
++        for bad in ported_credentialed {
++            assert!(
++                !is_local_asset_url(&Url::parse(bad).unwrap()),
++                "{bad} (port/creds) must be blocked"
++            );
++        }
++
++        // Everything off-origin — look-alikes, the IPC host, non-http(s) schemes — must be blocked.
++        for bad in [
++            "https://evil.example/",
++            "http://localhost/x",                   // wrong host
++            "https://tauri.localhost/",             // wrong scheme
++            "http://tauri.localhost.evil.example/", // suffix look-alike
++            "tauri://evil/",
++            "http://ipc.localhost/", // IPC host is not a navigation target
++            "data:text/html,<script>alert(1)</script>",
++            "file:///etc/passwd",
++            "javascript:alert(1)",
++        ] {
++            assert!(
++                !is_local_asset_url(&Url::parse(bad).unwrap()),
++                "{bad} should be blocked"
++            );
++        }
++    }
++}

--- a/implementations-plan/security-hardening/full-audit-2026-07-24/chunks/F-ci.diff
+++ b/implementations-plan/security-hardening/full-audit-2026-07-24/chunks/F-ci.diff
@@ -1,0 +1,2103 @@
+diff --git a/.github/actions/playwright-cache/action.yml b/.github/actions/playwright-cache/action.yml
+index 0b04e00..c440706 100644
+--- a/.github/actions/playwright-cache/action.yml
++++ b/.github/actions/playwright-cache/action.yml
+@@ -33,7 +33,7 @@ runs:
+ 
+     - name: Restore Playwright browser cache
+       id: cache
+-      uses: actions/cache/restore@v5
++      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+       with:
+         path: ~/.cache/ms-playwright
+         key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}-shell
+@@ -76,7 +76,7 @@ runs:
+       # RESTORES in the same run, sidestepping the CDN-hang on bad-routing
+       # runners. The `save` input is retained for clarity but no longer gates.
+       if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+-      uses: actions/cache/save@v5
++      uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
+       with:
+         path: ~/.cache/ms-playwright
+         key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}-shell
+diff --git a/.github/actions/setup-accelerator/action.yml b/.github/actions/setup-accelerator/action.yml
+index a23c3d5..b1ae87e 100644
+--- a/.github/actions/setup-accelerator/action.yml
++++ b/.github/actions/setup-accelerator/action.yml
+@@ -89,11 +89,11 @@ runs:
+         sudo apt-get update
+         sudo apt-get install -y libssl-dev
+ 
+-    - uses: oven-sh/setup-bun@v2
++    - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+       with:
+-        bun-version: latest
++        bun-version: 1.3.14
+ 
+-    - uses: actions/cache@v5
++    - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+       with:
+         path: ~/.bun/install/cache
+         key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+@@ -102,12 +102,14 @@ runs:
+     - run: bun install --frozen-lockfile
+       shell: bash
+ 
+-    - uses: dtolnay/rust-toolchain@stable
++    # F-015: pin to a master-history SHA (not the GC-able @stable commit) + explicit channel.
++    - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+       with:
++        toolchain: stable
+         components: ${{ inputs.rust-components }}
+         targets: ${{ inputs.rust-target }}
+ 
+-    - uses: Swatinem/rust-cache@v2
++    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+       with:
+         workspaces: ${{ inputs.rust-workspaces }}
+         shared-key: ${{ inputs.rust-cache-key }}
+@@ -116,3 +118,12 @@ runs:
+       if: inputs.run-prebuild != 'false'
+       shell: bash
+       run: bun run --cwd packages/accelerator prebuild
++
++    # F-012: the desktop src-tauri build.rs fails if the gitignored frontend/assets/*.js bundles are
++    # missing or stale. Build them here so every downstream cargo command (clippy/test/build) in a
++    # desktop job has them. Headless server jobs (install-tauri-system-deps: false) don't build
++    # src-tauri, so they skip this.
++    - name: Build frontend bundles (F-012)
++      if: inputs.install-tauri-system-deps != 'false'
++      shell: bash
++      run: bun run --cwd packages/accelerator frontend:build
+diff --git a/.github/actions/setup-aztec/action.yml b/.github/actions/setup-aztec/action.yml
+index 9ed071b..2191e3e 100644
+--- a/.github/actions/setup-aztec/action.yml
++++ b/.github/actions/setup-aztec/action.yml
+@@ -10,11 +10,11 @@ inputs:
+ runs:
+   using: composite
+   steps:
+-    - uses: oven-sh/setup-bun@v2
++    - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+       with:
+-        bun-version: latest
++        bun-version: 1.3.14
+ 
+-    - uses: actions/cache@v5
++    - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+       with:
+         path: ~/.bun/install/cache
+         key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+@@ -34,13 +34,13 @@ runs:
+ 
+     - name: Install Node.js 24
+       if: inputs.skip_cli != 'true'
+-      uses: actions/setup-node@v6
++      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+       with:
+-        node-version: 24
++        node-version: 24.18.0
+ 
+     - name: Install Foundry
+       if: inputs.skip_cli != 'true'
+-      uses: foundry-rs/foundry-toolchain@v1
++      uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1
+       with:
+         # Pinned, not "stable": aztec's L1 deploy wrapper (l1-contracts/scripts/forge_broadcast.js,
+         # since 4.3.1) passes `--batch-size` WITHOUT `--batch`; foundry 1.7 made `--batch-size`
+@@ -52,7 +52,7 @@ runs:
+     - name: Cache Aztec CLI
+       if: inputs.skip_cli != 'true'
+       id: cache-aztec
+-      uses: actions/cache@v5
++      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+       with:
+         path: ~/.aztec/versions/${{ steps.detect.outputs.version }}
+         key: ${{ runner.os }}-aztec-${{ steps.detect.outputs.version }}
+diff --git a/.github/workflows/_aztec-update.yml b/.github/workflows/_aztec-update.yml
+index f0f9267..adcce33 100644
+--- a/.github/workflows/_aztec-update.yml
++++ b/.github/workflows/_aztec-update.yml
+@@ -20,11 +20,15 @@ on:
+         required: false
+         default: ""
+         type: string
+-      auto_merge:
+-        description: "true: gh pr merge --auto --squash; false: gh pr merge --squash (immediate)"
++      merge_mode:
++        # F-008: `none` leaves the PR OPEN for human review (the safe default — a Windows @aztec bump
++        # must not auto-land an unreviewed bb.exe pin). `auto` enables `gh pr merge --auto --squash`,
++        # which still WAITS for the required checks (incl. the fail-closed Windows pin gate). The old
++        # `auto_merge: false` ran an IMMEDIATE `gh pr merge --squash` that bypassed CI entirely — removed.
++        description: "none: create/update the PR and stop (default). auto: gh pr merge --auto --squash (CI-gated)."
+         required: false
+-        default: true
+-        type: boolean
++        default: none
++        type: string
+       version:
+         description: "Force specific version (leave empty for auto-detect)"
+         required: false
+@@ -42,18 +46,22 @@ jobs:
+     name: Check for new ${{ inputs.dist_tag }}
+     runs-on: ubuntu-latest
+     timeout-minutes: 5
++    # F-008 least-privilege: reusable jobs inherit the CALLER's GITHUB_TOKEN scope unless downgraded
++    # here. This job only reads, so read-only — the token cannot merge/push even if a step tried.
++    permissions:
++      contents: read
+     outputs:
+       needs_update: ${{ steps.check.outputs.needs_update }}
+       new_version: ${{ steps.check.outputs.new_version }}
+       current_version: ${{ steps.check.outputs.current_version }}
+     steps:
+-      - uses: actions/checkout@v6
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+         with:
+           ref: ${{ inputs.target_branch }}
+ 
+-      - uses: oven-sh/setup-bun@v2
++      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+         with:
+-          bun-version: latest
++          bun-version: 1.3.14
+ 
+       - name: Check ${{ inputs.dist_tag }} version
+         id: check
+@@ -62,6 +70,15 @@ jobs:
+           INPUT_DIST_TAG: ${{ inputs.dist_tag }}
+         run: |
+           if [ -n "$INPUT_VERSION" ]; then
++            # F-008: validate the forced version against the strict pattern BEFORE emitting it as an
++            # output (it flows into branch names, commits, the fetch URL). A WHOLE-STRING bash `=~` match
++            # (not `grep`, which matches any single line) so a multiline value like $'5.0.0\nneeds_update=false'
++            # cannot slip an injected output record past the check. Generic error — never echo the raw value.
++            VERSION_RE='^[0-9]+\.[0-9]+\.[0-9]+(-(nightly\.[0-9]{8}|rc\.[0-9]+|aztecnr-rc\.[0-9]+))?$'
++            if [[ ! "$INPUT_VERSION" =~ $VERSION_RE ]]; then
++              echo "::error::Invalid forced version (rejected before use)"
++              exit 1
++            fi
+             CURRENT=$(bun -e "console.log(JSON.parse(require('fs').readFileSync('packages/sdk/package.json','utf8')).devDependencies['@aztec/aztec.js'])")
+             {
+               echo "needs_update=true"
+@@ -94,18 +111,21 @@ jobs:
+     if: needs.check-update.outputs.needs_update == 'true'
+     runs-on: ubuntu-latest
+     timeout-minutes: 10
++    # Needs contents:write ONLY here — the branch push. It does NOT create/merge PRs.
++    permissions:
++      contents: write
+     env:
+       NEW_VERSION: ${{ needs.check-update.outputs.new_version }}
+     steps:
+-      - uses: actions/checkout@v6
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+         with:
+           ref: ${{ inputs.target_branch }}
+ 
+-      - uses: oven-sh/setup-bun@v2
++      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+         with:
+-          bun-version: latest
++          bun-version: 1.3.14
+ 
+-      - uses: actions/cache@v5
++      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+         with:
+           path: ~/.bun/install/cache
+           key: ${{ runner.os }}-bun-${{ inputs.dist_tag }}-${{ needs.check-update.outputs.new_version }}
+@@ -119,6 +139,12 @@ jobs:
+       - name: Install dependencies with new versions
+         run: bun install
+ 
++      # F-008: after install (so resolveAztecBb() sees the NEW bb.js), report whether the live bb.js
++      # version has a reviewed Windows pin. Informational — never fetches/writes; the Windows Prebuild/
++      # Build Smoke gate is the enforcing fail-closed check on the PR.
++      - name: Report Windows bb.exe pin status
++        run: bun scripts/check-windows-bb-pin.ts
++
+       - name: Commit and push
+         env:
+           BRANCH_PREFIX: ${{ inputs.branch_prefix }}
+@@ -147,24 +173,29 @@ jobs:
+     if: needs.update.result == 'success'
+     runs-on: ubuntu-latest
+     timeout-minutes: 5
++    # F-008: read-only GITHUB_TOKEN — ALL PR create/edit/close/merge here use the scoped App tokens
++    # (create-pr token has no contents:write; the opt-in merge uses a separate contents-scoped token).
++    # So even the inherited GITHUB_TOKEN cannot merge/push on the `none` path.
++    permissions:
++      contents: read
+     env:
+       NEW_VERSION: ${{ needs.check-update.outputs.new_version }}
+       CURRENT_VERSION: ${{ needs.check-update.outputs.current_version }}
+     steps:
+-      # Short-lived, repo-scoped GitHub App token instead of the long-lived PAT.
+-      # Needs issues:write too — `gh pr edit --add-label` + `gh pr close --comment`
+-      # below go through the issues label/comment endpoints. The token still
+-      # triggers CI on the created PR (so `--auto` waits for the required checks).
++      # Short-lived, repo-scoped GitHub App token. F-008 least-privilege: this token has NO
++      # contents:write — it only creates/edits/closes PRs (pull-requests) + labels/comments (issues).
++      # It cannot merge (merge = contents:write). The `auto` path mints a SEPARATE, narrowly-scoped
++      # contents:write token below, only when explicitly opted in. `issues:write` is for
++      # `gh pr edit --add-label` + `gh pr close --comment`. The token still triggers CI on the PR.
+       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+         id: app-token
+         with:
+           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+-          permission-contents: write
+           permission-pull-requests: write
+           permission-issues: write
+ 
+-      - uses: actions/checkout@v6
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+ 
+       - name: Close stale update PRs
+         env:
+@@ -174,14 +205,19 @@ jobs:
+           NEW_VERSION: ${{ needs.check-update.outputs.new_version }}
+         run: |
+           CURRENT_BRANCH="${BRANCH_PREFIX}-${NEW_VERSION}"
++          # F-008: pass branch_prefix/current-branch as jq --arg DATA, never interpolated into the jq
++          # program (a crafted prefix could otherwise rewrite the filter and select every open PR).
+           gh pr list \
+             --base "$TARGET_BRANCH" \
+             --state open \
+             --json number,headRefName \
+-            --jq ".[] | select(.headRefName | startswith(\"${BRANCH_PREFIX}-\")) | select(.headRefName != \"${CURRENT_BRANCH}\") | .number" \
++          | jq -r --arg prefix "${BRANCH_PREFIX}-" --arg current "$CURRENT_BRANCH" \
++              '.[] | select(.headRefName | startswith($prefix)) | select(.headRefName != $current) | .number' \
+           | while read -r pr_num; do
+               echo "Closing stale PR #$pr_num"
+-              gh pr close "$pr_num" --delete-branch --comment "Superseded by ${NEW_VERSION} update."
++              # F-008 least-privilege: close WITHOUT --delete-branch (deletion needs contents:write,
++              # which this token no longer has). A stale branch is harmless; its PR is closed.
++              gh pr close "$pr_num" --comment "Superseded by ${NEW_VERSION} update."
+             done
+ 
+       - name: Create or update PR
+@@ -190,7 +226,6 @@ jobs:
+           BRANCH_PREFIX: ${{ inputs.branch_prefix }}
+           TARGET_BRANCH: ${{ inputs.target_branch }}
+           ADD_LABEL: ${{ inputs.add_label }}
+-          AUTO_MERGE: ${{ inputs.auto_merge }}
+           DIST_TAG: ${{ inputs.dist_tag }}
+           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+         run: |
+@@ -232,9 +267,27 @@ jobs:
+             gh pr edit "$PR_NUM" --add-label "$ADD_LABEL" 2>/dev/null || true
+           fi
+ 
+-          # Merge strategy: auto-merge waits for checks, immediate merges now
+-          if [ "$AUTO_MERGE" = "true" ]; then
+-            gh pr merge "$PR_NUM" --auto --squash --delete-branch
+-          else
+-            gh pr merge "$PR_NUM" --squash --delete-branch
+-          fi
++          # F-008: the PR is left OPEN for review. Merge (if opted in) happens in the separate,
++          # contents:write-scoped `auto-merge` step below — never here, and never immediately.
++          echo "PR #$PR_NUM is open for review: $(gh pr view "$PR_NUM" --json url --jq .url)"
++          echo "pr_num=$PR_NUM" >> "$GITHUB_OUTPUT"
++        id: pr
++
++      # F-008: `auto` opt-in only. A SEPARATE, narrowly-scoped contents:write token (the create-pr token
++      # above has none) enables `--auto --squash`, which WAITS for the required checks — including the
++      # fail-closed Windows pin gate. `none` (the default) skips this entirely, leaving the PR open.
++      - name: Enable auto-merge (opt-in)
++        if: inputs.merge_mode == 'auto'
++        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
++        id: merge-token
++        with:
++          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
++          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
++          permission-contents: write
++          permission-pull-requests: write
++      - name: Auto-merge (opt-in, CI-gated)
++        if: inputs.merge_mode == 'auto'
++        env:
++          GH_TOKEN: ${{ steps.merge-token.outputs.token }}
++          PR_NUM: ${{ steps.pr.outputs.pr_num }}
++        run: gh pr merge "$PR_NUM" --auto --squash --delete-branch
+diff --git a/.github/workflows/_e2e-app.yml b/.github/workflows/_e2e-app.yml
+index 373a901..689beb0 100644
+--- a/.github/workflows/_e2e-app.yml
++++ b/.github/workflows/_e2e-app.yml
+@@ -27,7 +27,7 @@ jobs:
+     # aztec node setup + the test; ~1-2 min install on a cache hit.
+     timeout-minutes: 55
+     steps:
+-      - uses: actions/checkout@v6
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+         with:
+           ref: ${{ inputs.ref || github.ref }}
+ 
+@@ -52,7 +52,7 @@ jobs:
+ 
+       - name: Upload Aztec logs
+         if: failure()
+-        uses: actions/upload-artifact@v7
++        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+         with:
+           name: aztec-node-logs-app
+           path: /tmp/aztec-node.log
+diff --git a/.github/workflows/_e2e-crash-recovery-windows.yml b/.github/workflows/_e2e-crash-recovery-windows.yml
+index 61d9012..b980dc6 100644
+--- a/.github/workflows/_e2e-crash-recovery-windows.yml
++++ b/.github/workflows/_e2e-crash-recovery-windows.yml
+@@ -21,7 +21,7 @@ jobs:
+     runs-on: windows-2025
+     timeout-minutes: 20
+     steps:
+-      - uses: actions/checkout@v6
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+       - name: Run crash-recovery crux spike
+         shell: pwsh
+         run: ./packages/accelerator/scripts/crash-recovery-smoke-windows.ps1
+diff --git a/.github/workflows/_e2e-updater-linux.yml b/.github/workflows/_e2e-updater-linux.yml
+index 8e75d9c..3a06953 100644
+--- a/.github/workflows/_e2e-updater-linux.yml
++++ b/.github/workflows/_e2e-updater-linux.yml
+@@ -37,6 +37,12 @@ on:
+         required: false
+         default: positive
+         type: string
++    secrets:
++      # F-004: sign the smoke feed with the prod updater key (which N-1 embeds). See _e2e-updater.yml.
++      TAURI_SIGNING_PRIVATE_KEY:
++        required: true
++      TAURI_SIGNING_PRIVATE_KEY_PASSWORD:
++        required: true
+ 
+ jobs:
+   updater-smoke-linux:
+@@ -46,11 +52,11 @@ jobs:
+     permissions:
+       contents: read
+     steps:
+-      - uses: actions/checkout@v6
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+ 
+-      - uses: oven-sh/setup-bun@v2
++      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+         with:
+-          bun-version: latest
++          bun-version: 1.3.14
+ 
+       # FUSE (AppImage runtime) + headless display + tray host + dbus. Running the
+       # AppImage natively (via FUSE) sets $APPIMAGE, which the Tauri Linux updater
+@@ -85,7 +91,7 @@ jobs:
+           } >> "$GITHUB_ENV"
+ 
+       - name: Download N artifacts (this run)
+-        uses: actions/download-artifact@v8
++        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+         with:
+           name: ${{ inputs.n-artifact }}
+           path: n-artifacts
+@@ -121,6 +127,8 @@ jobs:
+       - name: Updater smoke (install N-1 → auto-update to N → assert /health == N)
+         env:
+           UPDATER_SMOKE_MODE: ${{ inputs.mode }}
++          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
++          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+         run: |
+           APPIMAGE=$(find n1 -name '*.AppImage' | head -1)
+           if [ -z "$APPIMAGE" ]; then echo "::error::N-1 AppImage not found"; exit 1; fi
+diff --git a/.github/workflows/_e2e-updater-windows.yml b/.github/workflows/_e2e-updater-windows.yml
+index 2da1386..e0f7a5a 100644
+--- a/.github/workflows/_e2e-updater-windows.yml
++++ b/.github/workflows/_e2e-updater-windows.yml
+@@ -35,6 +35,13 @@ on:
+         required: false
+         default: positive
+         type: string
++    secrets:
++      # F-004: the synthetic N-1 keeps the committed PROD pubkey, so the smoke feed's manifest must be
++      # signed with the prod updater key (NOT the ephemeral key that only emitted N-1's artifacts).
++      TAURI_SIGNING_PRIVATE_KEY:
++        required: true
++      TAURI_SIGNING_PRIVATE_KEY_PASSWORD:
++        required: true
+ 
+ jobs:
+   updater-smoke-windows:
+@@ -48,7 +55,7 @@ jobs:
+       N1_VERSION: ${{ inputs.n1-version }}
+       SMOKE_MODE: ${{ inputs.mode }}
+     steps:
+-      - uses: actions/checkout@v6
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+       - uses: ./.github/actions/setup-accelerator
+         with:
+           rust-cache-key: accelerator-desktop-x86_64-pc-windows-msvc
+@@ -57,7 +64,7 @@ jobs:
+ 
+       # Download the REAL prod-signed N (this run's build): *-setup.nsis.zip + .sig.
+       - name: Download N (prod-signed build artifact)
+-        uses: actions/download-artifact@v8
++        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+         with:
+           name: ${{ inputs.n-artifact }}
+           path: ${{ runner.temp }}/n-dl
+@@ -111,6 +118,10 @@ jobs:
+         shell: pwsh
+         env:
+           UPDATER_SMOKE_MODE: ${{ inputs.mode }}
++          # PROD key for the manifest signature — overrides the ephemeral TAURI_SIGNING_PRIVATE_KEY that
++          # an earlier step exported to GITHUB_ENV (that one only built N-1's artifacts).
++          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
++          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+         run: |
+           $n1 = Get-ChildItem -Path "$env:RUNNER_TEMP\n1" -Filter "*-setup.exe" | Select-Object -First 1
+           if (-not $n1) { Write-Error "N-1 installer not found"; exit 1 }
+diff --git a/.github/workflows/_e2e-updater.yml b/.github/workflows/_e2e-updater.yml
+index 40f6b2e..a726051 100644
+--- a/.github/workflows/_e2e-updater.yml
++++ b/.github/workflows/_e2e-updater.yml
+@@ -38,6 +38,13 @@ on:
+         required: false
+         default: positive
+         type: string
++    secrets:
++      # F-004: a C4+ N-1 enforces the signed-manifest envelope, so the smoke feed must be signed with
++      # the prod updater key (which the synthetic/real N-1 embeds). Same key the build job uses.
++      TAURI_SIGNING_PRIVATE_KEY:
++        required: true
++      TAURI_SIGNING_PRIVATE_KEY_PASSWORD:
++        required: true
+ 
+ jobs:
+   updater-smoke:
+@@ -47,14 +54,14 @@ jobs:
+     permissions:
+       contents: read
+     steps:
+-      - uses: actions/checkout@v6
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+ 
+-      - uses: oven-sh/setup-bun@v2
++      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+         with:
+-          bun-version: latest
++          bun-version: 1.3.14
+ 
+       - name: Download N artifacts (this run)
+-        uses: actions/download-artifact@v8
++        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+         with:
+           name: ${{ inputs.n-artifact }}
+           path: n-artifacts
+@@ -86,6 +93,8 @@ jobs:
+       - name: Updater smoke (install N-1 → auto-update to N → assert /health == N)
+         env:
+           UPDATER_SMOKE_MODE: ${{ inputs.mode }}
++          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
++          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+         run: |
+           DMG=$(find n1 -name '*.dmg' | head -1)
+           if [ -z "$DMG" ]; then echo "::error::N-1 DMG not found"; exit 1; fi
+diff --git a/.github/workflows/_e2e-webdriver.yml b/.github/workflows/_e2e-webdriver.yml
+index 52a5665..da7d88d 100644
+--- a/.github/workflows/_e2e-webdriver.yml
++++ b/.github/workflows/_e2e-webdriver.yml
+@@ -8,7 +8,11 @@ on:
+         required: true
+         type: string
+       mode:
+-        description: "'dev' or 'release'"
++        description: >-
++          'dev' (tauri dev — fast, but is_dev()==true so it never runs the shipped custom-protocol path),
++          'built-debug' (F-012/D8: `tauri build --debug` — a real custom-protocol binary that exercises the
++          production asset+CSP path), or 'release' (release binary; note raw cargo build does NOT enable
++          tauri's custom-protocol feature, so it is also is_dev()==true).
+         required: false
+         type: string
+         default: "dev"
+@@ -27,12 +31,14 @@ jobs:
+         shell: bash
+         working-directory: packages/accelerator
+     steps:
+-      - uses: actions/checkout@v6
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+ 
+       # ── Shared env setup (Bun, Rust toolchain + cache, Linux Tauri deps, bb sidecar) ──
+       - uses: ./.github/actions/setup-accelerator
+         with:
+-          rust-cache-key: e2e-webdriver-${{ inputs.mode }}
++          # F-012: -v2 busts the shared cache once — an earlier PR build could have cached a stale/empty
++          # frontend asset embed (codegen output) that a later build restored instead of regenerating.
++          rust-cache-key: e2e-webdriver-v2-${{ inputs.mode }}
+           rust-components: ""
+ 
+       # ── Linux: WebDriver-specific extras (xvfb + tray + dbus) ──
+@@ -59,16 +65,34 @@ jobs:
+         working-directory: packages/accelerator/src-tauri
+         run: cargo build --release --features webdriver
+ 
++      # ── Build (dev — plain `cargo build`, run DIRECTLY, no `tauri dev`. F-012 ROOT CAUSE: `tauri dev`
++      #    injects a dev-server devUrl (e.g. http://127.0.0.1:1430), which makes tauri-codegen embed an EMPTY
++      #    asset set (context.rs: `dev && dev_url.is_some()`), so the webview's tauri:// protocol 404s every
++      #    asset. A plain `cargo build` has dev_url=None → codegen embeds frontendDist fully → tauri:// works.
++      #    setup-accelerator already built the frontend bundles the build.rs guard needs. ──
++      - name: Build app (dev)
++        if: inputs.mode == 'dev'
++        working-directory: packages/accelerator/src-tauri
++        run: cargo build --features webdriver
++
++      # ── Build (built-debug — F-012/D8: a real `tauri build` enables tauri's custom-protocol feature, so
++      #    the webdriver run exercises the SHIPPED asset/CSP path that `tauri dev` and raw `cargo build` skip.
++      #    Runs from packages/accelerator so tauri's beforeBuildCommand (bun run frontend:build) fires. ──
++      - name: Build app (built-debug)
++        if: inputs.mode == 'built-debug'
++        run: bunx tauri build --debug --no-bundle --features webdriver
++
+       # ── Launch app (single step, no platform conditionals) ──
+       - name: Launch app
+         run: |
+           EXE=""
+           [ "$RUNNER_OS" = "Windows" ] && EXE=".exe"
+-          if [ "${{ inputs.mode }}" = "release" ]; then
+-            APP_CMD="./src-tauri/target/release/aztec-accelerator$EXE"
+-          else
+-            APP_CMD="bunx tauri dev --no-watch --features webdriver"
+-          fi
++          case "${{ inputs.mode }}" in
++            release)     APP_CMD="./src-tauri/target/release/aztec-accelerator$EXE" ;;
++            built-debug) APP_CMD="./src-tauri/target/debug/aztec-accelerator$EXE" ;;
++            *)           APP_CMD="./src-tauri/target/debug/aztec-accelerator$EXE" ;; # dev: built above
++
++          esac
+           $APP_CMD > /tmp/tauri.log 2>&1 &
+           echo "TAURI_PID=$!" >> "$GITHUB_ENV"
+ 
+@@ -117,7 +141,7 @@ jobs:
+       # ── Artifacts on failure ──
+       - name: Upload logs
+         if: failure()
+-        uses: actions/upload-artifact@v7
++        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+         with:
+           name: webdriver-e2e-logs-${{ runner.os }}-${{ inputs.mode }}
+           path: /tmp/tauri.log
+diff --git a/.github/workflows/_e2e.yml b/.github/workflows/_e2e.yml
+index d33566b..b4ae6ca 100644
+--- a/.github/workflows/_e2e.yml
++++ b/.github/workflows/_e2e.yml
+@@ -25,7 +25,7 @@ jobs:
+     runs-on: ubuntu-latest
+     timeout-minutes: 45
+     steps:
+-      - uses: actions/checkout@v6
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+         with:
+           ref: ${{ inputs.ref || github.ref }}
+ 
+@@ -63,15 +63,20 @@ jobs:
+           AZTEC_BB_VERSION="$(cat packages/accelerator/src-tauri/AZTEC_VERSION)"
+           echo "AZTEC_BB_VERSION=$AZTEC_BB_VERSION" >> "$GITHUB_ENV"
+ 
+-      - uses: dtolnay/rust-toolchain@stable
++      # F-015: pin the action to a master-history SHA (NOT the @stable-generated commit, which
++      # upstream may GC) and select the channel explicitly via `toolchain:` — @stable was the
++      # channel selector, so pinning the ref alone would break the toolchain resolution.
++      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+         if: inputs.build_accelerator
++        with:
++          toolchain: stable
+ 
+       # This job builds the server crate FROM packages/accelerator/server, so
+       # Cargo writes all artifacts (incl. the src-tauri path-dep) under
+       # server/target. Cache that dir only. Use the SAME `shared-key` as the
+       # other linux server builds (smoke / release-smoke / release build-headless
+       # + setup-accelerator) so they cross-warm one shared server cache.
+-      - uses: Swatinem/rust-cache@v2
++      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+         if: inputs.build_accelerator
+         with:
+           workspaces: packages/accelerator/server -> target
+@@ -116,7 +121,7 @@ jobs:
+ 
+       - name: Upload Aztec logs
+         if: failure()
+-        uses: actions/upload-artifact@v7
++        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+         with:
+           name: aztec-node-logs-sdk
+           path: /tmp/aztec-node.log
+@@ -125,7 +130,7 @@ jobs:
+ 
+       - name: Upload accelerator logs
+         if: failure() && inputs.build_accelerator
+-        uses: actions/upload-artifact@v7
++        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+         with:
+           name: accelerator-logs
+           path: /tmp/accelerator.log
+diff --git a/.github/workflows/_publish-sdk.yml b/.github/workflows/_publish-sdk.yml
+index f119f03..85fd5fd 100644
+--- a/.github/workflows/_publish-sdk.yml
++++ b/.github/workflows/_publish-sdk.yml
+@@ -37,20 +37,39 @@ jobs:
+       id-token: write # needed for --provenance (Sigstore attestation)
+       contents: write
+     steps:
+-      - uses: actions/checkout@v6
++      # F-006: reject a malformed dist_tag BEFORE checkout or any token-bearing step. Job perms
++      # (id-token/contents: write) and checkout-persisted git credentials are live from step 1, so
++      # validation must come first. Whole-string bash match (not grep, which would pass a multiline
++      # value with one valid line); must start with a lowercase letter, so no leading '-' (npm
++      # option/argument injection) and no leading digit. Read via env, never interpolated into shell.
++      # (A still-invalid tag like a semver range that slips the regex fails later at npm — not an injection.)
++      - name: Validate dist_tag
++        env:
++          DIST_TAG: ${{ inputs.dist_tag }}
++          LC_ALL: C
++        run: |
++          if [[ ! "$DIST_TAG" =~ ^[a-z][a-z0-9._-]*$ ]]; then
++            # Do NOT echo the rejected value: a malformed multiline dist_tag could otherwise inject
++            # ::workflow-commands:: into the log stream. The value is already masked/available to the
++            # operator via the dispatch inputs.
++            echo "::error::Invalid dist_tag (must match ^[a-z][a-z0-9._-]*\$)"
++            exit 1
++          fi
++
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+         with:
+           fetch-depth: 0
+ 
+-      - uses: actions/setup-node@v6
++      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+         with:
+-          node-version: 24
++          node-version: 24.18.0
+           registry-url: https://registry.npmjs.org
+ 
+-      - uses: oven-sh/setup-bun@v2
++      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+         with:
+-          bun-version: latest
++          bun-version: 1.3.14
+ 
+-      - uses: actions/cache@v5
++      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+         with:
+           path: ~/.bun/install/cache
+           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+@@ -76,17 +95,21 @@ jobs:
+ 
+       - name: Determine SDK publish version
+         id: sdk-version
++        env:
++          AZTEC_VERSION: ${{ steps.aztec-version.outputs.version }}
+         run: |
+-          VERSION=$(bun scripts/get-sdk-publish-version.ts "${{ steps.aztec-version.outputs.version }}")
++          VERSION=$(bun scripts/get-sdk-publish-version.ts "$AZTEC_VERSION")
+           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+           echo "SDK publish version: $VERSION"
+ 
+       - name: Set SDK version and fix exports for npm
+         working-directory: packages/sdk
++        env:
++          SDK_VERSION: ${{ steps.sdk-version.outputs.version }}
+         run: |
+           node -e "
+             const p = require('./package.json');
+-            p.version = '${{ steps.sdk-version.outputs.version }}';
++            p.version = process.env.SDK_VERSION;
+             p.main = './dist/index.js';
+             p.types = './dist/index.d.ts';
+             p.exports = { '.': { types: './dist/index.d.ts', default: './dist/index.js' } };
+@@ -98,32 +121,37 @@ jobs:
+         working-directory: packages/sdk
+         env:
+           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+-        run: npm publish --provenance --access public --tag ${{ inputs.dist_tag }} --workspaces=false
++          DIST_TAG: ${{ inputs.dist_tag }}
++        # --tag="$DIST_TAG" (=-form + quoted): DIST_TAG is validated + inert shell data, and the
++        # =-form stops a value from being parsed as a separate npm option.
++        run: npm publish --provenance --access public --tag="$DIST_TAG" --workspaces=false
+ 
+       - name: Also tag as 'latest' on npm
+         if: inputs.latest && inputs.dist_tag != 'latest'
+         working-directory: packages/sdk
+         env:
+           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+-        run: npm dist-tag add "@alejoamiras/aztec-accelerator@${{ steps.sdk-version.outputs.version }}" latest
++          SDK_VERSION: ${{ steps.sdk-version.outputs.version }}
++        run: npm dist-tag add "@alejoamiras/aztec-accelerator@${SDK_VERSION}" latest
+ 
+       - name: Create git tag and GitHub release
+         env:
+           GH_TOKEN: ${{ github.token }}
++          SDK_VERSION: ${{ steps.sdk-version.outputs.version }}
++          AZTEC_VERSION: ${{ steps.aztec-version.outputs.version }}
++          DIST_TAG: ${{ inputs.dist_tag }}
+         run: |
+-          VERSION="${{ steps.sdk-version.outputs.version }}"
+-          AZTEC_VERSION="${{ steps.aztec-version.outputs.version }}"
+-          TAG="@alejoamiras/aztec-accelerator@${VERSION}"
++          TAG="@alejoamiras/aztec-accelerator@${SDK_VERSION}"
+ 
+           git config user.name "github-actions[bot]"
+           git config user.email "github-actions[bot]@users.noreply.github.com"
+           git tag "$TAG" || true
+           git push origin "$TAG" || true
+ 
+-          if [ "$VERSION" = "$AZTEC_VERSION" ]; then
+-            NOTES="Aligned with Aztec ${{ inputs.dist_tag }} version \`${AZTEC_VERSION}\`."
++          if [ "$SDK_VERSION" = "$AZTEC_VERSION" ]; then
++            NOTES="Aligned with Aztec ${DIST_TAG} version \`${AZTEC_VERSION}\`."
+           else
+-            NOTES="SDK revision for Aztec ${{ inputs.dist_tag }} version \`${AZTEC_VERSION}\`."
++            NOTES="SDK revision for Aztec ${DIST_TAG} version \`${AZTEC_VERSION}\`."
+           fi
+ 
+           # ALWAYS --latest=false: `inputs.latest` governs the npm dist-tag only. The repo's GitHub
+diff --git a/.github/workflows/accelerator.yml b/.github/workflows/accelerator.yml
+index e405c6e..1340e4b 100644
+--- a/.github/workflows/accelerator.yml
++++ b/.github/workflows/accelerator.yml
+@@ -3,7 +3,7 @@ name: Accelerator
+ on:
+   workflow_dispatch:
+   pull_request:
+-    branches: [main]
++    branches: [main, security-hardening]
+ 
+ # Cancel a superseded in-flight run when a new commit is pushed to the same PR.
+ concurrency:
+@@ -19,8 +19,8 @@ jobs:
+       desktop: ${{ steps.override.outputs.relevant || steps.filter.outputs.desktop }}
+       integration: ${{ steps.override.outputs.relevant || steps.filter.outputs.integration }}
+     steps:
+-      - uses: actions/checkout@v6
+-      - uses: dorny/paths-filter@v4
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
++      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
+         id: filter
+         with:
+           filters: |
+@@ -31,6 +31,8 @@ jobs:
+             # affect the accelerator's Rust/app build).
+             desktop:
+               - 'packages/accelerator/**'
++              - 'scripts/download-bb*.ts'
++              - 'scripts/__fixtures__/**'
+               - 'packages/sdk/package.json'
+               - 'biome.json'
+               - 'package.json'
+@@ -44,6 +46,8 @@ jobs:
+             # runs on SDK src changes (what `desktop` skips) AND everything else.
+             integration:
+               - 'packages/accelerator/**'
++              - 'scripts/download-bb*.ts'
++              - 'scripts/__fixtures__/**'
+               - 'packages/sdk/src/**'
+               - 'packages/sdk/package.json'
+               - 'biome.json'
+@@ -68,7 +72,7 @@ jobs:
+       run:
+         working-directory: packages/accelerator/src-tauri
+     steps:
+-      - uses: actions/checkout@v6
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+       - uses: ./.github/actions/setup-accelerator
+         with:
+           rust-cache-key: accelerator-desktop-x86_64-unknown-linux-gnu
+@@ -94,7 +98,7 @@ jobs:
+       run:
+         working-directory: packages/accelerator/src-tauri
+     steps:
+-      - uses: actions/checkout@v6
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+       - uses: ./.github/actions/setup-accelerator
+         with:
+           rust-cache-key: accelerator-desktop-x86_64-unknown-linux-gnu
+@@ -106,6 +110,66 @@ jobs:
+       # accelerator-core's own unit tests (113) — not exercised by `cargo test` in src-tauri.
+       - run: cargo test --manifest-path ../core/Cargo.toml
+ 
++  # F-004: full updater-feed sign/verify round-trip with a THROWAWAY key (no prod secret). Guards the
++  # version-binding property end-to-end against tauri-CLI drift and any change to the update-manifest
++  # tool: happy path (envelope -> tauri signer sign -> splice -> verify) must pass, and the F-004 splice
++  # attack (bump the OUTER version while the signed envelope stays put) must be rejected. The rejection
++  # logic itself is also unit-covered by accelerator-core tests above; this proves the real signing path.
++  updater-feed-e2e:
++    name: Updater Feed Sign/Verify E2E
++    needs: changes
++    if: needs.changes.outputs.desktop == 'true'
++    runs-on: ubuntu-latest
++    timeout-minutes: 15
++    steps:
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
++      - uses: ./.github/actions/setup-accelerator
++        with:
++          rust-cache-key: accelerator-desktop-x86_64-unknown-linux-gnu
++          rust-workspaces: packages/accelerator/core -> target
++          rust-components: ""
++          # Only the pure core example + the tauri signer are exercised — no GTK stack, no bb sidecar.
++          install-tauri-system-deps: "false"
++          run-prebuild: "false"
++      - name: Round-trip sign + verify (throwaway key)
++        run: |
++          set -euo pipefail
++          work="$(mktemp -d)"
++
++          # 1. Throwaway updater keypair (never a prod secret; empty password for CI). tauri writes the
++          #    private key + a .pub whose CONTENT is already base64(minisign .pub doc) — the exact format
++          #    tauri.conf.json.plugins.updater.pubkey uses, so the app verifies against this same shape.
++          ( cd packages/accelerator && bunx tauri signer generate --ci -p "" -w "$work/test.key" )
++          cp "$work/test.key.pub" "$work/pubkey.b64"
++          export TAURI_SIGNING_PRIVATE_KEY
++          TAURI_SIGNING_PRIVATE_KEY="$(cat "$work/test.key")"
++          export TAURI_SIGNING_PRIVATE_KEY_PASSWORD=""
++
++          # 2. Representative unsigned feed (artifact `signature` values are opaque to the manifest
++          #    binding — only the manifest signature is cryptographically checked here).
++          jq -n '{version:"1.2.3", notes:"ci", pub_date:"2026-01-01T00:00:00Z", platforms:{
++            "linux-x86_64":{signature:"art-linux", url:"https://example.test/app.AppImage", size:111},
++            "darwin-aarch64":{signature:"art-mac", url:"https://example.test/app.tar.gz", size:222}
++          }}' > "$work/latest.json"
++
++          tool() { cargo run --quiet --manifest-path packages/accelerator/core/Cargo.toml --example update-manifest -- "$@"; }
++
++          # 3. Happy path: envelope -> sign -> splice -> verify (must exit 0).
++          tool envelope --feed "$work/latest.json" > "$work/envelope.json"
++          ( cd packages/accelerator && bunx tauri signer sign "$work/envelope.json" )
++          tool splice --feed "$work/latest.json" --envelope "$work/envelope.json" --sig "$work/envelope.json.sig" > "$work/signed.json"
++          tool verify --feed "$work/signed.json" --pubkey "$work/pubkey.b64"
++          echo "happy-path verify OK"
++
++          # 4. F-004 splice attack: bump the OUTER version; the signed envelope stays at 1.2.3. verify
++          #    MUST reject (OuterMismatch). A pass here is a regression.
++          jq '.version = "9.9.9"' "$work/signed.json" > "$work/tampered.json"
++          if tool verify --feed "$work/tampered.json" --pubkey "$work/pubkey.b64"; then
++            echo "::error::version-splice feed VERIFIED but must have been rejected (F-004 regression)"
++            exit 1
++          fi
++          echo "splice-reject OK (F-004 downgrade attack correctly refused)"
++
+   lint:
+     name: Lint
+     needs: changes
+@@ -113,11 +177,11 @@ jobs:
+     runs-on: ubuntu-latest
+     timeout-minutes: 5
+     steps:
+-      - uses: actions/checkout@v6
+-      - uses: oven-sh/setup-bun@v2
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
++      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+         with:
+-          bun-version: latest
+-      - uses: actions/cache@v5
++          bun-version: 1.3.14
++      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+         with:
+           path: ~/.bun/install/cache
+           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+@@ -126,6 +190,8 @@ jobs:
+       - run: bun run lint
+       - name: Unit-test build scripts (copy-bb supply-chain gate)
+         run: bun run --cwd packages/accelerator test:unit
++      - name: Unit-test root scripts (download-bb F-007 cache-integrity gate)
++        run: bun run test:scripts
+ 
+   smoke:
+     name: Smoke
+@@ -137,7 +203,7 @@ jobs:
+       run:
+         working-directory: packages/accelerator/src-tauri
+     steps:
+-      - uses: actions/checkout@v6
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+       - uses: ./.github/actions/setup-accelerator
+         with:
+           rust-cache-key: accelerator-server-x86_64-unknown-linux-gnu
+@@ -220,7 +286,7 @@ jobs:
+       run:
+         working-directory: packages/accelerator/src-tauri
+     steps:
+-      - uses: actions/checkout@v6
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+       - uses: ./.github/actions/setup-accelerator
+         with:
+           rust-cache-key: accelerator-server-x86_64-unknown-linux-gnu
+@@ -248,11 +314,11 @@ jobs:
+     # cache hit, so this ceiling is a safety net that normal runs never approach.
+     timeout-minutes: 35
+     steps:
+-      - uses: actions/checkout@v6
+-      - uses: oven-sh/setup-bun@v2
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
++      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+         with:
+-          bun-version: latest
+-      - uses: actions/cache@v5
++          bun-version: 1.3.14
++      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+         with:
+           path: ~/.bun/install/cache
+           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+@@ -288,6 +354,19 @@ jobs:
+       runner: ${{ matrix.runner }}
+       mode: dev
+ 
++  # F-012 (D8): the dev matrix above runs `tauri dev`, which is `is_dev()==true` and never exercises the
++  # SHIPPED custom-protocol asset/CSP path. This Linux-only lane does a real `tauri build --debug` so the
++  # trust-boundary spec's CSP + per-window ACL assertions run against a production-mode binary. Linux-only
++  # keeps the extra full-compile cost to one job (the 3-OS dev matrix covers per-platform WebView/IPC diffs).
++  e2e-webdriver-builtdebug:
++    name: E2E WebDriver (built-debug, linux)
++    needs: changes
++    if: needs.changes.outputs.desktop == 'true'
++    uses: ./.github/workflows/_e2e-webdriver.yml
++    with:
++      runner: ubuntu-latest
++      mode: built-debug
++
+   windows-prebuild:
+     name: Windows Prebuild Smoke
+     needs: changes
+@@ -295,11 +374,11 @@ jobs:
+     runs-on: windows-latest
+     timeout-minutes: 15
+     steps:
+-      - uses: actions/checkout@v6
+-      - uses: oven-sh/setup-bun@v2
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
++      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+         with:
+-          bun-version: latest
+-      - uses: actions/cache@v5
++          bun-version: 1.3.14
++      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+         with:
+           path: ~/.bun/install/cache
+           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+@@ -341,7 +420,7 @@ jobs:
+       run:
+         working-directory: packages/accelerator/src-tauri
+     steps:
+-      - uses: actions/checkout@v6
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+       - uses: ./.github/actions/setup-accelerator
+         with:
+           rust-cache-key: accelerator-desktop-x86_64-pc-windows-msvc
+@@ -349,6 +428,10 @@ jobs:
+           rust-components: ""
+       - name: Compile + unit-test the app crate on Windows
+         run: cargo test
++      # accelerator-core on Windows: exercises the bb.exe name, platform binding, marker/publish, and
++      # directory-replacement paths that the app crate doesn't cover (F-007).
++      - name: Compile + unit-test accelerator-core on Windows
++        run: cargo test --manifest-path ../core/Cargo.toml
+       - name: Build the Tauri app (NSIS installer)
+         working-directory: packages/accelerator
+         shell: bash
+@@ -423,12 +506,14 @@ jobs:
+         changes,
+         clippy,
+         test,
++        updater-feed-e2e,
+         lint,
+         smoke,
+         release-smoke,
+         desktop-ui,
+         e2e,
+         e2e-webdriver,
++        e2e-webdriver-builtdebug,
+         windows-prebuild,
+         windows-build,
+       ]
+@@ -437,7 +522,7 @@ jobs:
+     steps:
+       - name: Check results
+         run: |
+-          results="${{ needs.changes.result }} ${{ needs.clippy.result }} ${{ needs.test.result }} ${{ needs.lint.result }} ${{ needs.smoke.result }} ${{ needs.release-smoke.result }} ${{ needs.desktop-ui.result }} ${{ needs.e2e.result }} ${{ needs.e2e-webdriver.result }} ${{ needs.windows-prebuild.result }} ${{ needs.windows-build.result }}"
++          results="${{ needs.changes.result }} ${{ needs.clippy.result }} ${{ needs.test.result }} ${{ needs.updater-feed-e2e.result }} ${{ needs.lint.result }} ${{ needs.smoke.result }} ${{ needs.release-smoke.result }} ${{ needs.desktop-ui.result }} ${{ needs.e2e.result }} ${{ needs.e2e-webdriver.result }} ${{ needs.e2e-webdriver-builtdebug.result }} ${{ needs.windows-prebuild.result }} ${{ needs.windows-build.result }}"
+           for r in $results; do
+             if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
+               echo "Job failed or was cancelled: $r"
+diff --git a/.github/workflows/actionlint.yml b/.github/workflows/actionlint.yml
+index 922e41f..57ccfc2 100644
+--- a/.github/workflows/actionlint.yml
++++ b/.github/workflows/actionlint.yml
+@@ -3,7 +3,7 @@ name: "Lint: Infra & Workflows"
+ on:
+   workflow_dispatch:
+   pull_request:
+-    branches: [main]
++    branches: [main, security-hardening]
+ 
+ jobs:
+   changes:
+@@ -15,8 +15,8 @@ jobs:
+       shell: ${{ steps.override.outputs.shell || steps.filter.outputs.shell }}
+       tofu: ${{ steps.override.outputs.tofu || steps.filter.outputs.tofu }}
+     steps:
+-      - uses: actions/checkout@v6
+-      - uses: dorny/paths-filter@v4
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
++      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
+         id: filter
+         with:
+           filters: |
+@@ -44,22 +44,25 @@ jobs:
+     runs-on: ubuntu-latest
+     timeout-minutes: 5
+     steps:
+-      - uses: actions/checkout@v6
+-      - uses: actions/cache@v5
+-        id: actionlint-cache
+-        with:
+-          path: ./actionlint
+-          key: actionlint-v1.7.11-${{ runner.os }}
+-      - name: Download actionlint
+-        if: steps.actionlint-cache.outputs.cache-hit != 'true'
+-        id: get_actionlint
+-        run: bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.11/scripts/download-actionlint.bash)
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
++      # F-015: download a PINNED actionlint release and verify its SHA-256 instead of piping a
++      # moving `download-actionlint.bash` into bash. No binary cache (a poisoned cache would be a
++      # trusted executable); the ~2 MB download each run is negligible. The prior setup was also
++      # mislabeled — the v1.7.11 installer defaults to actionlint 1.7.10 while the cache key said
++      # 1.7.11. Pinned to 1.7.12 (matches the local lint gate).
++      - name: Download + verify actionlint
++        env:
++          ACTIONLINT_VERSION: 1.7.12
++          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
++        run: |
++          url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
++          curl -fsSL "$url" -o actionlint.tar.gz
++          echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum -c -
++          tar -xzf actionlint.tar.gz actionlint
++          chmod +x actionlint
+         shell: bash
+       - name: Run actionlint
+-        run: |
+-          ACTIONLINT="${{ steps.get_actionlint.outputs.executable }}"
+-          [ -z "$ACTIONLINT" ] && ACTIONLINT="./actionlint"
+-          "$ACTIONLINT" -color
++        run: ./actionlint -color
+         shell: bash
+ 
+   shellcheck:
+@@ -69,9 +72,14 @@ jobs:
+     runs-on: ubuntu-latest
+     timeout-minutes: 5
+     steps:
+-      - uses: actions/checkout@v6
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+       - name: Run shellcheck
+-        run: shellcheck infra/*.sh
++        # F-015/C0: `shellcheck infra/*.sh` errors when the glob matches nothing (no infra scripts
++        # today), which fails the job on workflow_dispatch. `find … | xargs -0r` is empty-safe AND
++        # recursive — matching the `infra/**/*.sh` paths-filter so a nested script can't trigger the
++        # job yet silently skip linting. `xargs -0r` propagates shellcheck's real exit code (the old
++        # `&& … || echo` form would have masked a genuine failure as success).
++        run: find infra -type f -name '*.sh' -print0 | xargs -0r shellcheck
+ 
+   tofu:
+     name: Lint OpenTofu
+@@ -80,8 +88,8 @@ jobs:
+     runs-on: ubuntu-latest
+     timeout-minutes: 5
+     steps:
+-      - uses: actions/checkout@v6
+-      - uses: opentofu/setup-opentofu@v1
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
++      - uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1
+         with:
+           tofu_version: '1.10.0'
+       - name: Format check
+diff --git a/.github/workflows/app.yml b/.github/workflows/app.yml
+index 84cf20d..c2187d4 100644
+--- a/.github/workflows/app.yml
++++ b/.github/workflows/app.yml
+@@ -3,7 +3,7 @@ name: App
+ on:
+   workflow_dispatch:
+   pull_request:
+-    branches: [main]
++    branches: [main, security-hardening]
+ 
+ # Cancel a superseded in-flight run when a new commit is pushed to the same PR.
+ concurrency:
+@@ -18,8 +18,8 @@ jobs:
+     outputs:
+       relevant: ${{ steps.override.outputs.relevant || steps.filter.outputs.relevant }}
+     steps:
+-      - uses: actions/checkout@v6
+-      - uses: dorny/paths-filter@v4
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
++      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
+         id: filter
+         with:
+           filters: |
+@@ -46,11 +46,11 @@ jobs:
+     runs-on: ubuntu-latest
+     timeout-minutes: 5
+     steps:
+-      - uses: actions/checkout@v6
+-      - uses: oven-sh/setup-bun@v2
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
++      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+         with:
+-          bun-version: latest
+-      - uses: actions/cache@v5
++          bun-version: 1.3.14
++      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+         with:
+           path: ~/.bun/install/cache
+           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+@@ -69,11 +69,11 @@ jobs:
+     runs-on: ubuntu-latest
+     timeout-minutes: 5
+     steps:
+-      - uses: actions/checkout@v6
+-      - uses: oven-sh/setup-bun@v2
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
++      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+         with:
+-          bun-version: latest
+-      - uses: actions/cache@v5
++          bun-version: 1.3.14
++      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+         with:
+           path: ~/.bun/install/cache
+           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+@@ -90,11 +90,11 @@ jobs:
+     # a cache hit, so this ceiling is a safety net normal runs never approach.
+     timeout-minutes: 35
+     steps:
+-      - uses: actions/checkout@v6
+-      - uses: oven-sh/setup-bun@v2
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
++      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+         with:
+-          bun-version: latest
+-      - uses: actions/cache@v5
++          bun-version: 1.3.14
++      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+         with:
+           path: ~/.bun/install/cache
+           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+@@ -112,11 +112,11 @@ jobs:
+     # a cache hit, so this ceiling is a safety net normal runs never approach.
+     timeout-minutes: 35
+     steps:
+-      - uses: actions/checkout@v6
+-      - uses: oven-sh/setup-bun@v2
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
++      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+         with:
+-          bun-version: latest
+-      - uses: actions/cache@v5
++          bun-version: 1.3.14
++      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+         with:
+           path: ~/.bun/install/cache
+           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+diff --git a/.github/workflows/aztec-nightlies.yml b/.github/workflows/aztec-nightlies.yml
+deleted file mode 100644
+index 9715ef3..0000000
+--- a/.github/workflows/aztec-nightlies.yml
++++ /dev/null
+@@ -1,31 +0,0 @@
+-name: Aztec Nightlies Update
+-
+-on:
+-  workflow_dispatch:
+-    inputs:
+-      version:
+-        description: "Force specific version (leave empty for auto-detect)"
+-        required: false
+-        type: string
+-
+-concurrency:
+-  group: aztec-nightlies
+-  cancel-in-progress: true
+-
+-permissions:
+-  contents: write
+-  pull-requests: write
+-
+-jobs:
+-  update:
+-    uses: ./.github/workflows/_aztec-update.yml
+-    secrets:
+-      RELEASE_BOT_APP_ID: ${{ secrets.RELEASE_BOT_APP_ID }}
+-      RELEASE_BOT_PRIVATE_KEY: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+-    with:
+-      dist_tag: nightly
+-      target_branch: nightlies
+-      branch_prefix: chore/aztec-nightlies
+-      add_label: test-infra
+-      auto_merge: false
+-      version: ${{ inputs.version || '' }}
+diff --git a/.github/workflows/aztec-stable.yml b/.github/workflows/aztec-stable.yml
+index a4b6082..80c248a 100644
+--- a/.github/workflows/aztec-stable.yml
++++ b/.github/workflows/aztec-stable.yml
+@@ -13,8 +13,10 @@ concurrency:
+   cancel-in-progress: true
+ 
+ permissions:
++  # F-008: the GITHUB_TOKEN needs contents:write ONLY for the `update` job's branch push. PR
++  # create/edit/close use the reusable workflow's separate GitHub App token, so no pull-requests:write
++  # here. Merge (auto opt-in) uses a distinct contents-scoped app token inside the reusable workflow.
+   contents: write
+-  pull-requests: write
+ 
+ jobs:
+   update:
+@@ -26,5 +28,5 @@ jobs:
+       dist_tag: rc
+       target_branch: main
+       branch_prefix: chore/aztec-stable
+-      auto_merge: false
++      merge_mode: none
+       version: ${{ inputs.version || '' }}
+diff --git a/.github/workflows/deploy-landing.yml b/.github/workflows/deploy-landing.yml
+index 1590cf6..041d85a 100644
+--- a/.github/workflows/deploy-landing.yml
++++ b/.github/workflows/deploy-landing.yml
+@@ -16,10 +16,20 @@ jobs:
+     runs-on: ubuntu-latest
+     timeout-minutes: 10
+     steps:
+-      - uses: actions/checkout@v6
++      # F-005: the ci-landing role trusts only refs/heads/main; a workflow_dispatch from another ref would
++      # fail at AssumeRole anyway, but assert early so it fails before build with a clear message.
++      - name: Assert main ref
++        run: |
++          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
++            echo "::error::Deploy Landing Page must run on refs/heads/main (got $GITHUB_REF)"; exit 1
++          fi
++
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+ 
+-      - uses: oven-sh/setup-bun@v2
+-      - uses: actions/cache@v5
++      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
++        with:
++          bun-version: 1.3.14
++      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+         with:
+           path: ~/.bun/install/cache
+           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+@@ -28,15 +38,18 @@ jobs:
+ 
+       - run: bun run --cwd packages/landing build
+ 
+-      - uses: aws-actions/configure-aws-credentials@v6
++      - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
+         with:
+-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
++          role-to-assume: ${{ secrets.AWS_ROLE_ARN_LANDING }}
+           aws-region: ${{ secrets.AWS_REGION }}
+ 
+       - name: Deploy to S3
+         run: |
++          # F-005/F-004: NEVER delete the update feed. --exclude keeps `landing/releases/*` (and the exact
++          # `releases` key) out of the --delete set; the ci-landing IAM policy ALSO Denies those, so a
++          # missing exclude fails loud instead of deleting latest.json.
+           aws s3 sync packages/landing/dist/ s3://${{ secrets.S3_BUCKET_NAME }}/landing/ \
+-            --delete
++            --delete --exclude "releases" --exclude "releases/*"
+ 
+       - name: Invalidate CloudFront
+         run: |
+diff --git a/.github/workflows/publish-nightlies.yml b/.github/workflows/publish-nightlies.yml
+deleted file mode 100644
+index d8ed119..0000000
+--- a/.github/workflows/publish-nightlies.yml
++++ /dev/null
+@@ -1,82 +0,0 @@
+-name: Publish Nightlies
+-
+-on:
+-  workflow_dispatch:
+-
+-concurrency:
+-  group: publish-nightlies
+-  cancel-in-progress: true
+-
+-permissions:
+-  id-token: write
+-  contents: write
+-
+-jobs:
+-  changes:
+-    name: Detect changes
+-    runs-on: ubuntu-latest
+-    timeout-minutes: 2
+-    outputs:
+-      sdk: ${{ steps.filter.outputs.sdk }}
+-      playground: ${{ steps.filter.outputs.playground }}
+-    steps:
+-      - uses: actions/checkout@v6
+-      - uses: dorny/paths-filter@v4
+-        id: filter
+-        with:
+-          filters: |
+-            sdk:
+-              - "packages/sdk/**"
+-            playground:
+-              - "packages/playground/**"
+-
+-  e2e:
+-    uses: ./.github/workflows/_e2e.yml
+-    with:
+-      ref: ${{ github.sha }}
+-
+-  publish-sdk:
+-    needs: [changes, e2e]
+-    if: needs.changes.outputs.sdk == 'true' || github.event_name == 'workflow_dispatch'
+-    uses: ./.github/workflows/_publish-sdk.yml
+-    with:
+-      dist_tag: nightlies
+-    secrets:
+-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+-
+-  deploy-app:
+-    # Deploy playground unless E2E explicitly failed — skip on cancel, proceed on skip/success.
+-    if: ${{ !cancelled() && needs.e2e.result != 'failure' }}
+-    needs: e2e
+-    runs-on: ubuntu-latest
+-    timeout-minutes: 10
+-    steps:
+-      - uses: actions/checkout@v6
+-
+-      - uses: oven-sh/setup-bun@v2
+-      - uses: actions/cache@v5
+-        with:
+-          path: ~/.bun/install/cache
+-          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+-          restore-keys: ${{ runner.os }}-bun-
+-      - run: bun install --frozen-lockfile
+-
+-      - name: Build playground
+-        env:
+-          AZTEC_NODE_URL: ${{ secrets.TESTNET_AZTEC_NODE_URL }}
+-        run: bun run --cwd packages/playground build
+-
+-      - uses: aws-actions/configure-aws-credentials@v6
+-        with:
+-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+-          aws-region: ${{ secrets.AWS_REGION }}
+-
+-      - name: Deploy playground to S3
+-        run: |
+-          aws s3 sync packages/playground/dist/ s3://${{ secrets.S3_BUCKET_NAME }}/playground-nightly/ --delete
+-
+-      - name: Invalidate CloudFront
+-        run: |
+-          aws cloudfront create-invalidation \
+-            --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} \
+-            --paths "/playground-nightly/*"
+diff --git a/.github/workflows/publish-testnet.yml b/.github/workflows/publish-testnet.yml
+index b48dc46..db45a7a 100644
+--- a/.github/workflows/publish-testnet.yml
++++ b/.github/workflows/publish-testnet.yml
+@@ -13,9 +13,10 @@ concurrency:
+   group: publish-testnet
+   cancel-in-progress: true
+ 
++# F-005: least-privilege default. id-token: write (OIDC) is granted ONLY to the two jobs that need it
++# (deploy-app for AWS, publish-sdk for Sigstore provenance), not workflow-wide.
+ permissions:
+-  id-token: write
+-  contents: write
++  contents: read
+ 
+ jobs:
+   changes:
+@@ -26,8 +27,8 @@ jobs:
+       sdk: ${{ steps.filter.outputs.sdk }}
+       playground: ${{ steps.filter.outputs.playground }}
+     steps:
+-      - uses: actions/checkout@v6
+-      - uses: dorny/paths-filter@v4
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
++      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
+         id: filter
+         with:
+           filters: |
+@@ -46,6 +47,10 @@ jobs:
+     # Skip when deploying the playground only. latest:false — while @aztec deps are rc-labeled the
+     # SDK ships on the `testnet` dist-tag, never npm `latest` (which stays on the last stable line).
+     if: (needs.changes.outputs.sdk == 'true' || github.event_name == 'workflow_dispatch') && inputs.skip_sdk_publish != true
++    # id-token+contents:write for _publish-sdk.yml's Sigstore provenance + npm publish.
++    permissions:
++      id-token: write
++      contents: write
+     uses: ./.github/workflows/_publish-sdk.yml
+     with:
+       dist_tag: testnet
+@@ -59,11 +64,16 @@ jobs:
+     needs: e2e
+     runs-on: ubuntu-latest
+     timeout-minutes: 10
++    permissions:
++      id-token: write # OIDC → AWS (ci-playground-testnet role)
++      contents: read
+     steps:
+-      - uses: actions/checkout@v6
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+ 
+-      - uses: oven-sh/setup-bun@v2
+-      - uses: actions/cache@v5
++      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
++        with:
++          bun-version: 1.3.14
++      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+         with:
+           path: ~/.bun/install/cache
+           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+@@ -75,9 +85,9 @@ jobs:
+           AZTEC_NODE_URL: ${{ secrets.TESTNET_AZTEC_NODE_URL }}
+         run: bun run --cwd packages/playground build
+ 
+-      - uses: aws-actions/configure-aws-credentials@v6
++      - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
+         with:
+-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
++          role-to-assume: ${{ secrets.AWS_ROLE_ARN_PLAYGROUND }}
+           aws-region: ${{ secrets.AWS_REGION }}
+ 
+       - name: Deploy playground to S3
+diff --git a/.github/workflows/release-accelerator.yml b/.github/workflows/release-accelerator.yml
+index c41811a..6da78e1 100644
+--- a/.github/workflows/release-accelerator.yml
++++ b/.github/workflows/release-accelerator.yml
+@@ -7,6 +7,11 @@ on:
+         description: "Version to release (e.g. 1.2.0)"
+         required: true
+         type: string
++      auth_probe:
++        description: "F-005: prove the release OIDC role assumes correctly, then STOP (no build/tag/release/publish)"
++        required: false
++        type: boolean
++        default: false
+ 
+ concurrency:
+   group: release-accelerator
+@@ -48,6 +53,29 @@ jobs:
+           } >> "$GITHUB_OUTPUT"
+           echo "Resolved: version=$INPUT_VERSION  is_prerelease=$IS_PRERELEASE"
+ 
++  # F-005 (Codex C3): prove the release OIDC token can assume the release-feed role BEFORE any tag/release
++  # side effect. `tag` needs this, so a post-cutover trust/secret failure aborts before a dangling tag is
++  # pushed. Runs on every dispatch (the release role is assumable on Release Accelerator/main regardless of
++  # is_prerelease); with `auth_probe=true` this is the only meaningful job — the side-effecting jobs are
++  # all guarded off. GetBucketLocation is the least-privilege probe (allowed by the release policy).
++  release-auth-preflight:
++    name: Release AWS trust preflight
++    needs: [validate]
++    runs-on: ubuntu-latest
++    timeout-minutes: 5
++    permissions:
++      id-token: write
++      contents: read
++    steps:
++      - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
++        with:
++          role-to-assume: ${{ secrets.AWS_ROLE_ARN_RELEASE }}
++          aws-region: ${{ secrets.AWS_REGION }}
++      - name: Prove the release role (GetBucketLocation only)
++        run: |
++          aws s3api get-bucket-location --bucket "${{ secrets.S3_BUCKET_NAME }}" >/dev/null
++          echo "✅ release role assumed + GetBucketLocation OK"
++
+   e2e-webdriver:
+     name: Pre-release E2E Gate
+     needs: validate
+@@ -102,7 +130,7 @@ jobs:
+             runner: windows-latest
+             platform: windows-x86_64
+     steps:
+-      - uses: actions/checkout@v6
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+ 
+       - uses: ./.github/actions/setup-accelerator
+         with:
+@@ -220,7 +248,7 @@ jobs:
+           done
+ 
+       - name: Upload artifacts
+-        uses: actions/upload-artifact@v7
++        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+         with:
+           name: accelerator-${{ matrix.platform }}
+           path: |
+@@ -258,7 +286,7 @@ jobs:
+             runner: ubuntu-24.04-arm
+             platform: linux-arm64
+     steps:
+-      - uses: actions/checkout@v6
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+ 
+       - uses: ./.github/actions/setup-accelerator
+         with:
+@@ -317,7 +345,7 @@ jobs:
+           shasum -a 256 -c "$TARBALL.sha256"
+ 
+       - name: Upload artifacts
+-        uses: actions/upload-artifact@v7
++        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+         with:
+           name: accelerator-server-${{ matrix.platform }}
+           path: |
+@@ -332,7 +360,7 @@ jobs:
+     permissions:
+       contents: read
+     steps:
+-      - uses: actions/download-artifact@v8
++      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+         with:
+           name: accelerator-macos-arm64
+           path: artifacts
+@@ -402,7 +430,7 @@ jobs:
+ 
+       - name: Upload logs
+         if: failure()
+-        uses: actions/upload-artifact@v7
++        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+         with:
+           name: post-build-smoke-logs
+           path: /tmp/smoke.log
+@@ -423,7 +451,7 @@ jobs:
+     permissions:
+       contents: read
+     steps:
+-      - uses: actions/download-artifact@v8
++      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+         with:
+           name: accelerator-macos-x86_64
+           path: artifacts
+@@ -491,6 +519,9 @@ jobs:
+       n-artifact: ${{ matrix.n-artifact }}
+       n1-dmg-glob: ${{ matrix.n1-dmg-glob }}
+       mode: ${{ matrix.mode }}
++    secrets:
++      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
++      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+ 
+   # Linux/AppImage updater smoke — BLOCKING (in `tag.needs` + `release.needs`).
+   # Proves a user on the previous stable AppImage auto-updates to N AND the
+@@ -505,6 +536,9 @@ jobs:
+     uses: ./.github/workflows/_e2e-updater-linux.yml
+     with:
+       n-version: ${{ needs.validate.outputs.version }}
++    secrets:
++      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
++      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+ 
+   # Windows/NSIS updater smoke — BLOCKING (in tag.needs + release.needs), proven green on the
+   # 1.0.4-rc.3 dry-run (positive + negative). Tests the REAL prod-signed Windows artifact (this run's
+@@ -525,6 +559,9 @@ jobs:
+     with:
+       n-version: ${{ needs.validate.outputs.version }}
+       mode: positive
++    secrets:
++      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
++      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+ 
+   update-smoke-windows-negative:
+     name: Updater Smoke (windows-x86_64 / negative)
+@@ -539,43 +576,199 @@ jobs:
+     with:
+       n-version: ${{ needs.validate.outputs.version }}
+       mode: negative
++    secrets:
++      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
++      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+ 
+   tag:
+     name: Create Git Tag
+-    needs: [validate, build, build-headless, smoke, smoke-intel, update-smoke, update-smoke-linux, update-smoke-windows, update-smoke-windows-negative, e2e-webdriver]
++    needs: [validate, release-auth-preflight, build, build-headless, smoke, smoke-intel, update-smoke, update-smoke-linux, update-smoke-windows, update-smoke-windows-negative, e2e-webdriver]
++    # F-005: skip in auth_probe mode so a probe never pushes a tag. release-auth-preflight in `needs`
++    # means a broken release-role trust aborts BEFORE the tag is pushed (no dangling tag).
++    if: ${{ !inputs.auth_probe }}
+     runs-on: ubuntu-latest
+     timeout-minutes: 5
+     permissions:
+       contents: write
+     steps:
+-      - uses: actions/checkout@v6
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+         with:
+           fetch-tags: true
++      # codex audit #9: pin the tag to the EXACT commit the whole pipeline validated. checkout@v6
++      # defaults to github.sha, but assert it explicitly so the pushed tag can never target a
++      # different HEAD than the one build/smoke/e2e all ran against (shipped-integrity anchor).
++      - name: Verify checkout is the dispatched commit (tag == github.sha)
++        env:
++          EXPECTED_SHA: ${{ github.sha }}
++        run: |
++          ACTUAL_SHA="$(git rev-parse HEAD)"
++          if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
++            echo "::error::HEAD ($ACTUAL_SHA) != github.sha ($EXPECTED_SHA); refusing to tag a drifted commit"
++            exit 1
++          fi
++          echo "Tagging verified commit $ACTUAL_SHA"
+       - name: Create and push tag
+         env:
+           TAG: ${{ needs.validate.outputs.tag }}
++          EXPECTED_SHA: ${{ github.sha }}
+         run: |
+-          if git rev-parse "$TAG" >/dev/null 2>&1; then
+-            echo "Tag $TAG already exists, skipping creation"
++          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null 2>&1; then
++            # An existing tag MUST already point at github.sha; a tag pinned to a different commit is a
++            # release-integrity red flag (someone pre-created it) — fail rather than silently proceed.
++            EXISTING_SHA="$(git rev-parse "refs/tags/$TAG^{commit}")"
++            if [ "$EXISTING_SHA" != "$EXPECTED_SHA" ]; then
++              echo "::error::Tag $TAG already exists at $EXISTING_SHA, not github.sha ($EXPECTED_SHA); aborting"
++              exit 1
++            fi
++            echo "Tag $TAG already exists at the expected commit, skipping creation"
+           else
+             git tag "$TAG"
+             git push origin "$TAG"
+             echo "Created and pushed tag $TAG"
+           fi
+ 
++  # F-004: assemble, SIGN, and verify the auto-updater feed in an ISOLATED least-privilege job.
++  # The signed-manifest envelope binds the advertised version to the exact signed artifact set,
++  # closing the downgrade-splice (a feed writer advertising a HIGH version while pointing url/signature
++  # at an OLD, still-validly-signed artifact). Signing lives HERE (`contents: read` + the signing secret
++  # only) rather than in `release` (`contents: write` + `id-token: write` for OIDC→AWS) so the
++  # update-signing capability is never co-located with prod-cloud credentials. `release` consumes the
++  # signed feed as an artifact and never holds the signing key. The `verify` step runs the SAME
++  # production Rust verifier the app runs, so a mis-signed/mis-bound feed FAILS the release here instead
++  # of shipping a self-DoS (Layer A would then reject every update).
++  sign-update-feed:
++    name: Sign update feed
++    needs: [validate, build, build-headless, smoke, smoke-intel, update-smoke, update-smoke-linux, update-smoke-windows, update-smoke-windows-negative, e2e-webdriver]
++    # Only stable releases publish an auto-update feed (mirrors the old inline is_prerelease gate).
++    if: needs.validate.outputs.is_prerelease == 'false'
++    runs-on: ubuntu-latest
++    timeout-minutes: 15
++    permissions:
++      contents: read
++    steps:
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
++
++      - uses: ./.github/actions/setup-accelerator
++        with:
++          rust-target: x86_64-unknown-linux-gnu
++          rust-cache-key: accelerator-sign-feed
++          rust-workspaces: packages/accelerator/core -> target
++          rust-components: ""
++          # Signing + the pure-core `update-manifest` example need neither the GTK stack nor the bb sidecar.
++          install-tauri-system-deps: "false"
++          run-prebuild: "false"
++
++      - name: Download all artifacts
++        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
++        with:
++          path: artifacts
++
++      - name: Assemble, sign, and verify latest.json
++        env:
++          VERSION: ${{ needs.validate.outputs.version }}
++          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
++          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
++          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
++        run: |
++          set -euo pipefail
++          REPO="alejoamiras/aztec-accelerator"
++          BASE_URL="https://github.com/${REPO}/releases/download/${RELEASE_TAG}"
++
++          # Signatures from the .sig files. This job does NOT flatten/rename, so artifacts/ still holds
++          # both the updater artifacts AND their .sig siblings.
++          DARWIN_AARCH64_SIG=$(find artifacts/accelerator-macos-arm64 -name '*.app.tar.gz.sig' -exec cat {} \;)
++          DARWIN_X86_64_SIG=$(find artifacts/accelerator-macos-x86_64 -name '*.app.tar.gz.sig' -exec cat {} \;)
++          LINUX_APPIMAGE_SIG=$(find artifacts/accelerator-linux-x86_64 -name '*.AppImage.sig' -exec cat {} \;)
++          WINDOWS_X86_64_SIG=$(find artifacts/accelerator-windows-x86_64 -name '*-setup.nsis.zip.sig' -exec cat {} \;)
++
++          # Byte sizes from the ORIGINAL artifact files (identical bytes to the renamed release files the
++          # URLs point at). The signed envelope makes this size authoritative (SEC-03 cap can't be lied to).
++          size_of() { wc -c < "$1" | tr -d ' '; }
++          DARWIN_AARCH64_SIZE=$(size_of "$(find artifacts/accelerator-macos-arm64 -name '*.app.tar.gz' | head -1)")
++          DARWIN_X86_64_SIZE=$(size_of "$(find artifacts/accelerator-macos-x86_64 -name '*.app.tar.gz' | head -1)")
++          LINUX_X86_64_SIZE=$(size_of "$(find artifacts/accelerator-linux-x86_64 -name '*.AppImage' | head -1)")
++          WINDOWS_X86_64_SIZE=$(size_of "$(find artifacts/accelerator-windows-x86_64 -name '*-setup.nsis.zip' | head -1)")
++
++          # Empty sig/size ⇒ broken auto-update. Fail loudly (matches the old jq-block assertion).
++          for var_name in DARWIN_AARCH64_SIG DARWIN_X86_64_SIG LINUX_APPIMAGE_SIG WINDOWS_X86_64_SIG \
++                          DARWIN_AARCH64_SIZE DARWIN_X86_64_SIZE LINUX_X86_64_SIZE WINDOWS_X86_64_SIZE; do
++            if [ -z "${!var_name}" ]; then
++              echo "::error::Missing $var_name — cannot generate latest.json"
++              exit 1
++            fi
++          done
++
++          jq -n \
++            --arg version "$VERSION" \
++            --arg pub_date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
++            --arg darwin_aarch64_sig "$DARWIN_AARCH64_SIG" \
++            --arg darwin_aarch64_url "${BASE_URL}/Aztec-Accelerator-${VERSION}-macOS-Apple-Silicon.app.tar.gz" \
++            --argjson darwin_aarch64_size "$DARWIN_AARCH64_SIZE" \
++            --arg darwin_x86_64_sig "$DARWIN_X86_64_SIG" \
++            --arg darwin_x86_64_url "${BASE_URL}/Aztec-Accelerator-${VERSION}-macOS-Intel.app.tar.gz" \
++            --argjson darwin_x86_64_size "$DARWIN_X86_64_SIZE" \
++            --arg linux_x86_64_sig "$LINUX_APPIMAGE_SIG" \
++            --arg linux_x86_64_url "${BASE_URL}/Aztec-Accelerator-${VERSION}-Linux-x86_64.AppImage" \
++            --argjson linux_x86_64_size "$LINUX_X86_64_SIZE" \
++            --arg windows_x86_64_sig "$WINDOWS_X86_64_SIG" \
++            --arg windows_x86_64_url "${BASE_URL}/Aztec-Accelerator-${VERSION}-Windows-x86_64-setup.nsis.zip" \
++            --argjson windows_x86_64_size "$WINDOWS_X86_64_SIZE" \
++            '{
++              version: $version,
++              notes: ("Aztec Accelerator " + $version),
++              pub_date: $pub_date,
++              platforms: {
++                "darwin-aarch64": { signature: $darwin_aarch64_sig, url: $darwin_aarch64_url, size: $darwin_aarch64_size },
++                "darwin-x86_64": { signature: $darwin_x86_64_sig, url: $darwin_x86_64_url, size: $darwin_x86_64_size },
++                "linux-x86_64": { signature: $linux_x86_64_sig, url: $linux_x86_64_url, size: $linux_x86_64_size },
++                "windows-x86_64": { signature: $windows_x86_64_sig, url: $windows_x86_64_url, size: $windows_x86_64_size }
++              }
++            }' > latest.json
++
++          # Pinned pubkey, verbatim from tauri.conf.json (already base64 of the minisign .pub — the exact
++          # key the app + the plugin trust).
++          bun -e "console.log(JSON.parse(await Bun.file('packages/accelerator/src-tauri/tauri.conf.json').text()).plugins.updater.pubkey)" > pubkey.b64
++
++          tool() { cargo run --quiet --manifest-path packages/accelerator/core/Cargo.toml --example update-manifest -- "$@"; }
++
++          # Assemble the canonical envelope bytes → sign them with the release key → splice manifest +
++          # manifest_sig into the feed → VERIFY with the PRODUCTION verifier (fails the job on any
++          # mis-signed / mis-bound feed, before the release job can publish it).
++          tool envelope --feed latest.json > envelope.json
++          ( cd packages/accelerator && bunx tauri signer sign "${GITHUB_WORKSPACE}/envelope.json" )
++          tool splice --feed latest.json --envelope envelope.json --sig envelope.json.sig > latest.signed.json
++          tool verify --feed latest.signed.json --pubkey pubkey.b64
++          mv latest.signed.json latest.json
++
++          echo "Signed + verified latest.json:"
++          cat latest.json
++
++      - name: Upload signed update feed
++        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
++        with:
++          name: signed-update-feed
++          path: latest.json
++          if-no-files-found: error
++
+   release:
+     name: Create GitHub Release
+-    needs: [validate, build, build-headless, smoke, smoke-intel, update-smoke, update-smoke-linux, update-smoke-windows, update-smoke-windows-negative, tag, e2e-webdriver]
++    needs: [validate, build, build-headless, smoke, smoke-intel, update-smoke, update-smoke-linux, update-smoke-windows, update-smoke-windows-negative, tag, e2e-webdriver, sign-update-feed]
++    # sign-update-feed is SKIPPED for prereleases (they get no feed); a skipped need must not skip
++    # release. Run whenever nothing FAILED/was cancelled — so a failed signing correctly blocks release,
++    # a skipped one (prerelease) does not.
++    # F-005: `!inputs.auth_probe` so a probe never publishes. `tag` is skipped in probe mode, but this
++    # job's `!cancelled()` would otherwise still run it — guard explicitly.
++    if: ${{ !inputs.auth_probe && !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+     runs-on: ubuntu-latest
+     timeout-minutes: 5
+     permissions:
+       contents: write     # gh release create
+       id-token: write     # OIDC for aws-actions/configure-aws-credentials
+     steps:
+-      - uses: actions/checkout@v6
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+ 
+       - name: Download all artifacts
+-        uses: actions/download-artifact@v8
++        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+         with:
+           path: artifacts
+ 
+@@ -638,74 +831,22 @@ jobs:
+           done
+           echo "All ${#EXPECTED[@]} expected artifacts present"
+ 
+-      - name: Generate latest.json for auto-updater
++      # F-004: latest.json is now assembled, SIGNED, and verified by the isolated sign-update-feed job
++      # (contents: read + signing key only). This job just stages that verified feed alongside the
++      # release artifacts — no signing key here, no re-generation. Gated on stable exactly like the old
++      # inline step; prereleases still ship no feed.
++      - name: Download signed update feed
+         if: needs.validate.outputs.is_prerelease == 'false'
+-        env:
+-          VERSION: ${{ needs.validate.outputs.version }}
+-          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+-        run: |
+-          REPO="alejoamiras/aztec-accelerator"
+-          BASE_URL="https://github.com/${REPO}/releases/download/${RELEASE_TAG}"
+-
+-          # Read signatures from .sig files in artifacts
+-          DARWIN_AARCH64_SIG=$(find artifacts/accelerator-macos-arm64 -name '*.app.tar.gz.sig' -exec cat {} \; 2>/dev/null || echo "")
+-          DARWIN_X86_64_SIG=$(find artifacts/accelerator-macos-x86_64 -name '*.app.tar.gz.sig' -exec cat {} \; 2>/dev/null || echo "")
+-          LINUX_APPIMAGE_SIG=$(find artifacts -name '*.AppImage.sig' -exec cat {} \; 2>/dev/null || echo "")
+-          WINDOWS_X86_64_SIG=$(find artifacts/accelerator-windows-x86_64 -name '*-setup.nsis.zip.sig' -exec cat {} \; 2>/dev/null || echo "")
+-
+-          # Ground truth for debugging (the 1.0.5 incident): by this point "Flatten and rename
+-          # artifacts" has ALREADY mv'd every binary out of artifacts/ into release-files/ under its
+-          # release name — artifacts/ holds only the desktop .sig files (which is why the sig reads
+-          # above work). Any size/binary read MUST target release-files/, never artifacts/.
+-          echo "Artifacts tree (post-flatten — sigs only):"
+-          find artifacts -type f | sort
+-
+-          # Read artifact byte sizes (SEC-03): the client pre-flight-rejects an update whose advertised
+-          # size exceeds its cap, BEFORE the plugin buffers the whole artifact into memory. Read the
+-          # RENAMED files in release-files/ — the exact bytes the latest.json URLs point at (the
+-          # flatten step's EXPECTED assertion already guarantees they exist; a miss fails loudly here).
+-          DARWIN_AARCH64_SIZE=$(wc -c <"release-files/Aztec-Accelerator-${VERSION}-macOS-Apple-Silicon.app.tar.gz" | tr -d ' ')
+-          DARWIN_X86_64_SIZE=$(wc -c <"release-files/Aztec-Accelerator-${VERSION}-macOS-Intel.app.tar.gz" | tr -d ' ')
+-          LINUX_X86_64_SIZE=$(wc -c <"release-files/Aztec-Accelerator-${VERSION}-Linux-x86_64.AppImage" | tr -d ' ')
+-          WINDOWS_X86_64_SIZE=$(wc -c <"release-files/Aztec-Accelerator-${VERSION}-Windows-x86_64-setup.nsis.zip" | tr -d ' ')
+-
+-          # Assert all signatures AND sizes are present — empty values produce broken auto-updates
+-          for var_name in DARWIN_AARCH64_SIG DARWIN_X86_64_SIG LINUX_APPIMAGE_SIG WINDOWS_X86_64_SIG \
+-                          DARWIN_AARCH64_SIZE DARWIN_X86_64_SIZE LINUX_X86_64_SIZE WINDOWS_X86_64_SIZE; do
+-            if [ -z "${!var_name}" ]; then
+-              echo "::error::Missing $var_name — cannot generate latest.json"
+-              exit 1
+-            fi
+-          done
+-
+-          jq -n \
+-            --arg version "$VERSION" \
+-            --arg pub_date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+-            --arg darwin_aarch64_sig "$DARWIN_AARCH64_SIG" \
+-            --arg darwin_aarch64_url "${BASE_URL}/Aztec-Accelerator-${VERSION}-macOS-Apple-Silicon.app.tar.gz" \
+-            --argjson darwin_aarch64_size "$DARWIN_AARCH64_SIZE" \
+-            --arg darwin_x86_64_sig "$DARWIN_X86_64_SIG" \
+-            --arg darwin_x86_64_url "${BASE_URL}/Aztec-Accelerator-${VERSION}-macOS-Intel.app.tar.gz" \
+-            --argjson darwin_x86_64_size "$DARWIN_X86_64_SIZE" \
+-            --arg linux_x86_64_sig "$LINUX_APPIMAGE_SIG" \
+-            --arg linux_x86_64_url "${BASE_URL}/Aztec-Accelerator-${VERSION}-Linux-x86_64.AppImage" \
+-            --argjson linux_x86_64_size "$LINUX_X86_64_SIZE" \
+-            --arg windows_x86_64_sig "$WINDOWS_X86_64_SIG" \
+-            --arg windows_x86_64_url "${BASE_URL}/Aztec-Accelerator-${VERSION}-Windows-x86_64-setup.nsis.zip" \
+-            --argjson windows_x86_64_size "$WINDOWS_X86_64_SIZE" \
+-            '{
+-              version: $version,
+-              notes: ("Aztec Accelerator " + $version),
+-              pub_date: $pub_date,
+-              platforms: {
+-                "darwin-aarch64": { signature: $darwin_aarch64_sig, url: $darwin_aarch64_url, size: $darwin_aarch64_size },
+-                "darwin-x86_64": { signature: $darwin_x86_64_sig, url: $darwin_x86_64_url, size: $darwin_x86_64_size },
+-                "linux-x86_64": { signature: $linux_x86_64_sig, url: $linux_x86_64_url, size: $linux_x86_64_size },
+-                "windows-x86_64": { signature: $windows_x86_64_sig, url: $windows_x86_64_url, size: $windows_x86_64_size }
+-              }
+-            }' > release-files/latest.json
++        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
++        with:
++          name: signed-update-feed
++          path: signed-feed
+ 
+-          echo "Generated latest.json:"
++      - name: Stage signed latest.json
++        if: needs.validate.outputs.is_prerelease == 'false'
++        run: |
++          cp signed-feed/latest.json release-files/latest.json
++          echo "Staged signed latest.json:"
+           cat release-files/latest.json
+ 
+       - name: Create release
+@@ -806,10 +947,10 @@ jobs:
+               "${FILES[@]}"
+           fi
+ 
+-      - uses: aws-actions/configure-aws-credentials@v6
++      - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
+         if: needs.validate.outputs.is_prerelease == 'false'
+         with:
+-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
++          role-to-assume: ${{ secrets.AWS_ROLE_ARN_RELEASE }} # F-005: feed-only role (Put latest.json)
+           aws-region: ${{ secrets.AWS_REGION }}
+ 
+       - name: Upload latest.json to S3 for auto-updater
+@@ -819,9 +960,11 @@ jobs:
+           aws s3 cp release-files/latest.json s3://${{ secrets.S3_BUCKET_NAME }}/landing/releases/latest.json \
+             --content-type application/json \
+             --cache-control "max-age=300"
++          # F-005: the viewer-request CloudFront function rewrites the URI PRE-cache, so the cached key is
++          # `/landing/releases/latest.json`; invalidate that (keep the legacy path too, harmless).
+           aws cloudfront create-invalidation \
+             --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} \
+-            --paths "/releases/latest.json"
++            --paths "/landing/releases/latest.json" "/releases/latest.json"
+ 
+   # Enforce the live-feed check that was previously done by hand: after `release`
+   # uploads latest.json + invalidates CloudFront, confirm the PUBLIC prod feed
+@@ -835,8 +978,18 @@ jobs:
+     if: needs.validate.outputs.is_prerelease == 'false'
+     runs-on: ubuntu-latest
+     timeout-minutes: 15
+-    permissions: {}
++    permissions:
++      contents: read
+     steps:
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
++      - uses: ./.github/actions/setup-accelerator
++        with:
++          rust-target: x86_64-unknown-linux-gnu
++          rust-cache-key: accelerator-sign-feed
++          rust-workspaces: packages/accelerator/core -> target
++          rust-components: ""
++          install-tauri-system-deps: "false"
++          run-prebuild: "false"
+       - name: Poll the prod feed + assert it serves this release
+         env:
+           EXPECTED: ${{ needs.validate.outputs.version }}
+@@ -874,7 +1027,16 @@ jobs:
+             [ -n "$ok" ] || { echo "::error::asset URL not reachable (last=$code): $u"; exit 1; }
+             echo "✅ 200 $u"
+           done < <(printf '%s' "$FEED" | jq -r '.platforms[].url')
+-          echo "✅ live updater feed verified == $EXPECTED, all assets reachable"
++
++          # F-004 (audit M7): run the PRODUCTION verifier over the live feed body. Version + reachable
++          # URLs alone don't prove the signed manifest survived the upload/CDN — a corrupted or dropped
++          # manifest_sig leaves those intact while EVERY C4 client rejects the update. This is the only
++          # cryptographic check on the real published feed.
++          printf '%s' "$FEED" > live-latest.json
++          bun -e "console.log(JSON.parse(await Bun.file('packages/accelerator/src-tauri/tauri.conf.json').text()).plugins.updater.pubkey)" > pubkey.b64
++          cargo run --quiet --manifest-path packages/accelerator/core/Cargo.toml --example update-manifest -- \
++            verify --feed live-latest.json --pubkey pubkey.b64
++          echo "✅ live updater feed verified == $EXPECTED, all assets reachable, manifest signature valid"
+ 
+   bump-source:
+     name: Bump source version
+@@ -895,13 +1057,13 @@ jobs:
+           permission-contents: write
+           permission-pull-requests: write
+ 
+-      - uses: actions/checkout@v6
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+         with:
+           token: ${{ steps.app-token.outputs.token }}
+ 
+-      - uses: oven-sh/setup-bun@v2
++      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+         with:
+-          bun-version: latest
++          bun-version: 1.3.14
+ 
+       - name: Compute next version
+         id: next
+diff --git a/.github/workflows/sdk.yml b/.github/workflows/sdk.yml
+index 4351395..6c0057b 100644
+--- a/.github/workflows/sdk.yml
++++ b/.github/workflows/sdk.yml
+@@ -3,7 +3,7 @@ name: SDK
+ on:
+   workflow_dispatch:
+   pull_request:
+-    branches: [main]
++    branches: [main, security-hardening]
+ 
+ # Cancel a superseded in-flight run when a new commit is pushed to the same PR.
+ concurrency:
+@@ -18,8 +18,8 @@ jobs:
+     outputs:
+       relevant: ${{ steps.override.outputs.relevant || steps.filter.outputs.relevant }}
+     steps:
+-      - uses: actions/checkout@v6
+-      - uses: dorny/paths-filter@v4
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
++      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
+         id: filter
+         with:
+           filters: |
+@@ -45,11 +45,11 @@ jobs:
+     runs-on: ubuntu-latest
+     timeout-minutes: 5
+     steps:
+-      - uses: actions/checkout@v6
+-      - uses: oven-sh/setup-bun@v2
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
++      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+         with:
+-          bun-version: latest
+-      - uses: actions/cache@v5
++          bun-version: 1.3.14
++      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+         with:
+           path: ~/.bun/install/cache
+           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+@@ -64,11 +64,11 @@ jobs:
+     runs-on: ubuntu-latest
+     timeout-minutes: 5
+     steps:
+-      - uses: actions/checkout@v6
+-      - uses: oven-sh/setup-bun@v2
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
++      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+         with:
+-          bun-version: latest
+-      - uses: actions/cache@v5
++          bun-version: 1.3.14
++      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+         with:
+           path: ~/.bun/install/cache
+           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+@@ -83,11 +83,11 @@ jobs:
+     runs-on: ubuntu-latest
+     timeout-minutes: 5
+     steps:
+-      - uses: actions/checkout@v6
+-      - uses: oven-sh/setup-bun@v2
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
++      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+         with:
+-          bun-version: latest
+-      - uses: actions/cache@v5
++          bun-version: 1.3.14
++      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+         with:
+           path: ~/.bun/install/cache
+           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+diff --git a/.github/workflows/warm-playwright-cache.yml b/.github/workflows/warm-playwright-cache.yml
+index df5780f..e1c5d4a 100644
+--- a/.github/workflows/warm-playwright-cache.yml
++++ b/.github/workflows/warm-playwright-cache.yml
+@@ -36,13 +36,13 @@ jobs:
+     # (composite uses `timeout 1800`). This job is non-blocking + rerunnable.
+     timeout-minutes: 45
+     steps:
+-      - uses: actions/checkout@v6
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+ 
+-      - uses: oven-sh/setup-bun@v2
++      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+         with:
+-          bun-version: latest
++          bun-version: 1.3.14
+ 
+-      - uses: actions/cache@v5
++      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+         with:
+           path: ~/.bun/install/cache
+           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+diff --git a/.github/workflows/warm-rust-cache.yml b/.github/workflows/warm-rust-cache.yml
+index 5c07d18..0ca7dd0 100644
+--- a/.github/workflows/warm-rust-cache.yml
++++ b/.github/workflows/warm-rust-cache.yml
+@@ -35,7 +35,7 @@ jobs:
+       run:
+         working-directory: packages/accelerator/src-tauri
+     steps:
+-      - uses: actions/checkout@v6
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+       - uses: ./.github/actions/setup-accelerator
+         with:
+           rust-cache-key: accelerator-desktop-x86_64-unknown-linux-gnu
+@@ -51,7 +51,7 @@ jobs:
+       run:
+         working-directory: packages/accelerator/server
+     steps:
+-      - uses: actions/checkout@v6
++      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+       - uses: ./.github/actions/setup-accelerator
+         with:
+           rust-cache-key: accelerator-server-x86_64-unknown-linux-gnu

--- a/implementations-plan/security-hardening/full-audit-2026-07-24/chunks/G-scripts.diff
+++ b/implementations-plan/security-hardening/full-audit-2026-07-24/chunks/G-scripts.diff
@@ -1,0 +1,2017 @@
+diff --git a/packages/accelerator/scripts/build-frontend.ts b/packages/accelerator/scripts/build-frontend.ts
+new file mode 100644
+index 0000000..6a86237
+--- /dev/null
++++ b/packages/accelerator/scripts/build-frontend.ts
+@@ -0,0 +1,114 @@
++#!/usr/bin/env bun
++import { mkdir, rm } from "node:fs/promises";
++import path from "node:path";
++/**
++ * F-012: bundle the popup frontend ESM modules (`src-tauri/frontend-src/*.js`) into the
++ * gitignored `src-tauri/frontend/assets/*.js` that ship inside the Tauri app. Each page gets one
++ * self-contained bundle (the shared `bridge.js` + `@tauri-apps/api/core` are inlined), loaded via a
++ * single `<script type="module">`. This is what lets `withGlobalTauri: false` + `script-src 'self'`
++ * work: no inline scripts, no global back-door.
++ *
++ * Runs as tauri's beforeDev/beforeBuildCommand AND must run before any raw `cargo build` (the
++ * bundles are gitignored, so a fresh checkout has none). `build.rs` fails the Rust build if a bundle
++ * is missing or STALE vs the sources — the `.build-manifest.json` written here is that staleness key.
++ *
++ * Wired via `bun run --cwd packages/accelerator frontend:build`.
++ */
++import { Glob } from "bun";
++
++const ROOT = path.resolve(import.meta.dir, "..");
++const SRC_DIR = path.join(ROOT, "src-tauri", "frontend-src");
++const OUT_DIR = path.join(ROOT, "src-tauri", "frontend", "assets");
++const MANIFEST = path.join(OUT_DIR, ".build-manifest.json");
++// Also fingerprint the dependency surface: a @tauri-apps/api bump (package.json) or a resolution change
++// (root bun.lock) must invalidate the shipped bundles even if frontend-src/ is untouched (GATE-3 codex).
++const PKG_JSON = path.join(ROOT, "package.json");
++const LOCKFILE = path.join(ROOT, "..", "..", "bun.lock");
++
++// Per-page entrypoints (bridge.js is shared and pulled into each bundle, not an entry of its own).
++const ENTRIES = ["authorize.js", "settings.js", "update-prompt.js"] as const;
++
++/**
++ * SHA-256 over raw bytes → lowercase hex. `build.rs` recomputes it identically (sha2 crate) so the guard
++ * detects not just "forgot to rebuild" but a swapped/injected OUTPUT bundle — a fnv-style fingerprint an
++ * attacker could trivially forge would not. (An attacker who can rewrite BOTH a bundle and this manifest
++ * still wins; the guard's job is to catch accidental staleness and a bundle-only substitution.)
++ */
++function sha256Hex(bytes: ArrayBuffer | Uint8Array): string {
++  return new Bun.CryptoHasher("sha256").update(bytes).digest("hex");
++}
++
++/** Fingerprint every build INPUT: each frontend-src/*.js plus the dependency-surface files. */
++async function hashInputs(): Promise<Record<string, string>> {
++  const inputs: Record<string, string> = {};
++  const glob = new Glob("*.js");
++  const names: string[] = [];
++  for await (const name of glob.scan({ cwd: SRC_DIR })) names.push(name);
++  names.sort();
++  for (const name of names) {
++    inputs[`frontend-src/${name}`] = sha256Hex(
++      await Bun.file(path.join(SRC_DIR, name)).arrayBuffer(),
++    );
++  }
++  inputs["package.json"] = sha256Hex(await Bun.file(PKG_JSON).arrayBuffer());
++  inputs["bun.lock"] = sha256Hex(await Bun.file(LOCKFILE).arrayBuffer());
++  return inputs;
++}
++
++/** Fingerprint every emitted OUTPUT bundle (so a post-build swap is caught). */
++async function hashOutputs(): Promise<Record<string, string>> {
++  const outputs: Record<string, string> = {};
++  for (const e of ENTRIES) {
++    outputs[e] = sha256Hex(await Bun.file(path.join(OUT_DIR, e)).arrayBuffer());
++  }
++  return outputs;
++}
++
++async function main() {
++  // Snapshot inputs BEFORE bundling (to catch a source edit racing the build).
++  const inputsBefore = await hashInputs();
++
++  // Clean-before-build: never ship an orphaned stale bundle from a since-deleted source.
++  await rm(OUT_DIR, { recursive: true, force: true });
++  await mkdir(OUT_DIR, { recursive: true });
++
++  const result = await Bun.build({
++    entrypoints: ENTRIES.map((e) => path.join(SRC_DIR, e)),
++    outdir: OUT_DIR,
++    target: "browser",
++    format: "esm",
++    minify: true,
++    sourcemap: "none",
++    splitting: false,
++    naming: "[name].js",
++  });
++
++  if (!result.success) {
++    for (const log of result.logs) console.error(log);
++    throw new Error("frontend bundle build failed");
++  }
++
++  const emitted = new Set(result.outputs.map((o) => path.basename(o.path)));
++  for (const entry of ENTRIES) {
++    if (!emitted.has(entry)) throw new Error(`expected bundle ${entry} was not emitted`);
++  }
++
++  // Re-snapshot inputs AFTER bundling; a mismatch means a source changed mid-build → the manifest would
++  // record hashes for content the bundles don't reflect. Fail rather than record a lie.
++  const inputs = await hashInputs();
++  if (JSON.stringify(inputs) !== JSON.stringify(inputsBefore)) {
++    throw new Error("a tracked input changed during the bundle build; re-run frontend:build");
++  }
++
++  const outputs = await hashOutputs();
++  await Bun.write(
++    MANIFEST,
++    `${JSON.stringify({ schema: 2, algo: "sha256", inputs, outputs }, null, 2)}\n`,
++  );
++
++  console.log(
++    `frontend:build → ${ENTRIES.length} bundles + manifest in ${path.relative(ROOT, OUT_DIR)}`,
++  );
++}
++
++await main();
+diff --git a/packages/accelerator/scripts/copy-bb.test.ts b/packages/accelerator/scripts/copy-bb.test.ts
+index 94185ed..cb1534f 100644
+--- a/packages/accelerator/scripts/copy-bb.test.ts
++++ b/packages/accelerator/scripts/copy-bb.test.ts
+@@ -17,15 +17,71 @@ describe("windows bb.exe sidecar supply chain", () => {
+     expect(windowsBbReleaseTag("4.3.0-aztecnr-rc.1")).toBe("v4.3.0-aztecnr-rc.1");
+   });
+ 
+-  test("the shipped version has a pinned, well-formed checksum", () => {
+-    expect(resolveWindowsBbChecksum("4.2.0")).toBe(WINDOWS_BB_CHECKSUMS["4.2.0"]);
+-    expect(resolveWindowsBbChecksum("4.2.0")).toMatch(/^[0-9a-f]{64}$/);
++  test("the LIVE bb.js version has an accepted, well-formed manual-review pin", () => {
++    // F-008: key on the version the gate actually resolves (resolveAztecBb), not a hard-coded literal.
++    const { version } = resolveAztecBb();
++    expect(resolveWindowsBbChecksum(version)).toMatch(/^[0-9a-f]{64}$/);
++    expect(WINDOWS_BB_CHECKSUMS[version]?.provenance).toBe("manual-review");
+   });
+ 
+-  test("an unknown version fails closed — forces a hash review on every bb bump", () => {
++  test("an unknown version fails closed — forces a reviewed pin on every bb bump", () => {
+     expect(() => resolveWindowsBbChecksum("9.9.9")).toThrow(/No pinned Windows bb\.exe SHA-256/);
+   });
+ 
++  test("a non-manual-review provenance fails closed (reserved attestation)", () => {
++    WINDOWS_BB_CHECKSUMS["0.0.0-att"] = {
++      sha256: "a".repeat(64),
++      provenance: "attestation",
++      note: "reserved",
++    };
++    try {
++      expect(() => resolveWindowsBbChecksum("0.0.0-att")).toThrow(/not accepted yet/);
++    } finally {
++      delete WINDOWS_BB_CHECKSUMS["0.0.0-att"];
++    }
++  });
++
++  test("a malformed sha256 fails closed", () => {
++    WINDOWS_BB_CHECKSUMS["0.0.0-badsha"] = {
++      sha256: "NOTHEX",
++      provenance: "manual-review",
++      note: "x",
++    };
++    try {
++      expect(() => resolveWindowsBbChecksum("0.0.0-badsha")).toThrow(/malformed sha256/);
++    } finally {
++      delete WINDOWS_BB_CHECKSUMS["0.0.0-badsha"];
++    }
++  });
++
++  test("an empty / whitespace review note fails closed", () => {
++    WINDOWS_BB_CHECKSUMS["0.0.0-emptynote"] = {
++      sha256: "a".repeat(64),
++      provenance: "manual-review",
++      note: "",
++    };
++    WINDOWS_BB_CHECKSUMS["0.0.0-wsnote"] = {
++      sha256: "a".repeat(64),
++      provenance: "manual-review",
++      note: "   ",
++    };
++    try {
++      expect(() => resolveWindowsBbChecksum("0.0.0-emptynote")).toThrow(/empty review note/);
++      expect(() => resolveWindowsBbChecksum("0.0.0-wsnote")).toThrow(/empty review note/);
++    } finally {
++      delete WINDOWS_BB_CHECKSUMS["0.0.0-emptynote"];
++      delete WINDOWS_BB_CHECKSUMS["0.0.0-wsnote"];
++    }
++  });
++
++  test("every committed pin is manual-review with a well-formed sha + a real note", () => {
++    for (const [version, pin] of Object.entries(WINDOWS_BB_CHECKSUMS)) {
++      expect(pin.provenance, `${version} provenance`).toBe("manual-review");
++      expect(pin.sha256, `${version} sha`).toMatch(/^[0-9a-f]{64}$/);
++      expect(pin.note.trim().length, `${version} note`).toBeGreaterThan(0);
++    }
++  });
++
+   test("a tampered tarball is rejected (SHA-256 mismatch)", () => {
+     expect(() =>
+       assertSha256(Buffer.from("malicious payload"), "0".repeat(64), WINDOWS_BB_ASSET),
+diff --git a/packages/accelerator/scripts/copy-bb.ts b/packages/accelerator/scripts/copy-bb.ts
+index 9b3866f..59972f4 100644
+--- a/packages/accelerator/scripts/copy-bb.ts
++++ b/packages/accelerator/scripts/copy-bb.ts
+@@ -53,36 +53,89 @@ export function getTargetTriple(): string {
+ 
+ export const WINDOWS_BB_ASSET = "barretenberg-amd64-windows.tar.gz";
+ 
+-export const WINDOWS_BB_CHECKSUMS: Record<string, string> = {
+-  // @aztec/bb.js 4.2.0 — verified on windows-latest (Windows Prebuild Smoke CI gate).
+-  "4.2.0": "55043d74d20afd55cb3d3c5fd690b79f9d964ba52bfebd13bcba71b74a3d0c8f",
+-  // @aztec/bb.js 4.3.1 — sha256 of barretenberg-amd64-windows.tar.gz from the v4.3.1 release.
+-  "4.3.1": "58294203ba658d2c6d983dc22f68f3a2280f5107e9e973570e4adb751997fd2c",
+-  // @aztec/bb.js 5.0.0-rc.1 — sha256 of barretenberg-amd64-windows.tar.gz from the v5.0.0-rc.1
+-  // release (archive contains bb.exe only — the no-DLL canary holds). Required because the
+-  // 4.3.1→5.0.0-rc.1 lockfile bump makes resolveAztecBb() key on 5.0.0-rc.1; the Windows Prebuild
+-  // Smoke CI gate independently re-fetches + verifies this hash.
+-  "5.0.0-rc.1": "7fd01446b4d23810ab76163e500729d1a5310df4dcb8e9e03259ad477183c4dd",
+-  // @aztec/bb.js 5.0.0-rc.2 — sha256 of barretenberg-amd64-windows.tar.gz from the v5.0.0-rc.2
+-  // release (5.5 MB gzip, bb.exe only). Required by the rc.1→rc.2 lockfile bump so the Windows
+-  // Prebuild/Build Smoke gates can re-fetch + verify; without it resolveWindowsBbChecksum throws.
+-  "5.0.0-rc.2": "c0bf2429821453a2314d82ddd5d7ac25e28db35e9865a5b55fb126a1d94a7842",
++/**
++ * Provenance of a Windows bb.exe pin (F-008). ONLY `manual-review` is accepted today: a maintainer
++ * downloaded the release asset, inspected the release page + tag, diffed it against the prior pinned
++ * asset, and recorded the hash by hand. It is a CHANGE-DETECTOR, not cryptographic proof against a
++ * compromised upstream publisher — AztecProtocol does not yet sign/attest bb releases (the SEC-02
++ * residual, same upstream-signing gap as F-007). `attestation` is RESERVED for when they do (to be
++ * verified via `gh attestation verify` pinning repo + signer workflow + source ref/digest); it is NOT
++ * yet accepted and currently fails closed. A recognized string is not verification.
++ */
++export type WindowsBbProvenance = "manual-review" | "attestation";
++
++export interface WindowsBbPin {
++  sha256: string;
++  provenance: WindowsBbProvenance;
++  note: string;
++}
++
++// F-008: pins are NEVER auto-generated (`update-aztec-version.ts` no longer downloads + writes a hash —
++// a twice-downloaded asset is not independent evidence). A human adds each entry after review; the
++// Windows Prebuild/Build Smoke gate re-fetches + re-verifies against the pinned sha, failing closed on a
++// missing/mismatched/unaccepted-provenance entry.
++export const WINDOWS_BB_CHECKSUMS: Record<string, WindowsBbPin> = {
++  "4.2.0": {
++    sha256: "55043d74d20afd55cb3d3c5fd690b79f9d964ba52bfebd13bcba71b74a3d0c8f",
++    provenance: "manual-review",
++    note: "Legacy pin adopted as a change-detector — CI-hashed on windows-latest, not independently verified (SEC-02).",
++  },
++  "4.3.1": {
++    sha256: "58294203ba658d2c6d983dc22f68f3a2280f5107e9e973570e4adb751997fd2c",
++    provenance: "manual-review",
++    note: "Legacy pin, change-detector only — sha256 of the v4.3.1 release asset, not independently verified.",
++  },
++  "5.0.0-rc.1": {
++    sha256: "7fd01446b4d23810ab76163e500729d1a5310df4dcb8e9e03259ad477183c4dd",
++    provenance: "manual-review",
++    note: "Legacy pin, change-detector only — v5.0.0-rc.1 asset (bb.exe only, no-DLL canary), not independently verified.",
++  },
++  "5.0.0-rc.2": {
++    sha256: "c0bf2429821453a2314d82ddd5d7ac25e28db35e9865a5b55fb126a1d94a7842",
++    provenance: "manual-review",
++    note: "Legacy pin, change-detector only — v5.0.0-rc.2 asset (5.5 MB gzip, bb.exe only), not independently verified.",
++  },
+ };
+ 
+ export function windowsBbReleaseTag(version: string): string {
+   return `v${version}`;
+ }
+ 
++/**
++ * Resolve the pinned Windows bb.exe SHA-256 for a bb.js `version`. Fail-closed: a missing entry, an
++ * unaccepted provenance (only `manual-review` today — `attestation` is reserved until we implement
++ * `gh attestation verify`), or a malformed hash all throw (F-008).
++ */
+ export function resolveWindowsBbChecksum(version: string): string {
+-  const sha = WINDOWS_BB_CHECKSUMS[version];
+-  if (!sha) {
++  const pin = WINDOWS_BB_CHECKSUMS[version];
++  if (!pin) {
+     throw new Error(
+       `No pinned Windows bb.exe SHA-256 for @aztec/bb.js ${version}.\n` +
+-        `Download ${WINDOWS_BB_ASSET} from the v${version} aztec-packages release, ` +
+-        `sha256sum it, and add the hash to WINDOWS_BB_CHECKSUMS in copy-bb.ts.`,
++        `A human must add a REVIEWED pin: download ${WINDOWS_BB_ASSET} from the v${version} ` +
++        `aztec-packages release, verify the release page + tag signature, diff it against the prior ` +
++        `pinned asset, then add a { sha256, provenance: "manual-review", note } entry to ` +
++        `WINDOWS_BB_CHECKSUMS in copy-bb.ts. (Pins are never auto-generated — F-008.)`,
++    );
++  }
++  if (pin.provenance !== "manual-review") {
++    throw new Error(
++      `Windows bb.exe pin for ${version} has provenance "${pin.provenance}", which is not accepted yet. ` +
++        `Only "manual-review" is honored today; "attestation" requires implementing gh attestation verify (F-008).`,
++    );
++  }
++  if (!/^[0-9a-f]{64}$/.test(pin.sha256)) {
++    throw new Error(
++      `Windows bb.exe pin for ${version} has a malformed sha256: ${JSON.stringify(pin.sha256)}`,
++    );
++  }
++  // A manual-review pin MUST carry a non-empty review record (what a human checked). An empty/whitespace
++  // note means the review evidence is missing — fail closed (F-008).
++  if (typeof pin.note !== "string" || pin.note.trim().length === 0) {
++    throw new Error(
++      `Windows bb.exe pin for ${version} has an empty review note — a manual-review pin must record what was reviewed.`,
+     );
+   }
+-  return sha;
++  return pin.sha256;
+ }
+ 
+ export function assertSha256(data: Uint8Array, expected: string, label: string): void {
+diff --git a/packages/accelerator/scripts/sign-smoke-feed.sh b/packages/accelerator/scripts/sign-smoke-feed.sh
+new file mode 100755
+index 0000000..2401431
+--- /dev/null
++++ b/packages/accelerator/scripts/sign-smoke-feed.sh
+@@ -0,0 +1,37 @@
++#!/usr/bin/env bash
++# Sign a synthesized updater-smoke feed IN PLACE (F-004 Layer A).
++#
++# A C4+ N-1 build enforces the signed-manifest envelope, so the local smoke feed must carry a
++# `manifest` + `manifest_sig` signed with the SAME updater key N-1 embeds (the prod key — the synthetic
++# N-1 keeps the committed prod pubkey). This assembles the canonical envelope from the feed, signs it
++# with the key in TAURI_SIGNING_PRIVATE_KEY[_PASSWORD], and splices the two fields back in. Shared by
++# updater-smoke.sh (macOS) + updater-smoke-linux.sh so the envelope shape has ONE definition.
++#
++# Encoding contract (kept in lockstep with accelerator_core::update_manifest):
++#   - manifest     = base64(envelope.json bytes)
++#   - manifest_sig = the .sig file content VERBATIM (tauri writes it as base64(minisign doc))
++#
++# Usage: sign-smoke-feed.sh <feed.json> <repo-root>
++set -euo pipefail
++
++FEED="$1"
++REPO_ROOT="$2"
++: "${TAURI_SIGNING_PRIVATE_KEY:?TAURI_SIGNING_PRIVATE_KEY is required to sign the smoke feed}"
++
++ENVELOPE="$(dirname "$FEED")/envelope.json"
++# Envelope shape MUST match accelerator_core::update_manifest::SignedEnvelope (deny_unknown_fields):
++# exactly {schema, version, pub_date, platforms:{key:{url,size,signature}}}. The feed's platform
++# entries already carry exactly {signature,url,size}, so projecting them is field-name-exact.
++jq '{schema: "aztec-accelerator-update-manifest-v1", version, pub_date, platforms}' "$FEED" > "$ENVELOPE"
++
++# Sign the exact envelope bytes with the updater key (bunx resolves @tauri-apps/cli from the package).
++( cd "$REPO_ROOT/packages/accelerator" && bunx tauri signer sign "$ENVELOPE" )
++
++# base64 of the signed bytes; strip newlines (BSD + GNU base64 both wrap by default).
++MANIFEST_B64="$(base64 < "$ENVELOPE" | tr -d '\n')"
++MANIFEST_SIG="$(cat "$ENVELOPE.sig")" # already base64(minisign doc) — embed verbatim
++
++jq --arg m "$MANIFEST_B64" --arg s "$MANIFEST_SIG" '. + {manifest: $m, manifest_sig: $s}' \
++  "$FEED" > "$FEED.signed"
++mv "$FEED.signed" "$FEED"
++echo "── signed smoke feed: manifest + manifest_sig spliced ──"
+diff --git a/packages/accelerator/scripts/tauri-trust-boundary.test.ts b/packages/accelerator/scripts/tauri-trust-boundary.test.ts
+new file mode 100644
+index 0000000..852862f
+--- /dev/null
++++ b/packages/accelerator/scripts/tauri-trust-boundary.test.ts
+@@ -0,0 +1,240 @@
++/**
++ * F-012 trust-boundary static guards (`bun test scripts/`). These are the drift-detectors: they fail CI
++ * if a future change reopens the frontend trust boundary — an inline script/style, the `withGlobalTauri`
++ * global, a CSP relaxation, or a capability/command-matrix mismatch. They read files only (no app runtime),
++ * so they run fast on the GUI-less CI matrix. Grows per phase: P1 externalization (here); P2 CSP; P3 caps.
++ */
++import { describe, expect, test } from "bun:test";
++import path from "node:path";
++
++const SRC_TAURI = path.resolve(import.meta.dir, "..", "src-tauri");
++const FRONTEND = path.join(SRC_TAURI, "frontend");
++const FRONTEND_SRC = path.join(SRC_TAURI, "frontend-src");
++const TAURI_CONF = path.join(SRC_TAURI, "tauri.conf.json");
++
++// The exact CSP directives F-012 ships. Kept as an ordered list so the drift test pins each one — a future
++// relaxation (adding `unsafe-inline`, dropping `form-action`, widening `connect-src`) fails CI loudly.
++const REQUIRED_CSP: Record<string, string> = {
++  "default-src": "'self'",
++  "script-src": "'self'",
++  "style-src": "'self'",
++  "img-src": "'self'",
++  "connect-src": "ipc: http://ipc.localhost",
++  "object-src": "'none'",
++  "base-uri": "'none'",
++  "frame-ancestors": "'none'",
++  "form-action": "'none'",
++  "frame-src": "'none'",
++  "child-src": "'none'",
++  "worker-src": "'none'",
++};
++
++const PAGES = ["authorize.html", "settings.html", "update-prompt.html"] as const;
++
++async function read(p: string): Promise<string> {
++  return await Bun.file(p).text();
++}
++
++/** Strip `/* *​/` block and `//` line comments so guards match CODE, not prose in doc comments. */
++function stripComments(js: string): string {
++  return js.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
++}
++
++describe("F-012 P1 — frontend externalization", () => {
++  test("each popup page loads exactly one ES-module bundle and no other script", async () => {
++    for (const page of PAGES) {
++      const html = await read(path.join(FRONTEND, page));
++      const scripts = [...html.matchAll(/<script\b[^>]*>/gi)].map((m) => m[0]);
++      expect(scripts.length, `${page}: exactly one <script>`).toBe(1);
++      const tag = scripts[0];
++      expect(tag, `${page}: must be a module`).toContain('type="module"');
++      // Points at a bundled asset built from frontend-src/ — never an inline block.
++      expect(tag, `${page}: loads assets/*.js`).toMatch(/src="assets\/[a-z-]+\.js"/);
++    }
++  });
++
++  test("no inline scripts, inline styles, or markup event handlers in any page", async () => {
++    for (const page of PAGES) {
++      const html = await read(path.join(FRONTEND, page));
++      // An inline <script> has no `src=` before its closing `>`.
++      for (const tag of html.matchAll(/<script\b([^>]*)>/gi)) {
++        expect(tag[1], `${page}: <script> must have src (no inline JS)`).toContain("src=");
++      }
++      expect(html, `${page}: no <style> block`).not.toMatch(/<style\b/i);
++      expect(html, `${page}: no inline style= attribute`).not.toMatch(/\sstyle\s*=/i);
++      expect(html, `${page}: no on*= handler attribute`).not.toMatch(/\son[a-z]+\s*=\s*["']/i);
++    }
++  });
++
++  test("frontend-src references the official API, never the window.__TAURI__ global", async () => {
++    const glob = new Bun.Glob("*.js");
++    const names: string[] = [];
++    for await (const name of glob.scan({ cwd: FRONTEND_SRC })) names.push(name);
++    expect(names.length).toBeGreaterThanOrEqual(4); // bridge + 3 pages
++
++    let importsCore = false;
++    for (const name of names) {
++      const js = await read(path.join(FRONTEND_SRC, name));
++      const code = stripComments(js);
++      expect(code, `${name}: no window.__TAURI__ global back-door`).not.toMatch(
++        /window\.__TAURI__\b/,
++      );
++      if (/@tauri-apps\/api\/core/.test(code)) importsCore = true;
++    }
++    expect(importsCore, "the shared bridge imports invoke from @tauri-apps/api/core").toBe(true);
++  });
++
++  test("the old global tauri-bridge.js is gone", async () => {
++    expect(await Bun.file(path.join(FRONTEND, "tauri-bridge.js")).exists()).toBe(false);
++  });
++});
++
++describe("F-012 P2 — CSP + global flag drift guards", () => {
++  async function conf(): Promise<any> {
++    return JSON.parse(await read(TAURI_CONF));
++  }
++
++  test("withGlobalTauri is false (no window.__TAURI__ back-door)", async () => {
++    expect((await conf()).app?.withGlobalTauri).toBe(false);
++  });
++
++  test("CSP pins every required directive with no unsafe-* relaxation", async () => {
++    const csp: string = (await conf()).app?.security?.csp ?? "";
++    expect(csp, "csp must be set").toBeTruthy();
++
++    // Parse "name a b c; name2 …" into a directive → sources map.
++    const directives = new Map<string, string>();
++    for (const chunk of csp.split(";")) {
++      const parts = chunk.trim().split(/\s+/);
++      if (parts.length) directives.set(parts[0], parts.slice(1).join(" "));
++    }
++    for (const [name, sources] of Object.entries(REQUIRED_CSP)) {
++      expect(directives.get(name), `csp ${name}`).toBe(sources);
++    }
++    // connect-src deliberately EXCLUDES 'self' (popups never fetch) — only the IPC origins.
++    expect(directives.get("connect-src")).not.toContain("'self'");
++    // No inline/eval escape hatches, ever.
++    expect(csp).not.toContain("unsafe-inline");
++    expect(csp).not.toContain("unsafe-eval");
++  });
++
++  test("dev never silently weakens the shipped CSP (no devUrl, no weaker devCsp)", async () => {
++    const c = await conf();
++    // is_dev() serves the same csp only when devCsp is unset and there is no devUrl — pin both so a future
++    // edit can't turn the dev-mode PR-gate WebDriver run into a no-op against the real policy.
++    expect(c.build?.devUrl, "no devUrl").toBeUndefined();
++    const devCsp = c.app?.security?.devCsp;
++    if (devCsp !== undefined) expect(devCsp).toBe(c.app.security.csp);
++    // The asset-CSP nonce augmentation must stay on (never disable it).
++    expect(c.app?.security?.dangerousDisableAssetCspModification ?? false).toBe(false);
++  });
++});
++
++// The authoritative per-window (window → snake_case command) matrix. Every command a window's frontend
++// invokes MUST be here, and NOTHING more (least privilege). has_app_acl is all-or-nothing: a command absent
++// from a window's capability is default-DENIED for that window.
++const WINDOW_MATRIX: Record<string, string[]> = {
++  settings: [
++    "get_config",
++    "get_autostart_enabled",
++    "get_system_info",
++    "set_autostart",
++    "set_auto_update",
++    "set_speed",
++    "enable_safari_support",
++    "disable_safari_support",
++    "remove_approved_origin",
++  ],
++  authorize: ["get_verified_info", "get_pending_auth", "respond_auth"],
++  "update-prompt": ["respond_update_prompt"],
++};
++const snakeToPerm = (cmd: string) => `allow-${cmd.replace(/_/g, "-")}`;
++
++describe("F-012 P3 — per-window capability ACL", () => {
++  const CAPS = path.join(SRC_TAURI, "capabilities");
++
++  async function capFiles(): Promise<Record<string, any>> {
++    const glob = new Bun.Glob("*.json");
++    const out: Record<string, any> = {};
++    for await (const name of glob.scan({ cwd: CAPS })) {
++      out[name] = JSON.parse(await read(path.join(CAPS, name)));
++    }
++    return out;
++  }
++
++  test("exactly the 3 scoped capabilities exist — no default.json, no extras", async () => {
++    const files = await capFiles();
++    expect(Object.keys(files).sort()).toEqual([
++      "authorize.json",
++      "settings.json",
++      "update-prompt.json",
++    ]);
++    // The old broad default.json (core:default + plugin grants to every window) must be gone (D7 DROP).
++    expect(files["default.json"]).toBeUndefined();
++  });
++
++  test("each capability grants EXACTLY its window's commands and no others", async () => {
++    const files = await capFiles();
++    const byId: Record<string, any> = {};
++    for (const c of Object.values(files)) byId[c.identifier] = c;
++
++    for (const [id, cmds] of Object.entries(WINDOW_MATRIX)) {
++      const cap = byId[id];
++      expect(cap, `capability ${id}`).toBeTruthy();
++      // The window glob matches the runtime label (settings / auth-* / update-prompt).
++      const expectedWindow = id === "authorize" ? "auth-*" : id;
++      expect(cap.windows).toEqual([expectedWindow]);
++      // Exact permission set — kebab `allow-<cmd>`, no plugin/core grants (least privilege).
++      expect([...cap.permissions].sort()).toEqual(cmds.map(snakeToPerm).sort());
++      for (const p of cap.permissions) {
++        expect(p, `${id} grants only app allow-* perms`).toMatch(/^allow-[a-z-]+$/);
++      }
++    }
++  });
++
++  test("the authorization popup canNOT reach any settings mutator (least-privilege drift guard)", async () => {
++    const files = await capFiles();
++    const authorize = Object.values(files).find((c) => c.identifier === "authorize");
++    for (const settingsCmd of WINDOW_MATRIX.settings) {
++      expect(authorize.permissions, `auth must not grant ${settingsCmd}`).not.toContain(
++        snakeToPerm(settingsCmd),
++      );
++    }
++  });
++
++  test("build.rs COMMANDS == main.rs generate_handler! == union of capability grants (set-equality)", async () => {
++    const buildRs = await read(path.join(SRC_TAURI, "build.rs"));
++    const mainRs = await read(path.join(SRC_TAURI, "src", "main.rs"));
++
++    // build.rs: the string list passed to AppManifest.commands().
++    const commandsBlock = buildRs.match(/let commands: &\[&str\] = &\[([\s\S]*?)\];/);
++    expect(commandsBlock, "build.rs COMMANDS block").toBeTruthy();
++    const buildCommands = [...commandsBlock![1].matchAll(/"([a-z_]+)"/g)].map((m) => m[1]).sort();
++
++    // main.rs: the generate_handler! command list.
++    const handlerBlock = mainRs.match(/generate_handler!\[([\s\S]*?)\]/);
++    expect(handlerBlock, "main.rs generate_handler!").toBeTruthy();
++    const handlers = [...handlerBlock![1].matchAll(/commands::([a-z_]+)/g)].map((m) => m[1]).sort();
++
++    // union of every capability's granted commands (perm → snake).
++    const files = await capFiles();
++    const granted = new Set<string>();
++    for (const c of Object.values(files)) {
++      for (const p of c.permissions) granted.add(p.replace(/^allow-/, "").replace(/-/g, "_"));
++    }
++    const grantedSorted = [...granted].sort();
++
++    expect(buildCommands).toEqual(handlers); // declared surface == registered surface
++    expect(grantedSorted).toEqual(handlers); // every registered command is granted to exactly some window
++    expect(handlers.length).toBe(13);
++  });
++
++  test("tauri.conf.json pins the capability allowlist to exactly the 3", async () => {
++    const c = JSON.parse(await read(TAURI_CONF));
++    expect([...(c.app?.security?.capabilities ?? [])].sort()).toEqual([
++      "authorize",
++      "settings",
++      "update-prompt",
++    ]);
++  });
++});
+diff --git a/packages/accelerator/scripts/updater-smoke-linux.sh b/packages/accelerator/scripts/updater-smoke-linux.sh
+index 99484c5..f2fc31d 100755
+--- a/packages/accelerator/scripts/updater-smoke-linux.sh
++++ b/packages/accelerator/scripts/updater-smoke-linux.sh
+@@ -102,9 +102,12 @@ N_BASENAME="$(basename "$N_APPIMAGE")"
+ # Genuine N checksum, captured BEFORE the optional negative-mode tamper, so the
+ # positive path can assert the on-disk swap landed exactly N's bytes.
+ N_SUM="$(sha256sum "$N_APPIMAGE" | awk '{print $1}')"
++# Byte size of the GENUINE artifact (before any negative-mode tamper) — bound into the signed
++# manifest (F-004 Layer A + SEC-03).
++N_SIZE="$(wc -c < "$N_APPIMAGE" | tr -d ' ')"
+ cp "$N_APPIMAGE" "$SERVE_DIR/$N_BASENAME"
+ N_SIG="$(cat "$N_SIG_FILE")"
+-log "N artifact: $N_BASENAME (sha256=$N_SUM)"
++log "N artifact: $N_BASENAME (sha256=$N_SUM, $N_SIZE bytes)"
+ 
+ # Negative control: serve the GENUINE signature but a TAMPERED AppImage (append a
+ # byte). The updater downloads the artifact, then the minisign check over the
+@@ -138,11 +141,14 @@ sudo cp "$WORK/ca.pem" "$CA_DEST"
+ sudo update-ca-certificates >/dev/null 2>&1
+ echo "127.0.0.1 $HOST" | sudo tee -a /etc/hosts >/dev/null
+ 
+-# ── Synthesize latest.json for N ──
++# ── Synthesize + SIGN latest.json for N (F-004 Layer A) ──
++# A C4+ N-1 enforces the signed-manifest envelope, so the feed MUST carry manifest/manifest_sig signed
++# with the SAME (prod) key N-1 embeds. The workflow provides it via TAURI_SIGNING_PRIVATE_KEY[_PASSWORD].
+ jq -n --arg v "$N_VERSION" --arg key "$PLATFORM_KEY" --arg sig "$N_SIG" \
+-  --arg url "https://$HOST/releases/download/$N_BASENAME" \
++  --arg url "https://$HOST/releases/download/$N_BASENAME" --argjson size "$N_SIZE" \
+   '{version:$v, notes:("updater smoke "+$v), pub_date:"2026-01-01T00:00:00Z",
+-    platforms: { ($key): { signature:$sig, url:$url } }}' > "$WORK/latest.json"
++    platforms: { ($key): { signature:$sig, url:$url, size:$size } }}' > "$WORK/latest.json"
++"$REPO_ROOT/packages/accelerator/scripts/sign-smoke-feed.sh" "$WORK/latest.json" "$REPO_ROOT"
+ log "latest.json:"; cat "$WORK/latest.json"
+ 
+ # ── Start the local HTTPS feed on :443 ──
+diff --git a/packages/accelerator/scripts/updater-smoke-windows.ps1 b/packages/accelerator/scripts/updater-smoke-windows.ps1
+index 28ed3d9..cd200f3 100644
+--- a/packages/accelerator/scripts/updater-smoke-windows.ps1
++++ b/packages/accelerator/scripts/updater-smoke-windows.ps1
+@@ -96,7 +96,10 @@ try {
+   $Served = Join-Path $ServeDir $NName
+   Copy-Item $NZip.FullName $Served
+   $NSigText = (Get-Content $NSig.FullName -Raw).Trim()
+-  Log "N artifact: $NName"
++  # Byte size of the GENUINE artifact (before any negative-mode tamper) — bound into the signed
++  # manifest (F-004 Layer A + SEC-03).
++  $NSize = $NZip.Length
++  Log "N artifact: $NName ($NSize bytes)"
+ 
+   # Negative control: tamper the served zip (append a byte) but keep the GENUINE sig,
+   # so the minisign check over the tampered bytes MUST fail against the embedded pubkey.
+@@ -127,14 +130,40 @@ try {
+   # ── Scoped Defender exclusion (the UNSIGNED installer/exe) ──
+   Add-MpPreference -ExclusionPath $InstallRoot, $ServeDir -ErrorAction SilentlyContinue
+ 
+-  # ── Synthesize latest.json for N ──
+-  $latest = [ordered]@{
+-    version  = $NVersion
+-    notes    = "updater smoke $NVersion"
+-    pub_date = "2026-01-01T00:00:00Z"
+-    platforms = [ordered]@{ $PlatformKey = [ordered]@{ signature = $NSigText; url = "https://$FeedHost/releases/download/$NName" } }
+-  } | ConvertTo-Json -Depth 6
+-  Set-Content -Path (Join-Path $Work "latest.json") -Value $latest
++  # ── Synthesize + SIGN latest.json for N (F-004 Layer A) ──
++  # A C4+ N-1 enforces the signed-manifest envelope, so the feed MUST carry manifest/manifest_sig
++  # signed with the SAME (prod) key N-1 embeds. The synthetic N-1 keeps the committed prod pubkey, so
++  # the manifest key is the prod key — provided to THIS step's env (overriding the ephemeral key that
++  # only built N-1's artifacts). Encoding contract matches accelerator_core::update_manifest:
++  # manifest = base64(envelope bytes); manifest_sig = the .sig content verbatim (base64(minisign doc)).
++  $platform = [ordered]@{ signature = $NSigText; url = "https://$FeedHost/releases/download/$NName"; size = $NSize }
++  $platforms = [ordered]@{ $PlatformKey = $platform }
++  # The signed envelope shape MUST match SignedEnvelope (deny_unknown_fields): {schema, version,
++  # pub_date, platforms}. Write WITHOUT a BOM (pwsh 7 default) so the signed bytes parse.
++  $envelope = [ordered]@{
++    schema    = "aztec-accelerator-update-manifest-v1"
++    version   = $NVersion
++    pub_date  = "2026-01-01T00:00:00Z"
++    platforms = $platforms
++  }
++  $EnvPath = Join-Path $Work "envelope.json"
++  ($envelope | ConvertTo-Json -Depth 6) | Set-Content -Path $EnvPath -Encoding utf8NoBOM
++  Push-Location "$RepoRoot\packages\accelerator"
++  & bunx tauri signer sign $EnvPath
++  if ($LASTEXITCODE -ne 0) { Pop-Location; Write-Error "tauri signer sign failed for the smoke manifest"; exit 1 }
++  Pop-Location
++  $ManifestB64 = [Convert]::ToBase64String([IO.File]::ReadAllBytes($EnvPath))
++  $ManifestSig = (Get-Content "$EnvPath.sig" -Raw).Trim()
++  $latestObj = [ordered]@{
++    version      = $NVersion
++    notes        = "updater smoke $NVersion"
++    pub_date     = "2026-01-01T00:00:00Z"
++    platforms    = $platforms
++    manifest     = $ManifestB64
++    manifest_sig = $ManifestSig
++  }
++  $latest = $latestObj | ConvertTo-Json -Depth 6
++  Set-Content -Path (Join-Path $Work "latest.json") -Value $latest -Encoding utf8NoBOM
+   Log "latest.json:"; Write-Host $latest
+ 
+   # ── Start the local HTTPS feed on :443 (no sudo on Windows) ──
+diff --git a/packages/accelerator/scripts/updater-smoke.sh b/packages/accelerator/scripts/updater-smoke.sh
+index 896ce84..07d2f99 100755
+--- a/packages/accelerator/scripts/updater-smoke.sh
++++ b/packages/accelerator/scripts/updater-smoke.sh
+@@ -75,7 +75,10 @@ N_SIG_FILE="$(find "$N_ARTIFACTS_DIR" -name '*.app.tar.gz.sig' | head -1)"
+ N_BASENAME="$(basename "$N_TARBALL")"
+ cp "$N_TARBALL" "$SERVE_DIR/$N_BASENAME"
+ N_SIG="$(cat "$N_SIG_FILE")"
+-log "N artifact: $N_BASENAME"
++# Byte size of the GENUINE artifact (before any negative-mode tamper) — bound into the signed
++# manifest (F-004 Layer A + SEC-03). BSD/GNU `wc -c` both need the whitespace trimmed.
++N_SIZE="$(wc -c < "$N_TARBALL" | tr -d ' ')"
++log "N artifact: $N_BASENAME ($N_SIZE bytes)"
+ 
+ # Negative control: serve the GENUINE signature but a TAMPERED tarball (append a
+ # byte). The updater downloads the artifact, then the minisign check over the
+@@ -106,11 +109,15 @@ log "trusting CA + adding hosts entry"
+ sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "$WORK/ca.pem"
+ echo "127.0.0.1 $HOST" | sudo tee -a /etc/hosts >/dev/null
+ 
+-# ── Synthesize latest.json for N ──
++# ── Synthesize + SIGN latest.json for N (F-004 Layer A) ──
++# A C4+ N-1 enforces the signed-manifest envelope, so the feed MUST carry a `manifest`/`manifest_sig`
++# signed with the SAME updater key N-1 embeds (the prod key — the synthetic N-1 keeps the committed
++# prod pubkey). The workflow provides it via TAURI_SIGNING_PRIVATE_KEY[_PASSWORD].
+ jq -n --arg v "$N_VERSION" --arg key "$PLATFORM_KEY" --arg sig "$N_SIG" \
+-  --arg url "https://$HOST/releases/download/$N_BASENAME" \
++  --arg url "https://$HOST/releases/download/$N_BASENAME" --argjson size "$N_SIZE" \
+   '{version:$v, notes:("updater smoke "+$v), pub_date:"2026-01-01T00:00:00Z",
+-    platforms: { ($key): { signature:$sig, url:$url } }}' > "$WORK/latest.json"
++    platforms: { ($key): { signature:$sig, url:$url, size:$size } }}' > "$WORK/latest.json"
++"$REPO_ROOT/packages/accelerator/scripts/sign-smoke-feed.sh" "$WORK/latest.json" "$REPO_ROOT"
+ log "latest.json:"; cat "$WORK/latest.json"
+ 
+ # ── Start the local HTTPS feed on :443 ──
+diff --git a/scripts/__fixtures__/bb-cache-marker.json b/scripts/__fixtures__/bb-cache-marker.json
+new file mode 100644
+index 0000000..756faff
+--- /dev/null
++++ b/scripts/__fixtures__/bb-cache-marker.json
+@@ -0,0 +1,7 @@
++{
++  "schema": "aztec-accelerator/bb-cache-marker@1",
++  "version": "5.0.0-rc.2",
++  "platform": "amd64-linux",
++  "archive_sha256": "c0bf2429821453a2314d82ddd5d7ac25e28db35e9865a5b55fb126a1d94a7842",
++  "binary_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
++}
+diff --git a/scripts/__fixtures__/github-release-metadata.json b/scripts/__fixtures__/github-release-metadata.json
+new file mode 100644
+index 0000000..d65f276
+--- /dev/null
++++ b/scripts/__fixtures__/github-release-metadata.json
+@@ -0,0 +1,15 @@
++{
++  "tag_name": "v5.0.0-rc.2",
++  "name": "v5.0.0-rc.2",
++  "immutable": false,
++  "assets": [
++    {
++      "name": "barretenberg-amd64-linux.tar.gz",
++      "digest": "sha256:c0bf2429821453a2314d82ddd5d7ac25e28db35e9865a5b55fb126a1d94a7842"
++    },
++    {
++      "name": "barretenberg-arm64-darwin.tar.gz",
++      "digest": "sha256:7fd01446b4d23810ab76163e500729d1a5310df4dcb8e9e03259ad477183c4dd"
++    }
++  ]
++}
+diff --git a/scripts/check-windows-bb-pin.test.ts b/scripts/check-windows-bb-pin.test.ts
+new file mode 100644
+index 0000000..b662516
+--- /dev/null
++++ b/scripts/check-windows-bb-pin.test.ts
+@@ -0,0 +1,30 @@
++import { afterEach, describe, expect, test } from "bun:test";
++import { resolveAztecBb } from "../packages/accelerator/scripts/copy-bb.ts";
++import { checkWindowsBbPin } from "./check-windows-bb-pin.ts";
++
++// F-008: the pin-status check must resolve the LIVE bb.js version and NEVER touch the network.
++describe("check-windows-bb-pin", () => {
++  const origFetch = globalThis.fetch;
++  afterEach(() => {
++    globalThis.fetch = origFetch;
++  });
++
++  test("reports the live bb.js version's pin as present, with no network", () => {
++    globalThis.fetch = (() => {
++      throw new Error("check-windows-bb-pin must not fetch");
++    }) as typeof fetch;
++    const { version, present, message } = checkWindowsBbPin();
++    expect(version).toBe(resolveAztecBb().version); // keys on the gate's version, not argv
++    expect(present).toBe(true); // the committed live version has a manual-review pin
++    expect(message).toContain("present");
++  });
++
++  test("an unpinned version reports MANUAL PIN REQUIRED, with no network", () => {
++    globalThis.fetch = (() => {
++      throw new Error("check-windows-bb-pin must not fetch");
++    }) as typeof fetch;
++    const { present, message } = checkWindowsBbPin("9.9.9");
++    expect(present).toBe(false);
++    expect(message).toContain("MANUAL PIN REQUIRED");
++  });
++});
+diff --git a/scripts/check-windows-bb-pin.ts b/scripts/check-windows-bb-pin.ts
+new file mode 100644
+index 0000000..5fa0fc5
+--- /dev/null
++++ b/scripts/check-windows-bb-pin.ts
+@@ -0,0 +1,57 @@
++#!/usr/bin/env bun
++/**
++ * F-008: report whether the LIVE @aztec/bb.js version has a REVIEWED Windows bb.exe pin.
++ *
++ * Run this AFTER `bun install` — it resolves the installed bb.js version (the SAME key the Windows
++ * Prebuild/Build Smoke gate uses via resolveWindowsBbChecksum), never the argv/aztec.js version.
++ *
++ * Read-only: it NEVER downloads the asset or writes a pin. A pin is added by a human after review (see
++ * WINDOWS_BB_CHECKSUMS in packages/accelerator/scripts/copy-bb.ts) — a twice-downloaded asset is not
++ * independent evidence. This step is INFORMATIONAL; the enforcing fail-closed check is the Windows CI
++ * gate (resolveWindowsBbChecksum throws without an accepted pin), and the only automated bump caller
++ * (aztec-stable → main) runs that gate.
++ */
++import {
++  resolveAztecBb,
++  resolveWindowsBbChecksum,
++  WINDOWS_BB_ASSET,
++} from "../packages/accelerator/scripts/copy-bb.ts";
++
++export interface WindowsBbPinStatus {
++  version: string;
++  present: boolean;
++  message: string;
++}
++
++/** Report the pin status for `version` (defaults to the live bb.js version). Never touches the network. */
++export function checkWindowsBbPin(version: string = resolveAztecBb().version): WindowsBbPinStatus {
++  try {
++    const sha = resolveWindowsBbChecksum(version);
++    return {
++      version,
++      present: true,
++      message: `✓ Windows bb.exe pin present for @aztec/bb.js ${version} (sha256:${sha.slice(0, 12)}…, provenance manual-review).`,
++    };
++  } catch (err) {
++    const detail = err instanceof Error ? err.message : String(err);
++    return {
++      version,
++      present: false,
++      message:
++        `⚠️  MANUAL PIN REQUIRED for @aztec/bb.js ${version}\n` +
++        `The Windows Prebuild/Build Smoke CI gate stays RED until a human adds a reviewed pin.\n` +
++        `Steps: download ${WINDOWS_BB_ASSET} from the v${version} aztec-packages release, verify the\n` +
++        `release page + tag signature, diff it against the prior pinned asset, then add a\n` +
++        `{ sha256, provenance: "manual-review", note } entry to WINDOWS_BB_CHECKSUMS in\n` +
++        `packages/accelerator/scripts/copy-bb.ts. Pins are NEVER auto-generated (F-008).\n` +
++        `(${detail})`,
++    };
++  }
++}
++
++if (import.meta.main) {
++  const status = checkWindowsBbPin();
++  console.log(status.message);
++  // Informational only — exit 0 so the bump can still open its PR; the Windows CI gate is the enforcer.
++  process.exit(0);
++}
+diff --git a/scripts/download-bb.test.ts b/scripts/download-bb.test.ts
+new file mode 100644
+index 0000000..86dd01a
+--- /dev/null
++++ b/scripts/download-bb.test.ts
+@@ -0,0 +1,419 @@
++import { afterEach, beforeEach, describe, expect, test } from "bun:test";
++import { createHash } from "node:crypto";
++import {
++  existsSync,
++  linkSync,
++  mkdirSync,
++  mkdtempSync,
++  readFileSync,
++  rmSync,
++  statSync,
++  symlinkSync,
++  writeFileSync,
++} from "node:fs";
++import { tmpdir } from "node:os";
++import { join } from "node:path";
++import { gzipSync } from "node:zlib";
++import {
++  assertValidVersion,
++  type BbMarker,
++  cleanupOldVersions,
++  currentPlatform,
++  downloadBb,
++  downloadTarball,
++  fetchAssetDigest,
++  findSingleBb,
++  isValidVersionName,
++  listCachedVersions,
++  MARKER_NAME,
++  MARKER_SCHEMA,
++  readMarker,
++  sha256Hex,
++  verifyCachedBb,
++  versionBbPath,
++  versionMarkerPath,
++} from "./download-bb";
++
++// These tests exercise the exported functions on the host platform (Linux CI = amd64-linux, matching
++// the committed fixtures). The CLI itself refuses to run on Windows; the functions are platform-generic.
++
++const sha = (s: string): string => createHash("sha256").update(s).digest("hex");
++
++let base: string;
++const origFetch = globalThis.fetch;
++
++beforeEach(() => {
++  base = mkdtempSync(join(tmpdir(), "bbcache-"));
++  process.env.BB_VERSIONS_DIR = base;
++});
++afterEach(() => {
++  globalThis.fetch = origFetch;
++  delete process.env.BB_VERSIONS_DIR;
++  rmSync(base, { recursive: true, force: true });
++});
++
++/** Build a gzipped tar containing `barretenberg/bb` (+ optional unsafe members). */
++function buildTarball(
++  bbContent: string,
++  opts: { symlink?: boolean; extraBb?: boolean } = {},
++): Uint8Array {
++  const work = mkdtempSync(join(tmpdir(), "bbtar-"));
++  try {
++    const inner = join(work, "barretenberg");
++    mkdirSync(inner, { recursive: true });
++    if (opts.symlink) {
++      symlinkSync("/etc/passwd", join(inner, "bb"));
++    } else {
++      writeFileSync(join(inner, "bb"), bbContent);
++    }
++    if (opts.extraBb) {
++      const other = join(work, "other");
++      mkdirSync(other, { recursive: true });
++      writeFileSync(join(other, "bb"), "second-bb");
++    }
++    const tgz = join(work, "a.tgz");
++    const dirs = opts.extraBb ? ["barretenberg", "other"] : ["barretenberg"];
++    const p = Bun.spawnSync(["tar", "-czf", tgz, "-C", work, ...dirs]);
++    if (!p.success) throw new Error("test tar build failed");
++    return new Uint8Array(readFileSync(tgz));
++  } finally {
++    rmSync(work, { recursive: true, force: true });
++  }
++}
++
++// Minimal fetch fakes — download-bb only touches the fields below.
++function jsonResp(status: number, body: unknown) {
++  return { ok: status >= 200 && status < 300, status, statusText: "s", json: async () => body };
++}
++function streamResp(bytes: Uint8Array, o: { status?: number; contentLength?: string | null } = {}) {
++  const status = o.status ?? 200;
++  return {
++    ok: status >= 200 && status < 300,
++    status,
++    statusText: "s",
++    headers: {
++      get: (k: string) =>
++        k.toLowerCase() === "content-length"
++          ? o.contentLength === undefined
++            ? String(bytes.length)
++            : o.contentLength
++          : null,
++    },
++    body: new Response(bytes).body,
++  };
++}
++function routeFetch(fn: (url: string) => unknown): void {
++  globalThis.fetch = ((input: unknown) => Promise.resolve(fn(String(input)))) as typeof fetch;
++}
++
++/** Wire fetch so the api.github.com digest lookup + the release download both resolve for `version`. */
++function wireHappyFetch(version: string, tarball: Uint8Array): void {
++  const asset = `barretenberg-${currentPlatform()}.tar.gz`;
++  const digest = sha256Hex(tarball);
++  routeFetch((url) => {
++    if (url.includes("api.github.com")) {
++      return jsonResp(200, { assets: [{ name: asset, digest: `sha256:${digest}` }] });
++    }
++    return streamResp(tarball);
++  });
++}
++
++/** Write a valid { bb, marker } cache entry by hand (bypassing the download path). */
++function writeCacheEntry(version: string, bbContent: string, markerOverride: Partial<BbMarker> = {}): void {
++  const dir = join(base, version);
++  mkdirSync(dir, { recursive: true });
++  writeFileSync(join(dir, "bb"), bbContent);
++  const marker: BbMarker = {
++    schema: MARKER_SCHEMA,
++    version,
++    platform: currentPlatform(),
++    archive_sha256: sha("archive"),
++    binary_sha256: sha(bbContent),
++    ...markerOverride,
++  };
++  writeFileSync(versionMarkerPath(version), `${JSON.stringify(marker, null, 2)}\n`);
++}
++
++// ---------------------------------------------------------------------------
++
++describe("assertValidVersion / isValidVersionName (mirrors Rust is_valid_version)", () => {
++  test("accepts real versions", () => {
++    for (const v of ["5.0.0", "5.0.0-rc.2", "5.0.0-nightly.20260307", "4.2.0-aztecnr-rc.2"]) {
++      expect(isValidVersionName(v)).toBe(true);
++      expect(() => assertValidVersion(v)).not.toThrow();
++    }
++  });
++  test("rejects traversal + injection", () => {
++    for (const v of ["", ".hidden", "5.0.0.", "a..b", "../etc", "5.0.0/bb", "a b", "a;b", "x".repeat(129)]) {
++      expect(isValidVersionName(v)).toBe(false);
++      expect(() => assertValidVersion(v)).toThrow();
++    }
++  });
++});
++
++describe("readMarker / verifyCachedBb", () => {
++  test("valid entry verifies", () => {
++    writeCacheEntry("5.0.0-rc.2", "the-bb-bytes");
++    expect(verifyCachedBb("5.0.0-rc.2")).toBe(true);
++    expect(readMarker("5.0.0-rc.2")?.schema).toBe(MARKER_SCHEMA);
++  });
++  test("missing marker ⇒ false", () => {
++    const dir = join(base, "5.0.0-rc.2");
++    mkdirSync(dir, { recursive: true });
++    writeFileSync(join(dir, "bb"), "x");
++    expect(verifyCachedBb("5.0.0-rc.2")).toBe(false);
++  });
++  test("unknown schema ⇒ reject", () => {
++    writeCacheEntry("5.0.0-rc.2", "x", { schema: "other@9" });
++    expect(readMarker("5.0.0-rc.2")).toBeNull();
++    expect(verifyCachedBb("5.0.0-rc.2")).toBe(false);
++  });
++  test("version / platform mismatch ⇒ reject", () => {
++    writeCacheEntry("5.0.0-rc.2", "x", { version: "9.9.9" });
++    expect(verifyCachedBb("5.0.0-rc.2")).toBe(false);
++    writeCacheEntry("5.0.0-rc.3", "x", { platform: "arm64-solaris" });
++    expect(verifyCachedBb("5.0.0-rc.3")).toBe(false);
++  });
++  test("noncanonical hex ⇒ reject", () => {
++    writeCacheEntry("5.0.0-rc.2", "x", { binary_sha256: "NOTHEX" });
++    expect(verifyCachedBb("5.0.0-rc.2")).toBe(false);
++  });
++  test("tampered binary (hash mismatch) ⇒ reject", () => {
++    writeCacheEntry("5.0.0-rc.2", "original");
++    writeFileSync(versionBbPath("5.0.0-rc.2"), "tampered");
++    expect(verifyCachedBb("5.0.0-rc.2")).toBe(false);
++  });
++  test("oversized marker ⇒ reject", () => {
++    writeCacheEntry("5.0.0-rc.2", "x");
++    writeFileSync(versionMarkerPath("5.0.0-rc.2"), " ".repeat(5000));
++    expect(readMarker("5.0.0-rc.2")).toBeNull();
++  });
++});
++
++describe("fetchAssetDigest (fail-closed, mirrors release_metadata.rs)", () => {
++  const asset = `barretenberg-${currentPlatform()}.tar.gz`;
++  test("returns the hex on a valid release", async () => {
++    routeFetch(() => jsonResp(200, { assets: [{ name: asset, digest: `sha256:${sha("t")}` }] }));
++    expect(await fetchAssetDigest("5.0.0-rc.2", asset)).toBe(sha("t"));
++  });
++  test("non-2xx ⇒ throws", async () => {
++    routeFetch(() => jsonResp(404, {}));
++    await expect(fetchAssetDigest("5.0.0-rc.2", asset)).rejects.toThrow();
++  });
++  test("missing asset ⇒ throws", async () => {
++    routeFetch(() => jsonResp(200, { assets: [{ name: "other", digest: `sha256:${sha("t")}` }] }));
++    await expect(fetchAssetDigest("5.0.0-rc.2", asset)).rejects.toThrow();
++  });
++  test("malformed digest ⇒ throws", async () => {
++    routeFetch(() => jsonResp(200, { assets: [{ name: asset, digest: "sha256:xyz" }] }));
++    await expect(fetchAssetDigest("5.0.0-rc.2", asset)).rejects.toThrow();
++  });
++});
++
++describe("downloadTarball (bounded streaming)", () => {
++  test("404 ⇒ throws", async () => {
++    routeFetch(() => streamResp(new Uint8Array(0), { status: 404 }));
++    await expect(downloadTarball("5.0.0-rc.2")).rejects.toThrow();
++  });
++  test("declared oversize Content-Length ⇒ throws before streaming", async () => {
++    routeFetch(() => streamResp(new Uint8Array([1, 2, 3]), { contentLength: "70000000" }));
++    await expect(downloadTarball("5.0.0-rc.2")).rejects.toThrow();
++  });
++  test("normal body streams through", async () => {
++    const bytes = new Uint8Array([1, 2, 3, 4]);
++    routeFetch(() => streamResp(bytes));
++    expect(await downloadTarball("5.0.0-rc.2")).toEqual(bytes);
++  });
++});
++
++describe("findSingleBb (archive-member safety)", () => {
++  test("finds a single regular bb", () => {
++    const root = mkdtempSync(join(tmpdir(), "ex-"));
++    mkdirSync(join(root, "barretenberg"));
++    writeFileSync(join(root, "barretenberg", "bb"), "x");
++    expect(findSingleBb(root)).toBe(join(root, "barretenberg", "bb"));
++    rmSync(root, { recursive: true, force: true });
++  });
++  test("rejects a symlink member", () => {
++    const root = mkdtempSync(join(tmpdir(), "ex-"));
++    symlinkSync("/etc/passwd", join(root, "bb"));
++    expect(() => findSingleBb(root)).toThrow(/symlink/);
++    rmSync(root, { recursive: true, force: true });
++  });
++  test("rejects multiple bb entries", () => {
++    const root = mkdtempSync(join(tmpdir(), "ex-"));
++    mkdirSync(join(root, "a"));
++    mkdirSync(join(root, "b"));
++    writeFileSync(join(root, "a", "bb"), "1");
++    writeFileSync(join(root, "b", "bb"), "2");
++    expect(() => findSingleBb(root)).toThrow(/bb entries/);
++    rmSync(root, { recursive: true, force: true });
++  });
++  test("rejects when no bb present", () => {
++    const root = mkdtempSync(join(tmpdir(), "ex-"));
++    writeFileSync(join(root, "notbb"), "x");
++    expect(() => findSingleBb(root)).toThrow(/not found/);
++    rmSync(root, { recursive: true, force: true });
++  });
++  test("rejects a hardlink bb (nlink > 1)", () => {
++    const root = mkdtempSync(join(tmpdir(), "ex-"));
++    writeFileSync(join(root, "target"), "real");
++    linkSync(join(root, "target"), join(root, "bb")); // hardlink → bb nlink == 2
++    expect(() => findSingleBb(root)).toThrow(/hardlink/);
++    rmSync(root, { recursive: true, force: true });
++  });
++  test("rejects a directory named bb (no regular bb ⇒ not found)", () => {
++    const root = mkdtempSync(join(tmpdir(), "ex-"));
++    mkdirSync(join(root, "bb"));
++    expect(() => findSingleBb(root)).toThrow(/not found/);
++    rmSync(root, { recursive: true, force: true });
++  });
++  test("rejects a wrong-platform archive (only bb.exe ⇒ not found)", () => {
++    const root = mkdtempSync(join(tmpdir(), "ex-"));
++    writeFileSync(join(root, "bb.exe"), "windows");
++    expect(() => findSingleBb(root)).toThrow(/not found/);
++    rmSync(root, { recursive: true, force: true });
++  });
++});
++
++describe("downloadBb end-to-end", () => {
++  test("verifies, publishes bb + marker, and is a verified cache entry", async () => {
++    const v = "5.0.0-rc.2";
++    const tarball = buildTarball("real-bb-binary");
++    wireHappyFetch(v, tarball);
++    await downloadBb(v);
++
++    expect(readFileSync(versionBbPath(v), "utf8")).toBe("real-bb-binary");
++    expect(existsSync(versionMarkerPath(v))).toBe(true);
++    expect(verifyCachedBb(v)).toBe(true);
++    expect(readMarker(v)?.binary_sha256).toBe(sha("real-bb-binary"));
++  });
++
++  test("skips (no fetch) when a valid marker already exists", async () => {
++    const v = "5.0.0-rc.2";
++    writeCacheEntry(v, "already-here");
++    routeFetch(() => {
++      throw new Error("fetch must not be called on a verified skip");
++    });
++    await expect(downloadBb(v)).resolves.toBeUndefined();
++    expect(readFileSync(versionBbPath(v), "utf8")).toBe("already-here");
++  });
++
++  test("digest mismatch ⇒ throws and publishes nothing", async () => {
++    const v = "5.0.0-rc.2";
++    const tarball = buildTarball("real-bb-binary");
++    const asset = `barretenberg-${currentPlatform()}.tar.gz`;
++    routeFetch((url) => {
++      if (url.includes("api.github.com")) {
++        return jsonResp(200, { assets: [{ name: asset, digest: `sha256:${sha("WRONG")}` }] });
++      }
++      return streamResp(tarball);
++    });
++    await expect(downloadBb(v)).rejects.toThrow(/Integrity check failed/);
++    expect(existsSync(join(base, v))).toBe(false); // no live entry, no leftover
++  });
++
++  test("legacy/tampered entry ⇒ re-downloads to a verified state", async () => {
++    const v = "5.0.0-rc.2";
++    writeCacheEntry(v, "original");
++    writeFileSync(versionBbPath(v), "tampered"); // now marker-invalid
++    expect(verifyCachedBb(v)).toBe(false);
++
++    const tarball = buildTarball("fresh-bb");
++    wireHappyFetch(v, tarball);
++    await downloadBb(v);
++    expect(verifyCachedBb(v)).toBe(true);
++    expect(readFileSync(versionBbPath(v), "utf8")).toBe("fresh-bb");
++  });
++
++  test("rejects an unsafe (symlink) archive without publishing", async () => {
++    const v = "5.0.0-rc.2";
++    const tarball = buildTarball("", { symlink: true });
++    wireHappyFetch(v, tarball);
++    await expect(downloadBb(v)).rejects.toThrow(/symlink/);
++    expect(existsSync(join(base, v))).toBe(false);
++  });
++
++  test("rejects an invalid version BEFORE any fetch or fs write", async () => {
++    routeFetch(() => {
++      throw new Error("fetch must not run for an invalid version");
++    });
++    // assertValidVersion throws first — routeFetch would throw if we ever reached the network/fs path.
++    await expect(downloadBb("../../etc")).rejects.toThrow(/Invalid version/);
++  });
++
++  test("aborts on a corrupt/undecompressable archive (post-digest) without publishing", async () => {
++    const v = "5.0.0-rc.2";
++    const corrupt = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]); // not gzip
++    const asset = `barretenberg-${currentPlatform()}.tar.gz`;
++    routeFetch((url) => {
++      if (url.includes("api.github.com")) {
++        // digest matches the corrupt bytes, so it passes the integrity check and reaches gunzip.
++        return jsonResp(200, { assets: [{ name: asset, digest: `sha256:${sha256Hex(corrupt)}` }] });
++      }
++      return streamResp(corrupt);
++    });
++    await expect(downloadBb(v)).rejects.toThrow(/decompression|tar extraction/);
++    expect(existsSync(join(base, v))).toBe(false);
++  });
++
++  test("published bb + marker have owner-only-ish modes (Unix)", async () => {
++    const v = "5.0.0-rc.2";
++    wireHappyFetch(v, buildTarball("real-bb"));
++    await downloadBb(v);
++    expect(statSync(versionBbPath(v)).mode & 0o777).toBe(0o755);
++    expect(statSync(versionMarkerPath(v)).mode & 0o777).toBe(0o600);
++  });
++});
++
++describe("decompression bound (gzip-bomb defense)", () => {
++  test("gunzip rejects output exceeding the cap (the primitive downloadBb relies on)", () => {
++    const { gunzipSync } = require("node:zlib");
++    const gz = gzipSync(Buffer.alloc(2 * 1024 * 1024, 7)); // 2 MiB decompressed
++    expect(() => gunzipSync(gz, { maxOutputLength: 1024 * 1024 })).toThrow();
++    expect(gunzipSync(gz, { maxOutputLength: 4 * 1024 * 1024 }).length).toBe(2 * 1024 * 1024);
++  });
++});
++
++describe("listCachedVersions (inventory excludes stages + unmarked)", () => {
++  test("lists only valid-named, marker-bearing dirs", () => {
++    writeCacheEntry("5.0.0-rc.2", "x"); // valid + marked
++    mkdirSync(join(base, "5.0.0-rc.3"), { recursive: true }); // unmarked
++    writeFileSync(join(base, "5.0.0-rc.3", "bb"), "y");
++    // a crash-stale staging dir — dot-prefixed, WITH a marker inside — must NOT be listed
++    const stage = join(base, ".5.0.0-rc.9.tmp.deadbeef");
++    mkdirSync(stage, { recursive: true });
++    writeFileSync(join(stage, MARKER_NAME), "{}");
++    expect(listCachedVersions()).toEqual(["5.0.0-rc.2"]);
++  });
++});
++
++describe("cleanupOldVersions", () => {
++  test("never evicts a protected (this-invocation) version", () => {
++    for (const v of ["5.0.0-nightly.20260301", "5.0.0-nightly.20260302", "5.0.0-nightly.20260303"]) {
++      writeCacheEntry(v, "x");
++    }
++    // nightly limit is 2; protect the OLDEST so a non-protected one is evicted instead.
++    cleanupOldVersions(new Set(["5.0.0-nightly.20260301"]));
++    const left = listCachedVersions();
++    expect(left).toContain("5.0.0-nightly.20260301"); // protected survived
++    expect(left.length).toBe(2);
++  });
++});
++
++describe("cross-language contract fixtures", () => {
++  test("bb-cache-marker.json matches the marker schema", () => {
++    const m = JSON.parse(readFileSync(join(import.meta.dir, "__fixtures__", "bb-cache-marker.json"), "utf8"));
++    expect(m.schema).toBe(MARKER_SCHEMA);
++    for (const f of [m.archive_sha256, m.binary_sha256]) expect(f).toMatch(/^[0-9a-f]{64}$/);
++    expect(typeof m.version).toBe("string");
++    expect(typeof m.platform).toBe("string");
++  });
++  test("github-release-metadata.json has sha256-prefixed asset digests", () => {
++    const r = JSON.parse(
++      readFileSync(join(import.meta.dir, "__fixtures__", "github-release-metadata.json"), "utf8"),
++    );
++    expect(Array.isArray(r.assets)).toBe(true);
++    for (const a of r.assets) expect(a.digest).toMatch(/^sha256:[0-9a-f]{64}$/);
++  });
++});
+diff --git a/scripts/download-bb.ts b/scripts/download-bb.ts
+index 1e0d7e7..27b3bfe 100644
+--- a/scripts/download-bb.ts
++++ b/scripts/download-bb.ts
+@@ -6,123 +6,433 @@
+  *   bun scripts/download-bb.ts <version>[,<version>,...]
+  *   bun scripts/download-bb.ts --list
+  *
+- * Examples:
+- *   bun scripts/download-bb.ts 5.0.0-nightly.20260305
+- *   bun scripts/download-bb.ts 5.0.0-nightly.20260305,5.0.0-rc.1
+- *   bun scripts/download-bb.ts --list
+- *
+  * Downloads from Aztec GitHub releases into ~/.aztec-accelerator/versions/{version}/bb
+- * (or BB_VERSIONS_DIR if set). Runs retention cleanup after download.
++ * (or BB_VERSIONS_DIR if set), then runs retention cleanup.
++ *
++ * SECURITY (F-007): this cache is runtime-trusted — the accelerator executes `bb` from it over the
++ * private proving witness. So every download is verified against the GitHub release asset's published
++ * SHA-256 digest, extracted into a PRIVATE per-run staging dir with archive-member safety checks,
++ * ad-hoc re-signed (macOS), fingerprinted, and published atomically alongside a `bb.sha256.json` MARKER
++ * (archive digest + final-binary digest). The Rust runtime rehashes the cached `bb` against that marker
++ * on every use; a missing/tampered marker fails closed and re-downloads. Mirrors the fail-closed Rust
++ * pipeline in packages/accelerator/core/src/versions/{downloader,release_metadata,cache_layout}.rs.
++ *
++ * Windows: bb.exe ships as a bundled Tauri sidecar via packages/accelerator/scripts/copy-bb.ts — NOT
++ * this cache tool — so this script is Unix-only and refuses to run on win32.
+  */
+-import { chmodSync, existsSync, mkdirSync, rmSync } from "node:fs";
++import { createHash, randomBytes } from "node:crypto";
++import {
++  chmodSync,
++  closeSync,
++  copyFileSync,
++  existsSync,
++  lstatSync,
++  mkdirSync,
++  openSync,
++  readdirSync,
++  readFileSync,
++  readSync,
++  renameSync,
++  rmSync,
++  statSync,
++  writeFileSync,
++} from "node:fs";
+ import { homedir } from "node:os";
+ import { join } from "node:path";
++import { gunzipSync } from "node:zlib";
++
++// ---------------------------------------------------------------------------
++// Constants
++// ---------------------------------------------------------------------------
++
++export const MARKER_SCHEMA = "aztec-accelerator/bb-cache-marker@1";
++export const MARKER_NAME = "bb.sha256.json";
++// bb's tarball is ~5 MiB; cap far above that so a compromised CDN can't OOM us before the digest
++// mismatch is detected. Mirrors Rust MAX_DOWNLOAD_BYTES.
++const MAX_BB_TARBALL_BYTES = 64 * 1024 * 1024;
++// Decompressed ceiling — a ≤64 MB-compressed binary inflates to at most a few hundred MB. Applied as a
++// CUMULATIVE cap on the whole decompressed tar (before extraction, defeating a gzip bomb) AND to the
++// selected bb. Mirrors Rust MAX_DECOMPRESSED_BYTES.
++const MAX_BB_BINARY_BYTES = 512 * 1024 * 1024;
++const HEX64 = /^[0-9a-f]{64}$/;
++
++export interface BbMarker {
++  schema: string;
++  version: string;
++  platform: string;
++  archive_sha256: string;
++  binary_sha256: string;
++}
+ 
+ // ---------------------------------------------------------------------------
+-// Platform detection — matches accelerator's current_platform() (versions.rs)
+-// Aztec release naming: arm64-darwin, amd64-darwin, amd64-linux, arm64-linux
++// Platform detection — matches accelerator's current_platform() (release_metadata.rs)
+ // ---------------------------------------------------------------------------
+ 
+-function currentPlatform(): string {
++export function currentPlatform(): string {
+   const arch = process.arch === "arm64" ? "arm64" : "amd64";
+   const os = process.platform === "darwin" ? "darwin" : "linux";
+   return `${arch}-${os}`;
+ }
+ 
+-function downloadUrl(version: string): string {
+-  return `https://github.com/AztecProtocol/aztec-packages/releases/download/v${version}/barretenberg-${currentPlatform()}.tar.gz`;
++function assetName(): string {
++  return `barretenberg-${currentPlatform()}.tar.gz`;
++}
++
++export function downloadUrl(version: string): string {
++  return `https://github.com/AztecProtocol/aztec-packages/releases/download/v${version}/${assetName()}`;
+ }
+ 
+ // ---------------------------------------------------------------------------
+-// Paths — same as packages/accelerator/src-tauri/src/versions.rs
++// Version validation — mirror of Rust is_valid_version (version_policy.rs): the single
++// path-traversal/injection guard before a version string is used to build a cache path.
+ // ---------------------------------------------------------------------------
+ 
+-function versionsBaseDir(): string {
+-  return process.env.BB_VERSIONS_DIR || join(homedir(), ".aztec-accelerator", "versions");
++export function isValidVersionName(version: string): boolean {
++  return (
++    version.length > 0 &&
++    version.length <= 128 &&
++    !version.startsWith(".") &&
++    !version.endsWith(".") &&
++    !version.includes("..") &&
++    /^[A-Za-z0-9._-]+$/.test(version)
++  );
+ }
+ 
+-function versionBbPath(version: string): string {
+-  return join(versionsBaseDir(), version, "bb");
++export function assertValidVersion(version: string): void {
++  if (!isValidVersionName(version)) {
++    throw new Error(
++      `Invalid version string ${JSON.stringify(version)} — rejected by the path-traversal/injection guard`,
++    );
++  }
+ }
+ 
+-function listCachedVersions(): string[] {
+-  const base = versionsBaseDir();
+-  if (!existsSync(base)) return [];
+-  const { readdirSync } = require("node:fs");
+-  const versions: string[] = [];
+-  for (const entry of readdirSync(base, { withFileTypes: true })) {
+-    if (entry.isDirectory() && existsSync(join(base, entry.name, "bb"))) {
+-      versions.push(entry.name);
+-    }
+-  }
+-  return versions.sort();
++// ---------------------------------------------------------------------------
++// Paths
++// ---------------------------------------------------------------------------
++
++export function versionsBaseDir(): string {
++  return process.env.BB_VERSIONS_DIR || join(homedir(), ".aztec-accelerator", "versions");
++}
++function versionDir(version: string): string {
++  return join(versionsBaseDir(), version);
++}
++export function versionBbPath(version: string): string {
++  return join(versionDir(version), "bb");
++}
++export function versionMarkerPath(version: string): string {
++  return join(versionDir(version), MARKER_NAME);
+ }
+ 
+ // ---------------------------------------------------------------------------
+-// Download
++// Integrity: digest lookup, hashing, marker read + cached-bb verification
+ // ---------------------------------------------------------------------------
+ 
+-async function downloadBb(version: string): Promise<void> {
+-  const bbPath = versionBbPath(version);
++export function sha256Hex(data: Uint8Array): string {
++  return createHash("sha256").update(data).digest("hex");
++}
++
++/** Streamed SHA-256 of a file (chunked reads — never buffers the whole binary). Mirrors Rust sha256_file. */
++export function sha256File(path: string): string {
++  const hash = createHash("sha256");
++  const fd = openSync(path, "r");
++  try {
++    const buf = Buffer.allocUnsafe(64 * 1024);
++    let n: number;
++    while ((n = readSync(fd, buf, 0, buf.length, null)) > 0) {
++      hash.update(buf.subarray(0, n));
++    }
++  } finally {
++    closeSync(fd);
++  }
++  return hash.digest("hex");
++}
+ 
+-  if (existsSync(bbPath)) {
+-    console.log(`  ✓ ${version} (already cached)`);
+-    return;
++/**
++ * Fetch the expected SHA-256 for a release asset from the GitHub API. Mirrors
++ * release_metadata.rs::fetch_github_asset_digest, but FAIL-CLOSED at the call site: a non-2xx, a
++ * missing asset/digest, or a malformed digest THROWS (the Rust helper returns Ok(None) and its caller
++ * throws — same net behavior). Honors GITHUB_TOKEN to dodge the 60/hr unauth rate limit.
++ */
++export async function fetchAssetDigest(version: string, asset: string): Promise<string> {
++  const apiUrl = `https://api.github.com/repos/AztecProtocol/aztec-packages/releases/tags/v${version}`;
++  const headers: Record<string, string> = {
++    accept: "application/vnd.github+json",
++    "user-agent": "aztec-accelerator",
++  };
++  if (process.env.GITHUB_TOKEN) headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
++
++  const res = await fetch(apiUrl, { headers });
++  if (!res.ok) {
++    throw new Error(`Cannot verify bb v${version}: release metadata HTTP ${res.status} ${res.statusText}`);
++  }
++  const release = (await res.json()) as { assets?: Array<{ name?: string; digest?: string }> };
++  const found = (release.assets ?? []).find((a) => a.name === asset);
++  if (!found?.digest) {
++    throw new Error(`Cannot verify bb v${version}: no digest for asset ${asset} in release metadata`);
+   }
++  const hex = found.digest.startsWith("sha256:") ? found.digest.slice("sha256:".length) : "";
++  if (!HEX64.test(hex)) {
++    throw new Error(`Cannot verify bb v${version}: malformed asset digest ${JSON.stringify(found.digest)}`);
++  }
++  return hex;
++}
+ 
+-  const url = downloadUrl(version);
+-  console.log(`  ↓ ${version} — downloading from GitHub releases...`);
++/** Read + structurally validate a cached version's marker. Returns null on any defect (fail-closed). */
++export function readMarker(version: string): BbMarker | null {
++  const p = versionMarkerPath(version);
++  if (!existsSync(p)) return null;
++  try {
++    // Bounded read — a marker is a few hundred bytes; refuse an oversized blob.
++    if (statSync(p).size > 4096) return null;
++    const m = JSON.parse(readFileSync(p, "utf8")) as BbMarker;
++    if (m.schema !== MARKER_SCHEMA) return null;
++    if (m.version !== version) return null;
++    if (m.platform !== currentPlatform()) return null;
++    if (!HEX64.test(m.archive_sha256) || !HEX64.test(m.binary_sha256)) return null;
++    return m;
++  } catch {
++    return null;
++  }
++}
++
++/** True iff the cached bb for `version` is a present regular file whose bytes match its valid marker. */
++export function verifyCachedBb(version: string): boolean {
++  const bb = versionBbPath(version);
++  if (!existsSync(bb)) return false;
++  const st = lstatSync(bb);
++  if (!st.isFile()) return false;
++  const marker = readMarker(version);
++  if (!marker) return false;
++  return sha256File(bb) === marker.binary_sha256;
++}
+ 
+-  const response = await fetch(url);
+-  if (!response.ok) {
+-    if (response.status === 404) {
++// ---------------------------------------------------------------------------
++// Download (bounded streaming) + archive-member safety
++// ---------------------------------------------------------------------------
++
++/**
++ * Bounded streaming download (mirror Rust download_tarball): read the body chunk-by-chunk with a
++ * running byte cap. Never `arrayBuffer()` — that would buffer an unbounded body when Content-Length is
++ * absent or lying, defeating the cap.
++ */
++export async function downloadTarball(version: string): Promise<Uint8Array> {
++  const url = downloadUrl(version);
++  const res = await fetch(url);
++  if (!res.ok) {
++    if (res.status === 404) {
+       throw new Error(
+         `Version ${version} not found (404). Check available releases at:\n` +
+           `  https://github.com/AztecProtocol/aztec-packages/releases`,
+       );
+     }
+-    throw new Error(`Download failed: ${response.status} ${response.statusText}`);
++    throw new Error(`Download failed: ${res.status} ${res.statusText}`);
++  }
++  const declared = Number(res.headers.get("content-length") ?? "0");
++  if (declared > MAX_BB_TARBALL_BYTES) {
++    throw new Error(`bb v${version} download too large (advertised ${declared} bytes, max ${MAX_BB_TARBALL_BYTES})`);
++  }
++  if (!res.body) throw new Error(`bb v${version}: empty response body`);
++
++  const reader = res.body.getReader();
++  const chunks: Uint8Array[] = [];
++  let total = 0;
++  for (;;) {
++    const { done, value } = await reader.read();
++    if (done) break;
++    total += value.length;
++    if (total > MAX_BB_TARBALL_BYTES) {
++      throw new Error(`bb v${version} download exceeded ${MAX_BB_TARBALL_BYTES} bytes — aborting`);
++    }
++    chunks.push(value);
++  }
++  const out = new Uint8Array(total);
++  let off = 0;
++  for (const c of chunks) {
++    out.set(c, off);
++    off += c.length;
++  }
++  return out;
++}
++
++/**
++ * Locate exactly one regular file named `bb` in the extracted tree, rejecting unsafe members. Symlinks
++ * anywhere in the tree are rejected (a symlink `bb` → /etc/passwd is the classic archive-escape). Zero
++ * or multiple `bb` entries, a non-regular `bb`, or an oversized `bb` all fail closed. (Digest
++ * verification already ran before extraction, so this is defense-in-depth against a compromised-upstream
++ * archive whose digest was also forged.)
++ */
++export function findSingleBb(root: string): string {
++  const found: string[] = [];
++  const walk = (dir: string): void => {
++    for (const entry of readdirSync(dir, { withFileTypes: true })) {
++      const full = join(dir, entry.name);
++      const st = lstatSync(full);
++      if (st.isSymbolicLink()) {
++        throw new Error(`Unsafe archive member (symlink): ${entry.name}`);
++      }
++      if (st.isDirectory()) {
++        walk(full);
++        continue;
++      }
++      if (entry.name === "bb") {
++        if (!st.isFile()) throw new Error(`Unsafe archive: bb entry is not a regular file`);
++        // A tar hardlink extracts to an inode with nlink > 1 (linked to another extracted member); a
++        // lone legitimate bb has nlink 1. Reject to match the Rust path's regular-file-only guarantee.
++        if (st.nlink > 1) throw new Error(`Unsafe archive: bb is a hardlink (nlink=${st.nlink})`);
++        if (st.size > MAX_BB_BINARY_BYTES) {
++          throw new Error(`bb entry too large: ${st.size} bytes > ${MAX_BB_BINARY_BYTES}`);
++        }
++        found.push(full);
++      }
++    }
++  };
++  walk(root);
++  const [bb, ...rest] = found;
++  if (bb === undefined) throw new Error("bb binary not found in tarball");
++  if (rest.length > 0) throw new Error(`Unsafe archive: ${found.length} bb entries (expected exactly 1)`);
++  return bb;
++}
++
++// ---------------------------------------------------------------------------
++// Staged, verified install
++// ---------------------------------------------------------------------------
++
++/** Remove crash-stale staging siblings for `version` (`.{version}.tmp.*`) before starting a fresh one. */
++function reapStaleStages(version: string): void {
++  const base = versionsBaseDir();
++  if (!existsSync(base)) return;
++  const prefix = `.${version}.tmp.`;
++  for (const name of readdirSync(base)) {
++    if (name.startsWith(prefix)) {
++      rmSync(join(base, name), { recursive: true, force: true });
++    }
+   }
++}
++
++/**
++ * Create a per-run-UNIQUE, dot-prefixed, owner-only staging sibling (`.{version}.tmp.<rand>`). Unique so
++ * a concurrent Rust/TS publisher never shares (and stomps) one stage; dot-prefixed + non-version-named so
++ * inventory never surfaces an in-flight or crash-stale stage. `mkdir` is strict (non-recursive) so the
++ * astronomically-unlikely name collision fails closed rather than reusing a dir.
++ */
++function createStagingDir(version: string): string {
++  mkdirSync(versionsBaseDir(), { recursive: true, mode: 0o700 });
++  const stage = join(versionsBaseDir(), `.${version}.tmp.${randomBytes(6).toString("hex")}`);
++  mkdirSync(stage, { mode: 0o700 });
++  return stage;
++}
+ 
+-  const tarball = await response.arrayBuffer();
+-  const versionDir = join(versionsBaseDir(), version);
+-  mkdirSync(versionDir, { recursive: true });
++/**
++ * Download + verify + stage + finalize + marker + fail-closed publish for one version. Skips (verified)
++ * if the cache already holds a marker-valid binary.
++ */
++export async function downloadBb(version: string): Promise<void> {
++  assertValidVersion(version);
+ 
+-  // Extract tarball — bb binary is at the root of the archive
+-  const proc = Bun.spawn(["tar", "-xzf", "-", "-C", versionDir], {
+-    stdin: new Uint8Array(tarball),
+-  });
+-  const exitCode = await proc.exited;
+-  if (exitCode !== 0) {
+-    rmSync(versionDir, { recursive: true, force: true });
+-    throw new Error(`tar extraction failed (exit code ${exitCode})`);
++  if (verifyCachedBb(version)) {
++    console.log(`  ✓ ${version} (already cached, verified)`);
++    return;
+   }
+ 
+-  if (!existsSync(bbPath)) {
+-    rmSync(versionDir, { recursive: true, force: true });
+-    throw new Error(`bb binary not found after extraction at ${bbPath}`);
++  console.log(`  ↓ ${version} — downloading + verifying...`);
++  const archiveDigest = await fetchAssetDigest(version, assetName());
++  const tarball = await downloadTarball(version);
++  const actualArchive = sha256Hex(tarball);
++  if (actualArchive !== archiveDigest) {
++    throw new Error(
++      `Integrity check failed for bb v${version}: expected sha256:${archiveDigest}, got sha256:${actualArchive}`,
++    );
+   }
+ 
+-  chmodSync(bbPath, 0o755);
++  reapStaleStages(version);
++  const stage = createStagingDir(version);
++  try {
++    // Extract into an isolated subdir so only the promoted `bb` + marker ever publish.
++    const extract = join(stage, "extract");
++    mkdirSync(extract, { mode: 0o700 });
++    // Bound decompression BEFORE touching the fs: `gunzipSync` with a cumulative output cap aborts a
++    // gzip bomb (system `tar -xz` would stream an unbounded bomb to disk). Then extract the bounded tar.
++    let tarBytes: Buffer;
++    try {
++      tarBytes = gunzipSync(tarball, { maxOutputLength: MAX_BB_BINARY_BYTES });
++    } catch (e) {
++      throw new Error(
++        `bb v${version}: decompression aborted (exceeds ${MAX_BB_BINARY_BYTES} bytes or is corrupt): ${e instanceof Error ? e.message : String(e)}`,
++      );
++    }
++    const tarPath = join(stage, "archive.tar");
++    writeFileSync(tarPath, tarBytes, { mode: 0o600 });
++    const proc = Bun.spawnSync(["tar", "-xf", tarPath, "-C", extract]);
++    if (!proc.success) throw new Error(`tar extraction failed (exit code ${proc.exitCode})`);
++
++    const bbSrc = findSingleBb(extract);
++    const stagedBb = join(stage, "bb");
++    copyFileSync(bbSrc, stagedBb);
++    chmodSync(stagedBb, 0o755);
++
++    // macOS: clear quarantine + ad-hoc re-sign (chmod invalidates the original signature, and
++    // Gatekeeper SIGKILLs an unsigned binary). Codesign failure ABORTS — we never publish an
++    // unsignable bb. This mutates the bytes, so the marker fingerprint is taken AFTER it.
++    if (process.platform === "darwin") {
++      Bun.spawnSync(["xattr", "-cr", stagedBb]);
++      const cs = Bun.spawnSync(["codesign", "--force", "--sign", "-", stagedBb]);
++      if (!cs.success) {
++        throw new Error(`codesign failed for bb v${version} (exit ${cs.exitCode})`);
++      }
++    }
+ 
+-  // macOS: clear quarantine attribute and ad-hoc re-sign.
+-  // GitHub release binaries have ad-hoc signatures that get invalidated during
+-  // download/extraction, causing Gatekeeper to silently block execution (hang).
+-  if (process.platform === "darwin") {
+-    Bun.spawnSync(["xattr", "-d", "com.apple.quarantine", bbPath]);
+-    Bun.spawnSync(["codesign", "--force", "--sign", "-", bbPath]);
++    const binaryDigest = sha256File(stagedBb);
++    const marker: BbMarker = {
++      schema: MARKER_SCHEMA,
++      version,
++      platform: currentPlatform(),
++      archive_sha256: archiveDigest,
++      binary_sha256: binaryDigest,
++    };
++    writeFileSync(join(stage, MARKER_NAME), `${JSON.stringify(marker, null, 2)}\n`, { mode: 0o600 });
++
++    // Drop the extract scratch + archive so the stage holds only { bb, bb.sha256.json }.
++    rmSync(extract, { recursive: true, force: true });
++    rmSync(tarPath, { force: true });
++
++    // Fail-closed publish: remove any live entry, then rename the stage into place. A crash between
++    // the two leaves NO live entry (⇒ verified re-download next use) plus a `.tmp.<rand>` stage
++    // (reaped by the next install's stage-unique naming + cleanup). Deliberately NOT atomic replacement.
++    const vdir = versionDir(version);
++    if (existsSync(vdir)) rmSync(vdir, { recursive: true, force: true });
++    renameSync(stage, vdir);
++  } catch (err) {
++    rmSync(stage, { recursive: true, force: true });
++    throw err;
+   }
+ 
+-  const stat = Bun.file(bbPath);
+-  const sizeMb = ((await stat.size) / 1024 / 1024).toFixed(1);
+-  console.log(`  ✓ ${version} (${sizeMb} MB)`);
++  const sizeMb = (statSync(versionBbPath(version)).size / 1024 / 1024).toFixed(1);
++  console.log(`  ✓ ${version} (${sizeMb} MB, verified)`);
+ }
+ 
+ // ---------------------------------------------------------------------------
+-// Retention cleanup — same logic as bb-versions.ts
++// Inventory + retention
+ // ---------------------------------------------------------------------------
+ 
+-type NetworkTier = "nightly" | "devnet" | "testnet" | "mainnet";
++/**
++ * List cached versions: a directory is "cached" only if its name is a valid version (skips
++ * dot-prefixed `.tmp.<rand>` stages and junk) AND it holds a marker. Cheap stat only — never rehashes
++ * (execution paths rehash; inventory does not).
++ */
++export function listCachedVersions(): string[] {
++  const base = versionsBaseDir();
++  if (!existsSync(base)) return [];
++  const versions: string[] = [];
++  for (const entry of readdirSync(base, { withFileTypes: true })) {
++    if (!entry.isDirectory()) continue;
++    if (!isValidVersionName(entry.name)) continue; // excludes `.{v}.tmp.<rand>` (leading dot)
++    if (!existsSync(join(base, entry.name, MARKER_NAME))) continue;
++    versions.push(entry.name);
++  }
++  return versions.sort();
++}
++
++export type NetworkTier = "nightly" | "devnet" | "testnet" | "mainnet";
+ 
+ const RETENTION_LIMITS: Record<NetworkTier, number | null> = {
+   nightly: 2,
+@@ -131,7 +441,7 @@ const RETENTION_LIMITS: Record<NetworkTier, number | null> = {
+   mainnet: null,
+ };
+ 
+-function classifyVersion(version: string): NetworkTier {
++export function classifyVersion(version: string): NetworkTier {
+   const prerelease = version.split("-").slice(1).join("-");
+   if (prerelease.startsWith("nightly")) return "nightly";
+   if (prerelease.startsWith("devnet")) return "devnet";
+@@ -139,7 +449,12 @@ function classifyVersion(version: string): NetworkTier {
+   return "mainnet";
+ }
+ 
+-function cleanupOldVersions(): void {
++/**
++ * Evict old cached versions per tier retention. `protectedVersions` (the versions downloaded in THIS
++ * invocation) are never evicted — otherwise `download-bb.ts <old-nightly>` could delete the very
++ * version it just fetched.
++ */
++export function cleanupOldVersions(protectedVersions: Set<string> = new Set()): void {
+   const cached = listCachedVersions();
+   const byTier = new Map<NetworkTier, string[]>();
+   for (const v of cached) {
+@@ -151,11 +466,13 @@ function cleanupOldVersions(): void {
+   for (const [tier, versions] of byTier) {
+     const limit = RETENTION_LIMITS[tier];
+     if (limit === null) continue;
+-    const sorted = [...versions].sort();
++    const sorted = [...versions].sort(); // oldest first
+     while (sorted.length > limit) {
+-      const evict = sorted.shift()!;
+-      const dir = join(versionsBaseDir(), evict);
+-      rmSync(dir, { recursive: true, force: true });
++      // Evict the oldest NON-protected version; stop if only protected ones remain.
++      const idx = sorted.findIndex((v) => !protectedVersions.has(v));
++      if (idx === -1) break;
++      const [evict] = sorted.splice(idx, 1);
++      rmSync(join(versionsBaseDir(), evict), { recursive: true, force: true });
+       console.log(`  🗑 Evicted ${evict} (${tier} retention: keep ${limit})`);
+     }
+   }
+@@ -165,68 +482,76 @@ function cleanupOldVersions(): void {
+ // CLI
+ // ---------------------------------------------------------------------------
+ 
+-const args = process.argv.slice(2);
++async function main(): Promise<void> {
++  if (process.platform === "win32") {
++    console.error(
++      "download-bb.ts is not supported on Windows.\n" +
++        "The Windows bb.exe ships as a bundled Tauri sidecar via packages/accelerator/scripts/copy-bb.ts.",
++    );
++    process.exit(1);
++  }
+ 
+-if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
+-  console.log(`Usage: bun scripts/download-bb.ts <version>[,<version>,...] [--list]
++  const args = process.argv.slice(2);
+ 
+-Downloads bb binaries for specific Aztec versions.
++  if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
++    console.log(`Usage: bun scripts/download-bb.ts <version>[,<version>,...] [--list]
++
++Downloads + verifies bb binaries for specific Aztec versions.
+ 
+ Options:
+   --list    List cached versions and exit
+ 
+-Examples:
+-  bun scripts/download-bb.ts 5.0.0-nightly.20260305
+-  bun scripts/download-bb.ts 5.0.0-nightly.20260305,5.0.0-devnet.1
+-  bun scripts/download-bb.ts --list
+-
+ Cache: ${versionsBaseDir()}
+ Platform: ${currentPlatform()}`);
+-  process.exit(0);
+-}
++    process.exit(0);
++  }
+ 
+-if (args.includes("--list")) {
+-  const cached = listCachedVersions();
+-  console.log(`Cache: ${versionsBaseDir()}`);
+-  if (cached.length === 0) {
+-    console.log("No cached versions.");
+-  } else {
+-    console.log(`\n${cached.length} cached version(s):`);
+-    for (const v of cached) {
+-      const tier = classifyVersion(v);
+-      console.log(`  ${v} (${tier})`);
++  if (args.includes("--list")) {
++    const cached = listCachedVersions();
++    console.log(`Cache: ${versionsBaseDir()}`);
++    if (cached.length === 0) {
++      console.log("No cached versions.");
++    } else {
++      console.log(`\n${cached.length} cached version(s):`);
++      for (const v of cached) console.log(`  ${v} (${classifyVersion(v)})`);
+     }
++    process.exit(0);
+   }
+-  process.exit(0);
+-}
+ 
+-const versions = args
+-  .flatMap((a) => a.split(","))
+-  .map((v) => v.trim())
+-  .filter(Boolean);
++  const versions = args
++    .flatMap((a) => a.split(","))
++    .map((v) => v.trim())
++    .filter(Boolean);
+ 
+-if (versions.length === 0) {
+-  console.error("Error: no versions specified");
+-  process.exit(1);
+-}
+-
+-console.log(`Downloading bb for ${versions.length} version(s) [${currentPlatform()}]`);
+-console.log(`Cache: ${versionsBaseDir()}\n`);
++  if (versions.length === 0) {
++    console.error("Error: no versions specified");
++    process.exit(1);
++  }
+ 
+-let failed = false;
+-for (const version of versions) {
+-  try {
+-    await downloadBb(version);
+-  } catch (err) {
+-    console.error(`  ✗ ${version}: ${err instanceof Error ? err.message : String(err)}`);
+-    failed = true;
++  console.log(`Downloading bb for ${versions.length} version(s) [${currentPlatform()}]`);
++  console.log(`Cache: ${versionsBaseDir()}\n`);
++
++  let failed = false;
++  const downloaded = new Set<string>();
++  for (const version of versions) {
++    try {
++      await downloadBb(version);
++      downloaded.add(version);
++    } catch (err) {
++      console.error(`  ✗ ${version}: ${err instanceof Error ? err.message : String(err)}`);
++      failed = true;
++    }
+   }
+-}
+ 
+-console.log("");
+-cleanupOldVersions();
++  console.log("");
++  cleanupOldVersions(downloaded);
+ 
+-const cached = listCachedVersions();
+-console.log(`\nCached versions: ${cached.join(", ") || "(none)"}`);
++  const cached = listCachedVersions();
++  console.log(`\nCached versions: ${cached.join(", ") || "(none)"}`);
+ 
+-if (failed) process.exit(1);
++  if (failed) process.exit(1);
++}
++
++if (import.meta.main) {
++  await main();
++}
+diff --git a/scripts/update-aztec-version.ts b/scripts/update-aztec-version.ts
+index c33c042..31a174e 100644
+--- a/scripts/update-aztec-version.ts
++++ b/scripts/update-aztec-version.ts
+@@ -65,7 +65,6 @@ async function findMissingPackages(version: string, packageFiles: string[]): Pro
+ }
+ 
+ const CRS_FILE = "packages/playground/src/aztec.ts";
+-const COPY_BB_FILE = "packages/accelerator/scripts/copy-bb.ts";
+ 
+ /** Bump CRS_CACHE_VERSION so returning playground visitors re-download the CRS if bb.js changed its format. */
+ async function updateCrsCacheVersion(version: string): Promise<boolean> {
+@@ -76,26 +75,10 @@ async function updateCrsCacheVersion(version: string): Promise<boolean> {
+   return true;
+ }
+ 
+-/** Fetch + pin the Windows bb.exe SHA-256 (the Windows Prebuild/Build Smoke gates verify it). Best-effort. */
+-async function pinWindowsBbChecksum(version: string): Promise<string> {
+-  const original = await Bun.file(COPY_BB_FILE).text();
+-  if (original.includes(`"${version}":`)) return `Windows bb checksum: already pinned for ${version}.`;
+-  const url = `https://github.com/AztecProtocol/aztec-packages/releases/download/v${version}/barretenberg-amd64-windows.tar.gz`;
+-  try {
+-    const res = await fetch(url);
+-    if (!res.ok) return `Windows bb checksum: fetch failed (HTTP ${res.status}) — pin "${version}" in ${COPY_BB_FILE} manually.`;
+-    const digest = await crypto.subtle.digest("SHA-256", await res.arrayBuffer());
+-    const sha = [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+-    const marker = "};\n\nexport function resolveWindowsBbChecksum";
+-    const idx = original.indexOf(marker);
+-    const entry = `  // @aztec/bb.js ${version} — sha256 of barretenberg-amd64-windows.tar.gz from the v${version} release (auto-pinned).\n  "${version}": "${sha}",\n`;
+-    if (idx === -1) return `Windows bb checksum for ${version} = ${sha} — couldn't auto-insert; add it to ${COPY_BB_FILE} manually.`;
+-    await Bun.write(COPY_BB_FILE, original.slice(0, idx) + entry + original.slice(idx));
+-    return `Windows bb checksum: pinned ${version} = ${sha.slice(0, 12)}… in ${COPY_BB_FILE}.`;
+-  } catch (err) {
+-    return `Windows bb checksum: ${(err as Error).message} — pin "${version}" manually.`;
+-  }
+-}
++// F-008: the Windows bb.exe pin is NEVER auto-generated here. Auto-downloading the asset and writing its
++// own hash is circular (a twice-downloaded asset is not independent evidence). A human adds a reviewed
++// `manual-review` entry to WINDOWS_BB_CHECKSUMS (copy-bb.ts); the post-install `check-windows-bb-pin.ts`
++// step reports whether the live bb.js version has a pin, and the Windows CI gate fails closed without one.
+ 
+ async function main() {
+   const newVersion = process.argv[2];
+@@ -134,7 +117,7 @@ async function main() {
+   // Companion bumps an @aztec version change also requires (lessons from the 5.0.0-rc.2 bump):
+   const crsBumped = await updateCrsCacheVersion(newVersion);
+   if (crsBumped) console.log(`Bumped CRS_CACHE_VERSION → ${newVersion} in ${CRS_FILE}.`);
+-  console.log(await pinWindowsBbChecksum(newVersion));
++  // The Windows bb.exe pin is intentionally NOT touched here (F-008) — see check-windows-bb-pin.ts.
+ 
+   if (updatedFiles === 0 && !crsBumped) {
+     console.log("\nAll files already at target version. No changes needed.");

--- a/implementations-plan/security-hardening/full-audit-2026-07-24/chunks/H-infra.diff
+++ b/implementations-plan/security-hardening/full-audit-2026-07-24/chunks/H-infra.diff
@@ -1,0 +1,392 @@
+diff --git a/infra/rulesets/main-branch-protection.json b/infra/rulesets/main-branch-protection.json
+index 2204edf..9b16f1c 100644
+--- a/infra/rulesets/main-branch-protection.json
++++ b/infra/rulesets/main-branch-protection.json
+@@ -10,6 +10,9 @@
+     }
+   },
+   "rules": [
++    { "type": "deletion" },
++    { "type": "non_fast_forward" },
++    { "type": "required_linear_history" },
+     {
+       "type": "pull_request",
+       "parameters": {
+@@ -17,18 +20,20 @@
+         "require_code_owner_review": false,
+         "require_last_push_approval": false,
+         "required_approving_review_count": 0,
+-        "required_review_thread_resolution": false
++        "required_review_thread_resolution": true,
++        "allowed_merge_methods": ["squash", "rebase"]
+       }
+     },
+     {
+       "type": "required_status_checks",
+       "parameters": {
+-        "strict_required_status_checks_policy": false,
++        "strict_required_status_checks_policy": true,
+         "do_not_enforce_on_create": true,
+         "required_status_checks": [
+           { "context": "SDK Status", "integration_id": 15368 },
+           { "context": "App Status", "integration_id": 15368 },
+-          { "context": "Accelerator Status", "integration_id": 15368 }
++          { "context": "Accelerator Status", "integration_id": 15368 },
++          { "context": "Actionlint Status", "integration_id": 15368 }
+         ]
+       }
+     }
+diff --git a/infra/tofu/README.md b/infra/tofu/README.md
+index 6857608..6c21d90 100644
+--- a/infra/tofu/README.md
++++ b/infra/tofu/README.md
+@@ -81,7 +81,19 @@ After `tofu apply`, set these in the repo's GitHub settings:
+ 
+ | Secret | Value |
+ |--------|-------|
+-| `AWS_ROLE_ARN` | `tofu output ci_role_arn` |
++| `AWS_ROLE_ARN_LANDING` | `tofu output -raw landing_deploy_role_arn` |
++| `AWS_ROLE_ARN_RELEASE` | `tofu output -raw release_feed_role_arn` |
++| `AWS_ROLE_ARN_PLAYGROUND` | `tofu output -raw playground_testnet_role_arn` |
+ | `AWS_REGION` | `us-east-1` |
+ | `S3_BUCKET_NAME` | `tofu output s3_bucket_name` |
+ | `CLOUDFRONT_DISTRIBUTION_ID` | `tofu output cloudfront_distribution_id` |
++
++**F-005 (C5) per-pipeline deploy roles.** The single `AWS_ROLE_ARN` (from `ci_role_arn`) is replaced by
++three least-privilege, per-pipeline roles, each trusting ONLY its own workflow (the OIDC `workflow` NAME
++claim) on `main`. Only the release pipeline may write `landing/releases/latest.json` (the F-004 update
++feed); the landing role is explicitly denied it. **Cutover is staged + human-applied** — see the C5
++runbook (`implementations-plan/security-hardening/clusters/C5-runbook.md`): apply roles (legacy retained,
++trust-narrowed) → set the 3 new secrets → land the workflow cutover on `main` → smoke (incl. a negative
++cross-role AssumeRole test) → delete the legacy role + `AWS_ROLE_ARN` in a separate PR. `deploy-landing`
++must keep `--exclude "releases"`/`"releases/*"` on its `sync --delete` (the IAM Deny enforces it too).
++Adding a second release-feed object requires updating the release role's exact-object policy.
+diff --git a/infra/tofu/iam.tf b/infra/tofu/iam.tf
+index ea30827..f072294 100644
+--- a/infra/tofu/iam.tf
++++ b/infra/tofu/iam.tf
+@@ -9,8 +9,242 @@ resource "aws_iam_openid_connect_provider" "github" {
+ }
+ 
+ # -----------------------------------------------------------------------------
+-# CI Role (GitHub Actions → AWS via OIDC)
+-# Permissions: S3 deploy + CloudFront invalidation only
++# F-005 (C5): least-privilege deploy trust.
++#
++# The legacy single `ci` role (below) trusted 4 refs and had whole-bucket write, shared by every
++# pipeline. It is REPLACED by three per-pipeline roles, each trusting ONLY its own workflow (by the
++# GitHub OIDC `workflow` NAME claim) running on `main`, and scoped to only its S3 prefix. Only the
++# release pipeline may write the F-004-critical `landing/releases/latest.json`.
++#
++# `workflow` NAME claim (not `job_workflow_ref`): the two design audits disagreed on whether
++# `job_workflow_ref` is emitted for these TOP-LEVEL jobs; `workflow` is AWS-supported and present for
++# all jobs. A rename-to-impersonate attack requires merging to `main` — a subset of the already-accepted
++# "malicious code on main" residual. See implementations-plan/security-hardening/clusters/C5-CONSOLIDATED.md (D1).
++#
++# Cutover is human-applied and staged (see the C5 runbook): apply roles (legacy retained, trust-narrowed)
++# -> set the 3 secrets -> land the workflow cutover on main -> smoke -> delete the legacy role (separate PR).
++# -----------------------------------------------------------------------------
++
++locals {
++  # Only `main` is trusted (F-005: nightlies + chore/aztec-* refs dropped). Solo public repo.
++  github_sub_main = "repo:alejoamiras/aztec-accelerator:ref:refs/heads/main"
++}
++
++# Assume-role trust for each per-pipeline role: exact aud + exact main sub + exact workflow NAME.
++data "aws_iam_policy_document" "assume_landing" {
++  statement {
++    effect  = "Allow"
++    actions = ["sts:AssumeRoleWithWebIdentity"]
++    principals {
++      type        = "Federated"
++      identifiers = [aws_iam_openid_connect_provider.github.arn]
++    }
++    condition {
++      test     = "StringEquals"
++      variable = "token.actions.githubusercontent.com:aud"
++      values   = ["sts.amazonaws.com"]
++    }
++    condition {
++      test     = "StringEquals"
++      variable = "token.actions.githubusercontent.com:sub"
++      values   = [local.github_sub_main]
++    }
++    condition {
++      test     = "StringEquals"
++      variable = "token.actions.githubusercontent.com:workflow"
++      values   = ["Deploy Landing Page"]
++    }
++  }
++}
++
++data "aws_iam_policy_document" "assume_release" {
++  statement {
++    effect  = "Allow"
++    actions = ["sts:AssumeRoleWithWebIdentity"]
++    principals {
++      type        = "Federated"
++      identifiers = [aws_iam_openid_connect_provider.github.arn]
++    }
++    condition {
++      test     = "StringEquals"
++      variable = "token.actions.githubusercontent.com:aud"
++      values   = ["sts.amazonaws.com"]
++    }
++    condition {
++      test     = "StringEquals"
++      variable = "token.actions.githubusercontent.com:sub"
++      values   = [local.github_sub_main]
++    }
++    condition {
++      test     = "StringEquals"
++      variable = "token.actions.githubusercontent.com:workflow"
++      values   = ["Release Accelerator"]
++    }
++  }
++}
++
++data "aws_iam_policy_document" "assume_playground" {
++  statement {
++    effect  = "Allow"
++    actions = ["sts:AssumeRoleWithWebIdentity"]
++    principals {
++      type        = "Federated"
++      identifiers = [aws_iam_openid_connect_provider.github.arn]
++    }
++    condition {
++      test     = "StringEquals"
++      variable = "token.actions.githubusercontent.com:aud"
++      values   = ["sts.amazonaws.com"]
++    }
++    condition {
++      test     = "StringEquals"
++      variable = "token.actions.githubusercontent.com:sub"
++      values   = [local.github_sub_main]
++    }
++    condition {
++      test     = "StringEquals"
++      variable = "token.actions.githubusercontent.com:workflow"
++      values   = ["Publish Testnet"]
++    }
++  }
++}
++
++# ── Landing role: writes landing/* but is explicitly DENIED the release-feed prefix ──
++resource "aws_iam_role" "landing_deploy" {
++  name               = "aztec-accelerator-ci-landing"
++  assume_role_policy = data.aws_iam_policy_document.assume_landing.json
++}
++
++resource "aws_iam_role_policy" "landing_deploy" {
++  name = "aztec-accelerator-ci-landing-policy"
++  role = aws_iam_role.landing_deploy.id
++
++  policy = jsonencode({
++    Version = "2012-10-17"
++    Statement = [
++      {
++        Sid      = "LandingWrite"
++        Effect   = "Allow"
++        Action   = ["s3:PutObject", "s3:DeleteObject", "s3:AbortMultipartUpload"]
++        Resource = "${aws_s3_bucket.site.arn}/landing/*"
++      },
++      {
++        # SECURITY BOUNDARY (F-005/F-004): the landing pipeline must never write/delete the update feed.
++        # Explicit Deny beats the landing/* Allow and any future Allow. The workflow's `sync --delete`
++        # must `--exclude "releases"`/`"releases/*"` or the deploy fails on this Deny (the fail-loud property).
++        Sid    = "DenyReleaseFeed"
++        Effect = "Deny"
++        Action = ["s3:PutObject", "s3:DeleteObject", "s3:AbortMultipartUpload"]
++        Resource = [
++          "${aws_s3_bucket.site.arn}/landing/releases",
++          "${aws_s3_bucket.site.arn}/landing/releases/*",
++        ]
++      },
++      {
++        Sid       = "LandingList"
++        Effect    = "Allow"
++        Action    = "s3:ListBucket"
++        Resource  = aws_s3_bucket.site.arn
++        Condition = { StringLike = { "s3:prefix" = ["landing/*"] } }
++      },
++      {
++        Sid      = "BucketLocation"
++        Effect   = "Allow"
++        Action   = "s3:GetBucketLocation"
++        Resource = aws_s3_bucket.site.arn
++      },
++      {
++        Sid      = "Invalidate"
++        Effect   = "Allow"
++        Action   = "cloudfront:CreateInvalidation"
++        Resource = aws_cloudfront_distribution.site.arn
++      },
++    ]
++  })
++}
++
++# ── Release-feed role: may ONLY put the exact latest.json object (no List, no Delete) ──
++resource "aws_iam_role" "release_feed" {
++  name               = "aztec-accelerator-ci-release-feed"
++  assume_role_policy = data.aws_iam_policy_document.assume_release.json
++}
++
++resource "aws_iam_role_policy" "release_feed" {
++  name = "aztec-accelerator-ci-release-feed-policy"
++  role = aws_iam_role.release_feed.id
++
++  policy = jsonencode({
++    Version = "2012-10-17"
++    Statement = [
++      {
++        Sid      = "PutFeed"
++        Effect   = "Allow"
++        Action   = ["s3:PutObject", "s3:AbortMultipartUpload"]
++        Resource = "${aws_s3_bucket.site.arn}/landing/releases/latest.json"
++      },
++      {
++        Sid      = "BucketLocation"
++        Effect   = "Allow"
++        Action   = "s3:GetBucketLocation"
++        Resource = aws_s3_bucket.site.arn
++      },
++      {
++        Sid      = "Invalidate"
++        Effect   = "Allow"
++        Action   = "cloudfront:CreateInvalidation"
++        Resource = aws_cloudfront_distribution.site.arn
++      },
++    ]
++  })
++}
++
++# ── Playground (testnet) role: writes playground/* only ──
++resource "aws_iam_role" "playground_testnet" {
++  name               = "aztec-accelerator-ci-playground-testnet"
++  assume_role_policy = data.aws_iam_policy_document.assume_playground.json
++}
++
++resource "aws_iam_role_policy" "playground_testnet" {
++  name = "aztec-accelerator-ci-playground-testnet-policy"
++  role = aws_iam_role.playground_testnet.id
++
++  policy = jsonencode({
++    Version = "2012-10-17"
++    Statement = [
++      {
++        Sid      = "PlaygroundWrite"
++        Effect   = "Allow"
++        Action   = ["s3:PutObject", "s3:DeleteObject", "s3:AbortMultipartUpload"]
++        Resource = "${aws_s3_bucket.site.arn}/playground/*"
++      },
++      {
++        Sid       = "PlaygroundList"
++        Effect    = "Allow"
++        Action    = "s3:ListBucket"
++        Resource  = aws_s3_bucket.site.arn
++        Condition = { StringLike = { "s3:prefix" = ["playground/*"] } }
++      },
++      {
++        Sid      = "BucketLocation"
++        Effect   = "Allow"
++        Action   = "s3:GetBucketLocation"
++        Resource = aws_s3_bucket.site.arn
++      },
++      {
++        Sid      = "Invalidate"
++        Effect   = "Allow"
++        Action   = "cloudfront:CreateInvalidation"
++        Resource = aws_cloudfront_distribution.site.arn
++      },
++    ]
++  })
++}
++
++# -----------------------------------------------------------------------------
++# LEGACY CI Role — F-005: trust NARROWED to `main` only (nightlies + chore/aztec-* dropped). Broad policy
++# retained TEMPORARILY so live workflows keep deploying until the PR-2 workflow cutover lands on main;
++# this role + policy are removed in the SEPARATE Phase-3 PR after the new roles are smoked. Do NOT add
++# refs back here.
+ # -----------------------------------------------------------------------------
+ 
+ resource "aws_iam_role" "ci" {
+@@ -28,14 +262,7 @@ resource "aws_iam_role" "ci" {
+         Condition = {
+           StringEquals = {
+             "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+-          }
+-          StringLike = {
+-            "token.actions.githubusercontent.com:sub" = [
+-              "repo:alejoamiras/aztec-accelerator:ref:refs/heads/main",
+-              "repo:alejoamiras/aztec-accelerator:ref:refs/heads/nightlies",
+-              "repo:alejoamiras/aztec-accelerator:ref:refs/heads/chore/aztec-nightlies-*",
+-              "repo:alejoamiras/aztec-accelerator:ref:refs/heads/chore/aztec-stable-*",
+-            ]
++            "token.actions.githubusercontent.com:sub" = local.github_sub_main
+           }
+         }
+       }
+diff --git a/infra/tofu/outputs.tf b/infra/tofu/outputs.tf
+index 27e109d..775b48e 100644
+--- a/infra/tofu/outputs.tf
++++ b/infra/tofu/outputs.tf
+@@ -10,6 +10,21 @@ output "cloudfront_domain_name" {
+   value = aws_cloudfront_distribution.site.domain_name
+ }
+ 
++# Legacy shared role — removed in the F-005 Phase-3 PR after the per-pipeline roles are cut over.
+ output "ci_role_arn" {
+   value = aws_iam_role.ci.arn
+ }
++
++# F-005 per-pipeline deploy roles. The human wires each into its own GitHub Actions secret:
++# landing -> AWS_ROLE_ARN_LANDING, release -> AWS_ROLE_ARN_RELEASE, playground -> AWS_ROLE_ARN_PLAYGROUND.
++output "landing_deploy_role_arn" {
++  value = aws_iam_role.landing_deploy.arn
++}
++
++output "release_feed_role_arn" {
++  value = aws_iam_role.release_feed.arn
++}
++
++output "playground_testnet_role_arn" {
++  value = aws_iam_role.playground_testnet.arn
++}
+diff --git a/infra/tofu/s3.tf b/infra/tofu/s3.tf
+index 6580dd6..ea82012 100644
+--- a/infra/tofu/s3.tf
++++ b/infra/tofu/s3.tf
+@@ -14,6 +14,33 @@ resource "aws_s3_bucket_public_access_block" "site" {
+   restrict_public_buckets = true
+ }
+ 
++# F-005 (Codex C6): a compromised deploy token can start multipart uploads and leave incomplete parts,
++# which stay billable after the OIDC session expires. Abort incomplete multipart uploads after 1 day.
++resource "aws_s3_bucket_lifecycle_configuration" "site" {
++  bucket = aws_s3_bucket.site.id
++
++  rule {
++    id     = "abort-incomplete-multipart-uploads"
++    status = "Enabled"
++
++    filter {} # whole bucket
++
++    abort_incomplete_multipart_upload {
++      days_after_initiation = 1
++    }
++  }
++}
++
++# F-005 (Ask A8): versioning so an accidental/compromised site overwrite is recoverable WITHOUT granting
++# CI any DeleteObjectVersion. CI roles have no version permissions; recovery is an owner/admin action.
++resource "aws_s3_bucket_versioning" "site" {
++  bucket = aws_s3_bucket.site.id
++
++  versioning_configuration {
++    status = "Enabled"
++  }
++}
++
+ # Allow CloudFront OAC to read from the bucket
+ resource "aws_s3_bucket_policy" "site" {
+   bucket = aws_s3_bucket.site.id

--- a/implementations-plan/security-hardening/quality-audit-2026-07-24/release-ci-owner-runbook.md
+++ b/implementations-plan/security-hardening/quality-audit-2026-07-24/release-ci-owner-runbook.md
@@ -33,3 +33,59 @@ exfiltrate those secrets.
 3. Cross-refs the CONVERGED-SCOPE NEEDS-THE-OWNER items: **legacy-role retirement + protected
    environments** (C5 runbook) and **legacy-CA bounded rotation** — same "runbook is not mitigation
    until applied" caveat.
+
+---
+
+# Full-branch audit (2026-07-24) — owner-applied supply-chain items
+
+The whole-branch codex audit (`full-audit-2026-07-24/FINDINGS.md`) surfaced four items that are
+owner-applied (CI secret hygiene + infra), beyond the two code fixes already landed (F2, G2) and the
+in-code hardening (A1, B1/B2, H3). Ordered by priority.
+
+## F1 / G1 — production signing key exposed to smoke-test code (High/Critical)
+**Files:** `_e2e-updater{,-linux,-windows}.yml`, `release-accelerator.yml` (sign job),
+`packages/accelerator/scripts/sign-smoke-feed.sh`, `updater-smoke-windows.ps1`.
+**Issue:** the updater smoke jobs export `TAURI_SIGNING_PRIVATE_KEY` (+ password) into the environment
+and then (a) run repo-controlled scripts / `bunx tauri`, and (b) install + LAUNCH the N-1 release
+artifact. Child processes inherit the secret env; a compromised N-1 asset or CLI dependency could read
+and exfiltrate the production signing key — which defeats updater authenticity for every installed
+client.
+**Fix (owner):**
+1. Generate an EPHEMERAL smoke keypair per run; build/patch the N-1 fixture with its PUBLIC key, and
+   sign the smoke feed with the ephemeral PRIVATE key. The production key never enters a smoke job.
+2. Keep the production key ONLY in an isolated, protected release-signing job (or an HSM/OIDC signer)
+   that does NOT check out branch code, build, or run `bunx` fallback resolution — invoke a frozen,
+   digest-pinned signer binary. Pass the signed manifest downstream as an artifact.
+3. Never launch an application with signing secrets in its environment.
+This pairs with the **protected `release` environment** (item #1 above) — do them together.
+
+## H2 — legacy IAM role defeats the new per-pipeline isolation (High)
+**File:** `infra/tofu/iam.tf` (legacy role, ~lines 249-275).
+**Issue:** the retained legacy role trusts every workflow on `main` and keeps whole-bucket write. A
+compromised action in the OIDC-enabled landing-deploy job can assume it and overwrite
+`landing/releases/latest.json` — suppressing security updates or corrupting the feed. The new
+landing-role's release-feed deny does NOT apply to the legacy role.
+**Fix (owner):** cut over and DELETE the legacy role atomically; or, as an interim, restrict it to the
+landing prefix with the SAME explicit release-feed deny the new roles carry. Do not merge to `main`
+with the broad legacy role still active. (This is the CONVERGED-SCOPE legacy-role-retirement item.)
+
+## H4 — IAM OIDC condition may be unassumable after cutover (release-blocking correctness)
+**File:** `infra/tofu/iam.tf` (three new roles condition on both `token.actions.githubusercontent.com:sub`
+AND `:workflow`).
+**Issue:** codex asserts AWS will not evaluate the GitHub `workflow` OIDC claim as a condition key, so
+after cutover the `StringEquals` on `:workflow` never matches and the roles become **unassumable**
+(release pipeline breaks). `:sub` is the load-bearing, AWS-canonical claim regardless. My confidence is
+only moderate that codex is right (AWS *does* support custom claims present in the token, and `workflow`
+IS in GitHub's token) — but this must be **verified at the human-gated cutover** before relying on it.
+**Fix (owner):** the robust, AWS-canonical pattern is to scope on `:sub` via **GitHub Environments**
+(which appear in `sub` as `repo:OWNER/REPO:environment:<env>`) and DROP the fragile `:workflow` condition
+— which also delivers the per-pipeline isolation item #1 wants. This ties H4 + F1/G1 + item #1 into one
+"create protected environments, scope roles on `sub`" change. Verify assumability with a dispatch-time
+dry-run before removing the legacy role.
+
+## Note on H1 (branch protection 0-approvals) and the updater buffer (D1/D2)
+- **H1** (`infra/rulesets/main-branch-protection.json` `required_approving_review_count: 0`) is the
+  solo-dev risk-accept decision recorded above — revisit when a second maintainer joins.
+- **D1/D2** (updater unbounded feed/artifact buffer) remain the accepted availability-only residual
+  #345/M6; the fix (bounded streaming inside the plugin) needs an upstream/pinned-fork change and was
+  rejected in a prior round as making hand-written verification the sole authenticity control.

--- a/infra/tofu/s3.tf
+++ b/infra/tofu/s3.tf
@@ -31,11 +31,17 @@ resource "aws_s3_bucket_lifecycle_configuration" "site" {
   }
 
   # H3 (full-branch audit): versioning (below) keeps every prior copy on overwrite/delete, and CI has no
-  # DeleteObjectVersion — so a compromised deploy token that repeatedly uploads+deletes large objects
-  # would accumulate NONCURRENT versions that stay billable INDEFINITELY (storage-cost exhaustion). Expire
-  # noncurrent versions after a bounded recovery window, and cap how many are retained per object, so the
-  # anti-tamper recovery guarantee is preserved without unbounded cost. Current (live) versions are never
-  # touched by this rule.
+  # DeleteObjectVersion — so without expiry, noncurrent versions stay billable indefinitely.
+  #
+  # NOTE on S3 semantics (re-audit correction): `noncurrent_days` and `newer_noncurrent_versions` are
+  # AND-combined — a version is expired only once it is BOTH older than `noncurrent_days` AND beyond the
+  # newest N. So this rule bounds the STEADY STATE (after the window, at most ~10 noncurrent per object)
+  # and caps the transient to a 7-day window, but it does NOT strictly bound cost against an adversary
+  # churning many overwrites WITHIN 7 days. That is inherent: a strict count-only cap would instead let
+  # churn EVICT the good recovery version, defeating the anti-tamper intent — the two goals conflict under
+  # a compromised deploy token. The real fix for adversarial churn is CI LEAST-PRIVILEGE (object-count /
+  # rate limits, or S3 Object Lock), tracked in the owner runbook; S3 versioning here is a
+  # redeploy-from-source *convenience*, not the primary recovery. Current (live) versions are untouched.
   rule {
     id     = "expire-noncurrent-versions"
     status = "Enabled"
@@ -43,8 +49,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "site" {
     filter {} # whole bucket
 
     noncurrent_version_expiration {
-      noncurrent_days           = 30 # 30-day recovery window for an accidental/compromised overwrite
-      newer_noncurrent_versions = 10 # cap retained noncurrent copies per object (bounds churn abuse)
+      noncurrent_days           = 7  # recovery window; also caps the unbounded-churn transient to 7 days
+      newer_noncurrent_versions = 10 # steady-state cap: keep ~10 recent noncurrent copies per object
     }
   }
 }

--- a/infra/tofu/s3.tf
+++ b/infra/tofu/s3.tf
@@ -29,6 +29,24 @@ resource "aws_s3_bucket_lifecycle_configuration" "site" {
       days_after_initiation = 1
     }
   }
+
+  # H3 (full-branch audit): versioning (below) keeps every prior copy on overwrite/delete, and CI has no
+  # DeleteObjectVersion — so a compromised deploy token that repeatedly uploads+deletes large objects
+  # would accumulate NONCURRENT versions that stay billable INDEFINITELY (storage-cost exhaustion). Expire
+  # noncurrent versions after a bounded recovery window, and cap how many are retained per object, so the
+  # anti-tamper recovery guarantee is preserved without unbounded cost. Current (live) versions are never
+  # touched by this rule.
+  rule {
+    id     = "expire-noncurrent-versions"
+    status = "Enabled"
+
+    filter {} # whole bucket
+
+    noncurrent_version_expiration {
+      noncurrent_days           = 30 # 30-day recovery window for an accidental/compromised overwrite
+      newer_noncurrent_versions = 10 # cap retained noncurrent copies per object (bounds churn abuse)
+    }
+  }
 }
 
 # F-005 (Ask A8): versioning so an accidental/compromised site overwrite is recoverable WITHOUT granting

--- a/packages/accelerator/core/Cargo.lock
+++ b/packages/accelerator/core/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "axum",
  "base64",
  "dirs",
+ "filetime",
  "flate2",
  "futures-util",
  "hex",

--- a/packages/accelerator/core/Cargo.toml
+++ b/packages/accelerator/core/Cargo.toml
@@ -59,3 +59,4 @@ tower = { version = "0.5", features = ["util"] }
 tokio = { version = "1", features = ["test-util"] }
 serial_test = "3"
 futures-util = "0.3" # stalled/error body streams for the F-009 /prove read-timeout tests
+filetime = "0.2"     # backdate cache-dir mtimes in the B1/B2 age-gate reap/eviction tests

--- a/packages/accelerator/core/src/server/prove.rs
+++ b/packages/accelerator/core/src/server/prove.rs
@@ -1,9 +1,9 @@
 //! `/prove` request handler + version/thread resolution.
 //!
-//! The core proving path: authorize the origin, buffer the body under a 50MB cap, serialize
-//! behind the prove semaphore (bb already uses all cores), resolve+download the requested bb
-//! version, then run the proof and return base64 + an `x-prove-duration-ms` header. Extracted
-//! from server.rs (Q2).
+//! The core proving path: authorize the origin, buffer the body under a 50MB cap (bounded by the
+//! inflight-waiters gate, NOT the prove permit — A1), resolve+download the requested bb version, then
+//! acquire the single prove permit and run the proof (bb already uses all cores), returning base64 +
+//! an `x-prove-duration-ms` header. Extracted from server.rs (Q2).
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -131,10 +131,10 @@ pub(crate) fn compute_threads(state: &AppState) -> Option<usize> {
 
 const MAX_BODY_SIZE: usize = 50 * 1024 * 1024; // 50MB
 
-/// F-009: absolute deadline for buffering the request body while holding the single prove
-/// permit. Bounds a slowloris/stalled uploader before the permit is released. 30s is generous
-/// for 50MB over loopback (~1.7 MiB/s); it is a whole-body deadline, not an idle timeout, so
-/// drip-feeding cannot extend it.
+/// F-009: absolute deadline for buffering the request body. Bounds a slowloris/stalled uploader —
+/// after A1 the body is read WITHOUT the prove permit, so this deadline caps how long a slow upload
+/// occupies an inflight slot (not the prover). 30s is generous for 50MB over loopback (~1.7 MiB/s);
+/// it is a whole-body deadline, not an idle timeout, so drip-feeding cannot extend it.
 const BODY_READ_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Reject an honestly-declared oversize body BEFORE acquiring the prove permit, so a client
@@ -185,22 +185,18 @@ fn reject_declared_oversize(headers: &axum::http::HeaderMap) -> Result<(), Prove
     Ok(())
 }
 
-/// F-009: acquire the single prove permit, THEN buffer the body (under the size cap + an
-/// absolute read timeout). Returns the owned permit alongside the bytes so the caller holds it
-/// for the whole prove; the permit is released by RAII on every exit path (timeout, size error,
-/// disconnect, cancellation, panic, success). Testable seam.
-async fn acquire_and_read_body(
-    semaphore: Arc<Semaphore>,
+/// A1 (full-branch audit): buffer the request body under the size cap + an absolute read timeout,
+/// WITHOUT holding the single prove permit. Concurrent buffers are already bounded by the `_inflight`
+/// waiters cap (`MAX_INFLIGHT_PROVE`) the caller holds, so at most `MAX_INFLIGHT_PROVE × MAX_BODY_SIZE`
+/// is resident. Decoupling the read from the prove permit is the fix for the head-of-line DoS where one
+/// slow (slowloris) uploader held the CPU-bound prover for up to `read_timeout`, 429-ing everyone else;
+/// now a slow upload only occupies an inflight slot while the prover runs on ready requests. Testable seam.
+async fn read_body(
     raw_body: Body,
     max_body_size: usize,
     read_timeout: Duration,
-) -> Result<(OwnedSemaphorePermit, Bytes), ProveError> {
-    let permit = semaphore
-        .acquire_owned()
-        .await
-        .map_err(|_| ProveError::ServiceUnavailable)?;
-
-    let body = tokio::time::timeout(read_timeout, axum::body::to_bytes(raw_body, max_body_size))
+) -> Result<Bytes, ProveError> {
+    tokio::time::timeout(read_timeout, axum::body::to_bytes(raw_body, max_body_size))
         .await
         .map_err(|_| {
             tracing::warn!(
@@ -212,9 +208,7 @@ async fn acquire_and_read_body(
         .map_err(|e| {
             tracing::warn!("Failed to read request body: {e}");
             ProveError::PayloadTooLarge(e.to_string())
-        })?;
-
-    Ok((permit, body))
+        })
 }
 
 /// F-009: try to enter the bounded set of in-flight + waiting authorized `/prove` requests.
@@ -246,17 +240,10 @@ pub(crate) async fn prove(
     // F-009: turn away an honestly-declared oversize body before taking the prove permit.
     reject_declared_oversize(&parts.headers)?;
 
-    // F-009: acquire the single prove permit BEFORE buffering the body, so concurrent requests
-    // can't each pin a 50MB buffer ahead of the concurrency gate (memory DoS), and read the body
-    // under an absolute timeout so a stalled uploader can't hold the only permit indefinitely.
-    // `_permit` is held for the whole prove and released by RAII on every exit path.
-    let (_permit, body) = acquire_and_read_body(
-        state.prove_semaphore.clone(),
-        raw_body,
-        MAX_BODY_SIZE,
-        BODY_READ_TIMEOUT,
-    )
-    .await?;
+    // A1: buffer the body under ONLY the inflight cap (memory bounded to MAX_INFLIGHT_PROVE × 50MB),
+    // NOT the single prove permit — so a slow uploader occupies just an inflight slot for ≤30s and can't
+    // block the prover. The prove permit is acquired later, only around the CPU-bound proof itself.
+    let body = read_body(raw_body, MAX_BODY_SIZE, BODY_READ_TIMEOUT).await?;
     tracing::debug!(payload_bytes = body.len(), "Prove request payload size");
 
     let requested_version = parts
@@ -326,6 +313,17 @@ pub(crate) async fn prove(
         }
     }
     let threads = compute_threads(&state);
+
+    // A1: acquire the single prove permit ONLY now — around the CPU-bound proof — not across the body
+    // read + version download above (which ran concurrently under the inflight cap). bb saturates all
+    // cores, so proofs still run strictly one at a time; only the serialized *proving* is gated, not I/O.
+    // Held (RAII) until this function returns.
+    let _permit = state
+        .prove_semaphore
+        .clone()
+        .acquire_owned()
+        .await
+        .map_err(|_| ProveError::ServiceUnavailable)?;
 
     let start = std::time::Instant::now();
     let result = bb::prove(&body, version_for_prove.as_ref(), threads).await;
@@ -420,74 +418,54 @@ mod tests {
         assert!(try_enter(waiters.clone()).is_ok(), "slot freed on drop");
     }
 
-    #[tokio::test(start_paused = true)]
-    async fn body_not_read_until_permit_available() {
-        // F-009 ordering: with zero prove permits, even a READY body must not be returned — the
-        // permit gates the read (proves permit-before-body, not merely that the guard is live).
-        let sem = Arc::new(Semaphore::new(0));
-        let fut = acquire_and_read_body(
-            sem,
-            Body::from(Bytes::from_static(b"ready")),
-            1024,
-            Duration::from_secs(30),
-        );
-        tokio::pin!(fut);
-        assert!(
-            tokio::time::timeout(Duration::from_secs(60), &mut fut)
-                .await
-                .is_err(),
-            "acquire_and_read_body must not resolve without a prove permit"
-        );
-    }
-
     #[tokio::test]
-    async fn permit_acquired_before_body_and_released_on_drop() {
-        let sem = Arc::new(Semaphore::new(1));
-        let (permit, body) = acquire_and_read_body(
-            sem.clone(),
-            Body::from(Bytes::from_static(b"hello")),
+    async fn body_read_does_not_hold_the_prove_permit() {
+        // A1: reading the body must NOT depend on or hold the single prove permit — a slow uploader
+        // therefore can't block the prover. With zero prove permits available, a READY body still reads.
+        let sem = Arc::new(Semaphore::new(0)); // no prove permits at all
+        let body = read_body(
+            Body::from(Bytes::from_static(b"ready")),
             1024,
             Duration::from_secs(30),
         )
         .await
-        .expect("happy path");
-        assert_eq!(&body[..], &b"hello"[..]);
+        .expect("body reads without any prove permit");
+        assert_eq!(&body[..], &b"ready"[..]);
         assert_eq!(
             sem.available_permits(),
             0,
-            "permit held across the whole prove"
+            "read_body never touches the prove semaphore"
         );
+    }
+
+    #[tokio::test]
+    async fn prove_permit_is_held_only_around_proving_and_released_on_drop() {
+        // A1: the permit is acquired separately (in prove(), around bb::prove) and released by RAII.
+        let sem = Arc::new(Semaphore::new(1));
+        let permit = sem.clone().acquire_owned().await.expect("permit");
+        assert_eq!(sem.available_permits(), 0, "permit held during proving");
         drop(permit);
         assert_eq!(sem.available_permits(), 1, "permit released on drop");
     }
 
     #[tokio::test]
-    async fn oversized_body_errs_and_releases_permit() {
-        let sem = Arc::new(Semaphore::new(1));
-        let res = acquire_and_read_body(
-            sem.clone(),
+    async fn oversized_body_errs() {
+        let res = read_body(
             Body::from(vec![0u8; 10]),
             4, // tiny cap to force the length error deterministically
             Duration::from_secs(30),
         )
         .await;
         assert!(matches!(res, Err(ProveError::PayloadTooLarge(_))));
-        assert_eq!(
-            sem.available_permits(),
-            1,
-            "permit released after size error"
-        );
     }
 
     #[tokio::test(start_paused = true)]
-    async fn stalled_body_times_out_and_releases_permit() {
-        let sem = Arc::new(Semaphore::new(1));
+    async fn stalled_body_times_out() {
         // A body whose stream never yields → to_bytes never completes → the read timeout fires.
         // Under start_paused the virtual clock auto-advances to the only pending timer.
         let body =
             Body::from_stream(futures_util::stream::pending::<Result<Bytes, std::io::Error>>());
-        let res = acquire_and_read_body(sem.clone(), body, 1024, Duration::from_secs(30)).await;
+        let res = read_body(body, 1024, Duration::from_secs(30)).await;
         assert!(matches!(res, Err(ProveError::BodyReadTimeout)));
-        assert_eq!(sem.available_permits(), 1, "permit released after timeout");
     }
 }

--- a/packages/accelerator/core/src/server/prove.rs
+++ b/packages/accelerator/core/src/server/prove.rs
@@ -438,15 +438,9 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn prove_permit_is_held_only_around_proving_and_released_on_drop() {
-        // A1: the permit is acquired separately (in prove(), around bb::prove) and released by RAII.
-        let sem = Arc::new(Semaphore::new(1));
-        let permit = sem.clone().acquire_owned().await.expect("permit");
-        assert_eq!(sem.available_permits(), 0, "permit held during proving");
-        drop(permit);
-        assert_eq!(sem.available_permits(), 1, "permit released on drop");
-    }
+    // (A1: the "permit only around proving" placement in prove() is exercised end-to-end by the
+    // prove-handler integration tests, not a unit test — a standalone semaphore-RAII assertion would only
+    // test tokio, not this code, so it was removed per the re-audit.)
 
     #[tokio::test]
     async fn oversized_body_errs() {

--- a/packages/accelerator/core/src/versions/downloader.rs
+++ b/packages/accelerator/core/src/versions/downloader.rs
@@ -15,6 +15,7 @@ use super::version_policy::AztecVersion;
 use std::error::Error;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 pub async fn download_bb(version: &AztecVersion) -> Result<PathBuf, Box<dyn Error + Send + Sync>> {
     // The `&AztecVersion` parameter IS the #99 traversal guard: a value of this type can only have
@@ -197,8 +198,33 @@ fn unique_staging_dir(version_dir: &Path) -> Result<PathBuf, Box<dyn Error + Sen
     Ok(version_dir.with_file_name(format!(".{name}.tmp.{}-{nanos}-{seq}", std::process::id())))
 }
 
+/// B1/B2 (full-branch audit): a cache dir is only "stale" (crash-orphaned / safe to delete) if it has
+/// not been touched within this window. A legitimate concurrent download stages + publishes in seconds;
+/// a freshly-downloaded in-use version has a recent mtime. Anything modified within this window is
+/// presumed ACTIVE (another request's in-progress stage, or a just-downloaded version about to be
+/// proved) and is left alone, so concurrent requests can't reap/evict each other's live data. 5 minutes
+/// is far longer than any legitimate download+extract yet far shorter than a crash-orphan's age.
+const CACHE_ENTRY_ACTIVE_WINDOW: Duration = Duration::from_secs(5 * 60);
+
+/// True if `path` was modified within [`CACHE_ENTRY_ACTIVE_WINDOW`] (⇒ presumed active, do not delete).
+/// Fails SAFE: an unreadable/ambiguous mtime is treated as recent (keep it) rather than reaped.
+pub(crate) fn recently_active(path: &Path) -> bool {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return true; // can't stat → don't delete
+    };
+    let Ok(modified) = meta.modified() else {
+        return true;
+    };
+    match modified.elapsed() {
+        Ok(age) => age < CACHE_ENTRY_ACTIVE_WINDOW,
+        Err(_) => true, // mtime in the future (clock skew) → treat as active
+    }
+}
+
 /// Remove crash-stale staging siblings for this version (`.{name}.tmp.*`) before a fresh install, so a
-/// crashed prior run can't accumulate hidden cache data. Best-effort: errors are ignored.
+/// crashed prior run can't accumulate hidden cache data. B1: only reap stages OLDER than the active
+/// window — otherwise a concurrent same-version download's in-progress stage would be deleted out from
+/// under it. Best-effort: errors are ignored.
 fn reap_stale_stages(version_dir: &Path) {
     let (Some(parent), Some(name)) = (
         version_dir.parent(),
@@ -213,6 +239,7 @@ fn reap_stale_stages(version_dir: &Path) {
                 .file_name()
                 .to_str()
                 .is_some_and(|n| n.starts_with(&prefix))
+                && !recently_active(&entry.path())
             {
                 let _ = std::fs::remove_dir_all(entry.path());
             }
@@ -471,6 +498,33 @@ mod tests {
         assert!(contents.contains("echo hello"));
     }
 
+    /// B1 (full-branch audit): `reap_stale_stages` must NOT delete a FRESH (recently-active) staging
+    /// sibling — that would be a concurrent same-version download's in-progress stage. Only an OLD
+    /// (crash-orphaned) stage is reaped.
+    #[test]
+    fn reap_stale_stages_spares_recently_active_stages() {
+        let base = tempfile::tempdir().unwrap();
+        let version_dir = base.path().join("5.0.0-rc.2");
+        // A fresh stage (just created ⇒ recent mtime) — simulates a concurrent download's live stage.
+        let fresh = base.path().join(".5.0.0-rc.2.tmp.freshABC");
+        std::fs::create_dir_all(&fresh).unwrap();
+        std::fs::write(fresh.join("bb"), b"in-progress").unwrap();
+        // An OLD stage — backdate its mtime well past the active window.
+        let old = base.path().join(".5.0.0-rc.2.tmp.oldXYZ");
+        std::fs::create_dir_all(&old).unwrap();
+        let long_ago =
+            std::time::SystemTime::now() - (CACHE_ENTRY_ACTIVE_WINDOW + Duration::from_secs(60));
+        filetime::set_file_mtime(&old, filetime::FileTime::from_system_time(long_ago)).unwrap();
+
+        reap_stale_stages(&version_dir);
+
+        assert!(
+            fresh.exists(),
+            "a recently-active stage must be spared (B1)"
+        );
+        assert!(!old.exists(), "a crash-stale (old) stage is still reaped");
+    }
+
     /// F-007 staged verified install: `install_version_dir` extracts + finalizes + writes the marker in
     /// a unique staging dir, then publishes fail-closed — replacing any stale entry wholesale, leaving
     /// no staging dir, and producing a marker whose `binary_sha256` matches the FINAL published binary.
@@ -498,10 +552,15 @@ mod tests {
         let base = tempfile::tempdir().unwrap();
         let version_dir = base.path().join("5.0.0-test");
 
-        // A crash-stale staging sibling from a prior run must be reaped by the next install.
+        // A crash-stale staging sibling from a prior run must be reaped by the next install. B1: it must
+        // be genuinely OLD (backdated past the active window) — a FRESH sibling is a concurrent download
+        // and is deliberately spared (covered by reap_stale_stages_spares_recently_active_stages).
         let stale = base.path().join(".5.0.0-test.tmp.999-0-0");
         std::fs::create_dir_all(&stale).unwrap();
         std::fs::write(stale.join("junk"), b"stale").unwrap();
+        let long_ago =
+            std::time::SystemTime::now() - (CACHE_ENTRY_ACTIVE_WINDOW + Duration::from_secs(60));
+        filetime::set_file_mtime(&stale, filetime::FileTime::from_system_time(long_ago)).unwrap();
 
         // Fresh install → bb + marker present, marker binds the published binary bytes (post-finalize).
         install_version_dir(&version_dir, &tarball, "5.0.0-test", &archive_digest).unwrap();

--- a/packages/accelerator/core/src/versions/downloader.rs
+++ b/packages/accelerator/core/src/versions/downloader.rs
@@ -199,11 +199,19 @@ fn unique_staging_dir(version_dir: &Path) -> Result<PathBuf, Box<dyn Error + Sen
 }
 
 /// B1/B2 (full-branch audit): a cache dir is only "stale" (crash-orphaned / safe to delete) if it has
-/// not been touched within this window. A legitimate concurrent download stages + publishes in seconds;
-/// a freshly-downloaded in-use version has a recent mtime. Anything modified within this window is
-/// presumed ACTIVE (another request's in-progress stage, or a just-downloaded version about to be
-/// proved) and is left alone, so concurrent requests can't reap/evict each other's live data. 5 minutes
-/// is far longer than any legitimate download+extract yet far shorter than a crash-orphan's age.
+/// not been touched within this window. A legitimate concurrent download stages + publishes in seconds
+/// (the network download runs BEFORE staging and is capped at 64 MB; the staging step is just a
+/// tarball extract of one flat `bb` binary, whose write bumps the staging dir's own mtime), and a
+/// freshly-downloaded in-use version has a recent mtime. Anything modified within this window is presumed
+/// ACTIVE and is left alone, so concurrent requests can't reap/evict each other's live data. 5 minutes is
+/// ~60× any real extract yet far shorter than a crash-orphan's age.
+///
+/// This is a HEURISTIC, not a lock (re-audit): it does NOT protect a TRULY-OLD cached version that is
+/// being re-executed (reading/executing a binary doesn't refresh its dir mtime) — that residual is a
+/// narrow, recoverable (re-download) TOCTOU; the robust fix is a cross-request lease, deferred. It can
+/// also leave the cache transiently ABOVE its retention limit if many versions are downloaded within one
+/// window — self-healing (a later cleanup, once they age out, evicts them). Both trades favor
+/// availability over strictness and are bounded. See FINDINGS.md B1/B2.
 const CACHE_ENTRY_ACTIVE_WINDOW: Duration = Duration::from_secs(5 * 60);
 
 /// True if `path` was modified within [`CACHE_ENTRY_ACTIVE_WINDOW`] (⇒ presumed active, do not delete).

--- a/packages/accelerator/core/src/versions/version_policy.rs
+++ b/packages/accelerator/core/src/versions/version_policy.rs
@@ -291,6 +291,15 @@ pub async fn cleanup_old_versions(bundled: &AztecVersion, in_use: Option<&AztecV
     };
     for version in evictions(&cached, bundled, in_use) {
         let dir = base.join(version.as_str());
+        // B2 (full-branch audit): skip a version whose dir was touched within the active window — it was
+        // just downloaded (and is likely about to be proved by a CONCURRENT request whose own cleanup
+        // exempts a DIFFERENT in_use version). Age-gating stops two concurrent detached cleanups from
+        // evicting each other's fresh-in-use binary. A truly-old in-use version is still a narrow,
+        // recoverable (re-download) TOCTOU — a full cross-request lease is deferred (see FINDINGS.md B2).
+        if super::downloader::recently_active(&dir) {
+            tracing::debug!(version = %version, "Skipping eviction of a recently-active version");
+            continue;
+        }
         match std::fs::remove_dir_all(&dir) {
             Ok(()) => tracing::info!(version = %version, "Evicted old bb version"),
             Err(e) => tracing::warn!(version = %version, error = %e, "Failed to evict bb version"),

--- a/scripts/download-bb.ts
+++ b/scripts/download-bb.ts
@@ -165,7 +165,23 @@ export async function fetchAssetDigest(version: string, asset: string): Promise<
   if (!res.ok) {
     throw new Error(`Cannot verify bb v${version}: release metadata HTTP ${res.status} ${res.statusText}`);
   }
-  const release = (await res.json()) as { assets?: Array<{ name?: string; digest?: string }> };
+  const release = (await res.json()) as {
+    immutable?: boolean;
+    assets?: Array<{ name?: string; digest?: string }>;
+  };
+  // G2 (full-branch audit): the asset AND the digest we verify against both come from the SAME GitHub
+  // release. On a MUTABLE release, a compromised Aztec release token could swap the asset and its
+  // reported digest together, and our check would still pass — this is an inherent trust in Aztec's
+  // release infra. We do NOT hard-require `immutable` (Aztec releases are not all immutable — the API
+  // returns `immutable: false` — so requiring it would break every legitimate download, repeating the
+  // version-floor over-block mistake). Instead we surface the weaker guarantee with a warning; tighten
+  // to a hard requirement only once Aztec publishes immutable releases. See FINDINGS.md (G2).
+  if (release.immutable === false) {
+    console.warn(
+      `⚠️  bb v${version}: GitHub release is MUTABLE — its asset digest is not tamper-locked after publish. ` +
+        `Integrity rests on Aztec's release infrastructure (inherent supply-chain trust).`,
+    );
+  }
   const found = (release.assets ?? []).find((a) => a.name === asset);
   if (!found?.digest) {
     throw new Error(`Cannot verify bb v${version}: no digest for asset ${asset} in release metadata`);


### PR DESCRIPTION
Whole-branch security audit of `security-hardening` (the thing you asked for: a fresh, iterate-to-
convergence codex `gpt-5.6-sol` audit scoped to the *entire current* `main...security-hardening` code
delta, #400+#401 folded in) plus its remediation. Full triage in `full-audit-2026-07-24/FINDINGS.md`.

## Audit result — the core is clean
8 codex chunks (auth/prove, bb-cache/versions, win_acl/certs/recovery, updater, tauri/frontend,
CI/workflows, scripts, infra), every finding verified by hand. **No new Critical/High in the prover,
origin-auth, canonicalization, crypto/manifest, or Windows-ACL surface.** The two scariest auth
findings were **verified false positives** (chunk-boundary artifacts): the clickjacking arbiter *is*
wired (`respond_auth`→`resolve_active`), and headless denies unapproved origins immediately. Chunk C
(win_acl/certs/crash-recovery) was **clean**. The real signal was supply-chain hygiene.

## Fixed in this PR (code/config)
- **F2** (`_publish-sdk.yml`): `git tag/push || true` swallowed failures → a pre-claimed wrong-commit
  tag could be blessed. Now `git ls-remote` (fails loudly on network/auth) requires any existing tag to
  resolve to HEAD, else abort.
- **A1** (`prove.rs`): the single prove permit was held during body upload + bb download → one slow
  uploader blocked the prover for 30s. Now the body is read + version downloaded under only the
  inflight cap; the permit wraps just `bb::prove`.
- **B1/B2** (`downloader.rs`, `version_policy.rs`): concurrent downloads could reap/evict each other's
  live cache data. Added an mtime recency guard (fail-safe) to stage-reap + eviction.
- **G2** (`download-bb.ts`): warn (not fail) when the bb release is mutable — surfaces the inherent
  Aztec-release trust without bricking downloads.
- **H3** (`s3.tf`): noncurrent S3 versions never expired → churn cost. Added a 7-day + 10-copy expiry
  (with an honest note on the AWS AND-semantics + the residual that adversarial churn needs CI
  least-privilege).

## Documented, not code-changed (with rationale)
- **E1** (bounded auth-popup flood, ≤10 windows, unapproved origins): the proper fix re-architects the
  5-round-converged C9 arbiter across the lib/bin split — disproportionate + regression-risky for a
  bounded, non-crashing annoyance. **Recommend not fixing in code**; owner may opt in.
- **D1/D2** (updater buffer): the accepted #345/M6 residual. **H1** (0-approval branch protection): the
  solo-dev risk-accept.

## Owner runbook (`quality-audit-2026-07-24/release-ci-owner-runbook.md`)
**F1/G1** (production signing key exposed in CI smoke jobs), **H2** (legacy IAM role), **H4** (IAM
`workflow`-claim → GitHub-Environments cutover) — with concrete steps; several tie together into one
"protected environments + scope roles on `sub`" change.

## Validation
core 185 unit tests + clippy + fmt; scripts 79 tests + biome; `bun run test` + `lint:actions` exit 0;
tofu fmt. Codex re-audited the remediation to convergence: **SOUND, no new issue**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
