### PR TITLE
fix(ci): install deps in the linux/macOS updater smokes so feed signing resolves

### DIFF
--- a/.github/workflows/_e2e-updater-linux.yml
+++ b/.github/workflows/_e2e-updater-linux.yml
@@ -58,6 +58,14 @@ jobs:
         with:
           bun-version: 1.3.14
 
+      # REQUIRED for sign-smoke-feed.sh: it runs `bunx tauri signer sign`, which only resolves the
+      # LOCAL @tauri-apps/cli (a devDependency of packages/accelerator). Without an install, bunx
+      # falls back to fetching an npm package literally named `tauri` — which has no executable, so
+      # the smoke dies with "could not determine executable to run for package tauri". The Windows
+      # smoke never hit this because it uses ./.github/actions/setup-accelerator, which installs.
+      - name: Install dependencies (provides @tauri-apps/cli for feed signing)
+        run: bun install --frozen-lockfile
+
       # FUSE (AppImage runtime) + headless display + tray host + dbus. Running the
       # AppImage natively (via FUSE) sets $APPIMAGE, which the Tauri Linux updater
       # replaces in place — `--appimage-extract-and-run` would NOT, breaking the

--- a/.github/workflows/_e2e-updater.yml
+++ b/.github/workflows/_e2e-updater.yml
@@ -60,6 +60,14 @@ jobs:
         with:
           bun-version: 1.3.14
 
+      # REQUIRED for sign-smoke-feed.sh: it runs `bunx tauri signer sign`, which only resolves the
+      # LOCAL @tauri-apps/cli (a devDependency of packages/accelerator). Without an install, bunx
+      # falls back to fetching an npm package literally named `tauri` — which has no executable, so
+      # the smoke dies with "could not determine executable to run for package tauri". The Windows
+      # smoke never hit this because it uses ./.github/actions/setup-accelerator, which installs.
+      - name: Install dependencies (provides @tauri-apps/cli for feed signing)
+        run: bun install --frozen-lockfile
+
       - name: Download N artifacts (this run)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:


### PR DESCRIPTION
The 1.0.7-rc.1 dry run built and notarized cleanly on every platform, then ALL six
updater smokes failed with:

    error: could not determine executable to run for package tauri

Root cause: `sign-smoke-feed.sh` (new in the security-hardening campaign) runs
`bunx tauri signer sign`, which only resolves the LOCAL @tauri-apps/cli — a
devDependency of packages/accelerator. The linux and macOS smoke jobs set up bun but
never ran `bun install`, so bunx fell back to fetching an npm package literally named
`tauri`, which ships no executable. The Windows smoke was unaffected because it uses
./.github/actions/setup-accelerator, which already runs `bun install --frozen-lockfile`.

Fix: add the same `bun install --frozen-lockfile` to _e2e-updater.yml and
_e2e-updater-linux.yml before the smoke runs.

This is the fragility the audit's G1 finding called out ("invoke a frozen local signer,
never bunx fallback resolution") — the dependency is now guaranteed present rather than
resolved opportunistically. Hardening the script to call the local binary by path
directly is a follow-up, tracked with G1.

actionlint clean.