### PR TITLE
fix(ci): make the windows updater smoke actually emit its diagnostics on failure

### DIFF
--- a/packages/accelerator/scripts/updater-smoke-windows.ps1
+++ b/packages/accelerator/scripts/updater-smoke-windows.ps1
@@ -176,7 +176,7 @@ try {
     try { Invoke-RestMethod -Uri "https://$FeedHost/releases/latest.json" -TimeoutSec 3 | Out-Null; $feedUp = $true; break } catch { }
     Start-Sleep -Milliseconds 500
   }
-  if (-not $feedUp) { Write-Error "feed server not reachable"; Dump-Logs; exit 1 }
+  if (-not $feedUp) { Dump-Logs; Write-Error "feed server not reachable"; exit 1 }
 
   # ── Install N-1 silently (currentUser → %LOCALAPPDATA%, no UAC) ──
   # Timed (not -Wait): a non-silent NSIS prompt would hang the runner forever, so fail fast.
@@ -207,7 +207,7 @@ try {
     & schtasks /Delete /F /TN $TaskName *> $null
     & schtasks /Query /TN $TaskName *> $null
     if ($LASTEXITCODE -eq 0) {
-      Write-Error "(#97) pre-run cleanup FAILED — a stale '$TaskName' task survived /Delete; cannot prove this run armed it."; Dump-Logs; exit 1
+      Dump-Logs; Write-Error "(#97) pre-run cleanup FAILED — a stale '$TaskName' task survived /Delete; cannot prove this run armed it."; exit 1
     }
     Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run" -Name "Aztec Accelerator" -Value "`"$($Exe.FullName)`""
     Log "armed crash-recovery (stale task cleared + verified gone; autostart Run key set)"
@@ -246,11 +246,11 @@ try {
     Log "NEGATIVE: asserting /health never reports $NVersion (tampered artifact rejected), 120s"
     for ($i = 0; $i -lt 60; $i++) {
       try { $got = (Invoke-RestMethod -Uri $HealthUrl -TimeoutSec 3).version } catch { $got = $null }
-      if ($got -eq $NVersion) { Write-Error "NEGATIVE FAILED — a TAMPERED artifact was ACCEPTED (updated to $NVersion). The updater is not verifying signatures."; Dump-Logs; exit 1 }
+      if ($got -eq $NVersion) { Dump-Logs; Write-Error "NEGATIVE FAILED — a TAMPERED artifact was ACCEPTED (updated to $NVersion). The updater is not verifying signatures."; exit 1 }
       Start-Sleep -Seconds 2
     }
     if (-not (Select-String -Path (Join-Path $Work "feed.log") -Pattern "/releases/download/" -Quiet)) {
-      Write-Error "NEGATIVE inconclusive — the updater never downloaded the artifact, so signature rejection wasn't exercised."; Dump-Logs; exit 1
+      Dump-Logs; Write-Error "NEGATIVE inconclusive — the updater never downloaded the artifact, so signature rejection wasn't exercised."; exit 1
     }
     Log "SUCCESS (negative) — updater downloaded the tampered artifact and refused to update"
     Dump-Logs; exit 0
@@ -266,10 +266,10 @@ try {
     Start-Sleep -Seconds 2
   }
   if (-not $updated) {
-    Write-Error "updater smoke failed — /health never reported $NVersion (does Tauri's Windows updater apply the .nsis.zip? see feed/app logs)"; Dump-Logs; exit 1
+    Dump-Logs; Write-Error "updater smoke failed — /health never reported $NVersion (does Tauri's Windows updater apply the .nsis.zip? see feed/app logs)"; exit 1
   }
   if (-not (Select-String -Path (Join-Path $Work "feed.log") -Pattern "/releases/download/" -Quiet)) {
-    Write-Error "/health reports $NVersion but the feed log has no download hit — the update didn't flow through our feed."; Dump-Logs; exit 1
+    Dump-Logs; Write-Error "/health reports $NVersion but the feed log has no download hit — the update didn't flow through our feed."; exit 1
   }
   Log "SUCCESS — updated to $NVersion via the local feed (artifact downloaded + relaunched)"
 
@@ -285,7 +285,7 @@ try {
   # (#97) ARMED: the poller must have seen the task PRESENT (N-1 registered it; the stale task was
   #   cleared pre-run, so this is genuinely this run's registration — not a leftover).
   if ($sawPresent -ne 1) {
-    Write-Error "(#97) ARMING proof FAILED — '$TaskName' was never observed present; N-1 did not register the crash-recovery task (autostart Run key or startup enable_crash_recovery regressed). The update-while-armed scenario was never set up."; Dump-Logs; exit 1
+    Dump-Logs; Write-Error "(#97) ARMING proof FAILED — '$TaskName' was never observed present; N-1 did not register the crash-recovery task (autostart Run key or startup enable_crash_recovery regressed). The update-while-armed scenario was never set up."; exit 1
   }
   # (#97) DISARM: after being present, the task must have been SUSTAINED-absent (>=3 consecutive ~200ms
   #   samples ≈ >=600ms) during the update. The real disarm-before-install window is the whole NSIS
@@ -293,7 +293,7 @@ try {
   #   If it stayed armed throughout, disable_crash_recovery() never disarmed — the race is live (and the
   #   end-state re-arm check below would still pass, hiding it: the exact #96 gap).
   if ($maxAbsentStreak -lt 3) {
-    Write-Error "(#97) DISARM proof FAILED — '$TaskName' was never observed sustained-absent during the update (longest consecutive-absent run: $maxAbsentStreak samples). disable_crash_recovery() did not disarm before install; the half-written-binary race is live."; Dump-Logs; exit 1
+    Dump-Logs; Write-Error "(#97) DISARM proof FAILED — '$TaskName' was never observed sustained-absent during the update (longest consecutive-absent run: $maxAbsentStreak samples). disable_crash_recovery() did not disarm before install; the half-written-binary race is live."; exit 1
   }
   Log "(#97) armed + disarmed — task seen present, then sustained-absent ($maxAbsentStreak samples) across the install"
 
@@ -305,7 +305,7 @@ try {
     Start-Sleep -Seconds 2
   }
   if (-not $rearmed) {
-    Write-Error "update succeeded but '$TaskName' is ABSENT — the guard did not re-arm (updater.rs rearm path or N-startup enable_crash_recovery failed)."; Dump-Logs; exit 1
+    Dump-Logs; Write-Error "update succeeded but '$TaskName' is ABSENT — the guard did not re-arm (updater.rs rearm path or N-startup enable_crash_recovery failed)."; exit 1
   }
   Log "(#97) re-armed — full armed→disarm→re-arm cycle proven"
   exit 0


### PR DESCRIPTION
Every failure path in updater-smoke-windows.ps1 was written as:

    Write-Error "..."; Dump-Logs; exit 1

GitHub runs pwsh with $ErrorActionPreference = 'Stop', so Write-Error TERMINATES the
script immediately and the trailing Dump-Logs never runs. The harness therefore threw
away exactly the evidence it was designed to capture — feed.log, feed.err, the app's own
updater log, and the last /health response — on all 9 failure paths.

That is why the 1.0.7-rc.1 Windows failures were undiagnosable: we could see WHICH
assertion failed but never WHY.

Reordered all 9 call sites to `Dump-Logs; Write-Error ...; exit 1` so the diagnostics are
emitted before the terminating error.

No behaviour change to what is asserted — only that a failing run now explains itself.