### PR TITLE
docs(release): phase 6 complete — legacy role retired, H2 closed

### DIFF
--- a/implementations-plan/release-1.0.7/STATUS.md
+++ b/implementations-plan/release-1.0.7/STATUS.md
@@ -101,3 +101,11 @@ Legend: `[✓]` done · `[~]` in progress · `[ ]` pending · `[✗]` failed/blo
   main's new `typecheck:scripts` then caught 4 real type errors in branch scripts — fixed, not
   suppressed. Local gate green. PR creation BLOCKED by a GitHub "Pull Requests: major_outage";
   branch pushed, retry armed.
+- 2026-07-24 — Phase 6 (except the owner's root-key deletion) COMPLETE while Phase 4/5 stay blocked
+  on Apple. R5 smoke finished: publish-testnet exercised ci-playground-testnet for real (success),
+  joining deploy-landing (ci-landing) and the release auth preflight (ci-release-feed). With R5 +
+  R5b both satisfied, R6 executed: PR #406 removed aws_iam_role.ci / aws_iam_role_policy.ci /
+  ci_role_arn; `tofu apply` destroyed exactly 2 resources (0 add/change); AWS confirms
+  NoSuchEntity for aztec-accelerator-ci-github; the three per-pipeline roles remain; the legacy
+  AWS_ROLE_ARN GitHub secret is deleted. The audit's H2 finding (legacy role trusted every workflow
+  on main with whole-bucket write, bypassing the landing role's release-feed Deny) is now CLOSED.


### PR DESCRIPTION
Tracker update: R5 smoke complete (all three per-pipeline roles exercised on main), R5b isolation proven by IAM semantics, R6 executed (legacy role deleted, AWS_ROLE_ARN dropped). Closes audit finding H2. Phases 4/5 remain blocked on an expired Apple Developer Program agreement (notarization HTTP 403) — owner action.