### PR TITLE
ci(security): feed-health monitor + main-ref dispatch guards + verify-tag (F-005)

### DIFF
--- a/.github/workflows/publish-testnet.yml
+++ b/.github/workflows/publish-testnet.yml
@@ -25,6 +25,22 @@ permissions:
   contents: read
 
 jobs:
+  # F-005 (Codex GATE-3 H4): gate all side effects (npm publish + AWS deploy) on a main-ref
+  # dispatch. The playground OIDC role trusts only main, so the AWS leg fails on its own — but
+  # npm does NOT check the ref, and `publish-sdk` runs BEFORE `deploy-app`. Without this a
+  # feature-ref dispatch would irreversibly publish the SDK to npm and only then fail at AWS.
+  assert-main:
+    name: Assert main ref
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Assert dispatched from main
+        run: |
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "::error::Publish Testnet must be dispatched from refs/heads/main (got $GITHUB_REF)"
+            exit 1
+          fi
+
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
@@ -54,7 +70,7 @@ jobs:
       build_accelerator: ${{ inputs.skip_sdk_publish != true }}
 
   publish-sdk:
-    needs: [changes, e2e]
+    needs: [assert-main, changes, e2e]
     # Skip when deploying the playground only. The SDK publishes on the `testnet`
     # dist-tag; npm `latest` moves ONLY via promote-latest.yml, after the live
     # acceptance smoke (_publish-sdk.yml has no latest capability at all).
@@ -71,8 +87,11 @@ jobs:
 
   deploy-app:
     # Deploy playground unless E2E explicitly failed — skip on cancel, proceed on skip/success.
-    if: ${{ !cancelled() && needs.e2e.result != 'failure' }}
-    needs: e2e
+    # The explicit assert-main success check is REQUIRED, not redundant: `!cancelled()` overrides
+    # GitHub's normal skipped-needs propagation, so without it this job would still deploy after
+    # assert-main failed (F-005 H4).
+    if: ${{ !cancelled() && needs.e2e.result != 'failure' && needs.assert-main.result == 'success' }}
+    needs: [assert-main, e2e]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/release-accelerator.yml
+++ b/.github/workflows/release-accelerator.yml
@@ -32,6 +32,18 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       is_prerelease: ${{ steps.version.outputs.is_prerelease }}
     steps:
+      # F-005 (Codex GATE-3 H2): reject any dispatch not on refs/heads/main BEFORE any
+      # build/tag/release. Every other job depends on `validate` (directly or transitively),
+      # so this gates the whole run, and it matches the release role's `sub=main` + `workflow`
+      # OIDC trust — without it an off-main dispatch still builds and SIGNS artifacts with the
+      # production updater key before failing later at the AWS step.
+      - name: Assert main ref
+        run: |
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "::error::Release Accelerator must be dispatched from refs/heads/main (got $GITHUB_REF)"
+            exit 1
+          fi
+
       - name: Validate and output version
         id: version
         env:
@@ -932,10 +944,16 @@ jobs:
           # Strip leading whitespace from each line (YAML indentation artifact)
           sed -i 's/^          //' /tmp/release-notes.md
 
+          # F-005 (Codex GATE-3 H1): --verify-tag makes `gh release create` FAIL when the tag
+          # does not already exist (pushed by the `tag` job) instead of silently auto-creating
+          # it from HEAD. A release must never be published when `tag` was skipped — e.g. after
+          # a failed release-auth-preflight — because the auto-created tag would point at
+          # whatever HEAD happened to be rather than the reviewed commit.
           if [ "$IS_PRERELEASE" = "true" ]; then
             gh release create "$RELEASE_TAG" \
               --title "Aztec Accelerator $VERSION" \
               --notes-file /tmp/release-notes.md \
+              --verify-tag \
               --prerelease \
               --latest=false \
               "${FILES[@]}"
@@ -943,6 +961,7 @@ jobs:
             gh release create "$RELEASE_TAG" \
               --title "Aztec Accelerator $VERSION" \
               --notes-file /tmp/release-notes.md \
+              --verify-tag \
               --latest \
               "${FILES[@]}"
           fi

--- a/.github/workflows/update-feed-health.yml
+++ b/.github/workflows/update-feed-health.yml
@@ -1,0 +1,107 @@
+name: Update Feed Health
+
+# The updater feed at aztec-accelerator.dev/releases/latest.json is what every INSTALLED app
+# polls to discover a new version. It was silently dead for ~6 weeks after deploy-landing's
+# `s3 sync --delete` wiped it (fixed by adding `--exclude "releases*"` + an IAM Deny), and
+# nothing surfaced it — the release pipeline only writes the feed, it never reads it back on a
+# later day. This is the standing read-back that turns a dead or STALE feed into a next-day
+# discovery instead of a months-later one.
+#
+# Deliberately credential-free: the feed is a public URL, so this needs no AWS role, no secrets
+# and no checkout — only the default GITHUB_TOKEN (contents: read) to look up the latest release
+# for the staleness comparison. Nothing here can be leveraged if the workflow is ever tampered
+# with, which is why it is safe to run on a schedule without review.
+on:
+  schedule:
+    - cron: "0 7 * * *" # daily 07:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: update-feed-health
+  cancel-in-progress: true
+
+jobs:
+  probe:
+    name: Probe latest.json
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fetch and validate the live updater feed
+        env:
+          FEED: https://aztec-accelerator.dev/releases/latest.json
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # 1. Reachable at all — this is the check that would have caught the 6-week outage.
+          code=$(curl -sS --max-time 30 -o feed.json -w '%{http_code}' "$FEED")
+          if [ "$code" != "200" ]; then
+            echo "::error::updater feed returned HTTP $code (expected 200) — $FEED"
+            exit 1
+          fi
+
+          # 2. Structurally intact (catches a truncated or half-written upload).
+          if ! jq -e . feed.json >/dev/null 2>&1; then
+            echo "::error::updater feed is not valid JSON"
+            exit 1
+          fi
+          for k in manifest manifest_sig version platforms; do
+            if ! jq -e --arg k "$k" 'has($k)' feed.json >/dev/null; then
+              echo "::error::updater feed is missing top-level key: $k"
+              exit 1
+            fi
+          done
+
+          # 3. The F-004 signed envelope is actually present. An empty signature would mean
+          #    clients fall back to trusting the plain feed body.
+          if [ -z "$(jq -r '.manifest_sig // empty' feed.json)" ]; then
+            echo "::error::manifest_sig is empty — the F-004 signed-manifest envelope is broken"
+            exit 1
+          fi
+
+          # 4. NOT STALE. A feed frozen at an old version still returns a perfectly healthy 200
+          #    while silently stranding every installed app, so compare against the real latest
+          #    stable release. This is the failure mode a naive uptime check cannot see.
+          feed_ver=$(jq -r .version feed.json)
+          latest_tag=$(gh release list --exclude-pre-releases --limit 20 --json tagName \
+            --jq '[.[].tagName | select(startswith("accelerator-v"))][0]')
+          latest_ver="${latest_tag#accelerator-v}"
+          if [ -z "$latest_ver" ]; then
+            echo "::error::could not resolve the latest stable accelerator release to compare against"
+            exit 1
+          fi
+          if [ "$feed_ver" != "$latest_ver" ]; then
+            echo "::error::feed advertises $feed_ver but the latest stable release is $latest_ver — feed is stale"
+            exit 1
+          fi
+
+          # 5. Every platform present AND its artifact actually downloadable. A partial upload
+          #    leaves one OS silently unable to update while the other three look fine.
+          for p in darwin-aarch64 darwin-x86_64 linux-x86_64 windows-x86_64; do
+            url=$(jq -r --arg p "$p" '.platforms[$p].url // empty' feed.json)
+            if [ -z "$url" ]; then
+              echo "::error::updater feed is missing platform: $p"
+              exit 1
+            fi
+            # Range-request a single byte: proves the asset resolves without pulling ~90MB.
+            acode=$(curl -sSL --max-time 60 -o /dev/null -w '%{http_code}' -r 0-0 "$url")
+            case "$acode" in
+              200 | 206) ;;
+              *)
+                echo "::error::$p artifact returned HTTP $acode — $url"
+                exit 1
+                ;;
+            esac
+          done
+
+          {
+            echo "### ✅ Updater feed healthy"
+            echo ""
+            echo "- version: \`$feed_ver\` (matches latest stable \`$latest_tag\`)"
+            echo "- platforms: 4/4 present and downloadable"
+            echo "- \`manifest_sig\`: present"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/implementations-plan/security-hardening/quality-audit-2026-07-24/README.md
+++ b/implementations-plan/security-hardening/quality-audit-2026-07-24/README.md
@@ -1,0 +1,145 @@
+# security-hardening — pre-main-merge codex xhigh quality audit (2026-07-24)
+
+User-requested: several iterations of codex gpt-5.6-sol @ xhigh over the WHOLE security-hardening branch
+(vs main, 169 files / ~16.3k insertions) before it merges to main. Each cluster C0–C10 + closeout already
+had its own blueprint + audit during the campaign; this is a fresh whole-branch pass for merge confidence.
+
+Codex can't audit 16k lines in one run (infra-kills), so chunked by concern; each chunk = one tight
+read-only codex run. Verdicts + folded findings logged here. Loop drives chunk-by-chunk, then re-audits.
+
+## Chunks (round 1)
+1. origin-auth + request-safety — core: authorization.rs, server.rs, server/auth.rs, server/host.rs, config.rs
+2. bb-cache + Windows-ACL FFI — core: bb.rs, downloader.rs, win_acl.rs, versions.rs
+3. updater + certs (crypto) — core: update_manifest.rs, updater_state.rs; src-tauri: certs.rs, updater.rs
+4. tauri boundary — src-tauri: commands.rs, windows.rs, crash_recovery.rs, main.rs
+5. frontend — frontend-src: authorize.js, settings.js, update-prompt.js, bridge.js
+6. scripts — scripts/*.ts (download-bb, copy-bb, bb-version, build-frontend, check-windows-bb-pin)
+7. CI — .github/workflows/* (OIDC, SHA-pinning, publish, _aztec-update)
+8. infra — infra/tofu/*.tf + infra/rulesets
+
+## Findings log
+(appended per chunk below)
+
+### Round 1 · Chunk 1 (origin-auth + request-safety) — REJECT
+- **HIGH** — `authorization.rs:315-320` / `server.rs:123-126` / `server/auth.rs:80-87`: same-origin piggyback
+  appends UNBOUNDED senders (`req.senders.push`) before any waiter cap → one unapproved origin firing/aborting
+  many `/prove` requests accumulates senders (memory/connection DoS), each waiting up to the ~660s backstop.
+  FIX: cap senders-per-pending-request; reject (429/deny) past the cap.
+- **MEDIUM** — `server/auth.rs:80-85` / `authorization.rs:337-343`: the /prove backstop resolves the active
+  request but discards the promoted id (core can't reach the window layer), so if the 60s activation timer
+  ALSO failed, the promoted popup is server-active but unraised/unarmed. FIX: propagate promotion (add an
+  on_promote callback core→src-tauri, or equivalent).
+
+### Round 1 · Chunk 2 (bb-cache + Windows-ACL FFI) — REJECT
+- **HIGH** — `bb.rs:38-39,191-206,229`: cache verify (`verify_cached_bb` rehash) and execute (`Command::spawn`)
+  are path-separated → TOCTOU: swap the cached binary between verify and spawn and the replacement gets the
+  witness. FIX (hard): verify+exec the same fd (Linux fexecve / hold an open handle), or accept as a
+  documented same-user residual. [C6/F-007 pre-existing]
+- **MEDIUM/HIGH** — `win_acl.rs:164-256`: `verify_owner_only` checks only the DACL ACEs, NOT the object OWNER.
+  A foreign-owned object retains implicit WRITE_DAC and can rewrite the DACL. FIX: verify (and/or set) the
+  object owner == current-user SID (OWNER_SECURITY_INFORMATION).
+- **COVERAGE GAP** — I named `downloader.rs`/`versions.rs` (don't exist). Re-run chunk 2b on the REAL
+  download/decompress/tar-safety + version-policy files (see ls output).
+
+### Round 1 · Chunk 2b (versions/ download + policy) — REJECT
+- **HIGH** — `version_policy.rs:67-85,187-196` / `downloader.rs:19-48`: no trusted-pin/downgrade policy — a
+  caller can request an OLD vulnerable official bb release; it passes GitHub digest verify + runs. TRIAGE:
+  likely bounded by threat model (the bb version is chosen by the LOCAL same-user SDK, not a remote origin) —
+  candidate for min-version-floor OR documented-accepted. Needs user threat-model call.
+- **HIGH** — `cache_layout.rs:9-13,134-188` / `downloader.rs:28-31`: home-resolution failure falls back to
+  CWD with no ownership/privacy check → attacker-writable CWD can preseed a malicious bb + self-authored
+  matching marker → verify passes, download skipped. FIX: remove the CWD fallback (fail closed, like F-003).
+- **MED** — `downloader.rs:194-212,238-262`: stale-stage reaping + delete-then-rename are unsynchronized →
+  concurrent installers can delete each other's active stage. FIX: per-version lock/serialization.
+
+### TRIAGE NOTE
+Most findings so far are PRE-EXISTING campaign code (C2/C6/C7), in scope for the whole-branch audit but a
+large re-hardening. Split: clear fixes (piggyback cap · CWD-fallback fail-closed · win_acl owner-verify ·
+staging lock) vs threat-model/design calls needing the user (version-downgrade policy · verify/exec TOCTOU
+same-user · backstop-no-promote rare). Complete chunks 3–8, then present the full triaged set for the
+remediation-scope decision.
+
+### Round 1 · Chunk 3 (updater + certs) — REJECT
+- **HIGH** — `updater.rs:381-402`: if `record_pending` fails after install(v3), it restarts + releases the
+  lock anyway → a still-running v1 can pass the unchanged floor and install signed v2 over v3. FIX: on
+  record_pending failure, don't release/restart into a lowered-floor state. [C4/F-004]
+- **HIGH** — `certs.rs:187-225`: migration deletes `ca.key` but retains the trusted CA anchor → a
+  pre-migration copied/backed-up key still mints trusted certs. TRIAGE: rotating the CA breaks existing
+  trust (user re-trust) — threat-model call. [F-016]
+- **MED** — `updater.rs:298-355`: size cap checked AFTER buffering the body → OOM before rejection. FIX:
+  bound the stream during download.
+- **MED** — `updater.rs:210-227`: unsigned multi-GB feed `notes`/`platforms` buffered+parsed before manifest
+  verify → periodic-check DoS. FIX: cap feed response size pre-parse.
+- **MED** — `certs.rs:71-353`: cert rotation non-transactional (leaf cert replaced before key on crash) →
+  persistent mismatch accepted by presence/expiry check. FIX: transactional swap or validity-check the pair.
+- Codex confirmed SOUND: sig envelope, version→artifact binding, VerifiedUpdate, localhost-SAN, TLS params,
+  keyless-CA-on-disk.
+
+## PLAN: complete chunks 4–8 (tauri · frontend · scripts · CI · infra), THEN present the full triaged
+## findings to the user for the remediation-scope + threat-model decisions before any large re-hardening.
+
+### Round 1 · Chunk 4 (tauri boundary) — REJECT  [⚠ several in MY closeout code]
+- **BLOCKING (my C8 bug)** — `commands.rs:83-90` / `crash_recovery.rs:84-99`: enable_transaction rollback runs
+  `disable_crash_recovery()` unconditionally even when prior_enabled=true → a transient arm failure DELETES
+  pre-existing recovery, downgrading a fully-enabled install to launcher-only. FIX: on prior_enabled, do NOT
+  disarm on rollback (restore prior fully).
+- **BLOCKING** — `commands.rs:92-95` / `main.rs:334-336`: set_autostart(false) + Quit discard
+  `disable_crash_recovery()==false` → deletion-failure reported as success; surviving task relaunches. FIX:
+  surface/propagate the confirmed-disarm bool.
+- **HIGH** — `commands.rs:52,83` / `main.rs:516`: `is_enabled().unwrap_or(false)` → I/O error treated as
+  disabled → rollback may disable a real launcher / startup skips rearm. FIX: treat unknown conservatively.
+- **MED (my C9 arbiter race)** — `windows.rs:132-153` / `commands.rs:236-242`: A can promote B before B's
+  window is built → arm_active_popup finds no window, B builds stale unfocused/non-topmost. FIX: order
+  build-before-promote, or re-raise on build.
+- **BLOCKING** — `crash_recovery.rs:277-288` / `main.rs:238-256`: Linux `systemctl enable` doesn't START the
+  unit; .desktop + systemd both launch, no dup-instance exit → C8/F-010 supervision design. TRIAGE: design.
+
+### Round 1 · Chunk 5 (frontend) — REJECT  (no XSS; textContent used)
+- **MED** — `update-prompt.js:3-6`: versions from URL params, not backend-confirmed → fake-update display.
+  FIX: route through a server-authoritative pending-update (mirror the authorize get_pending_auth fix). [pre-existing]
+- **MED (my C9)** — `authorize.js`: inactive-state + click-guard cover Allow/Deny but NOT the Remember
+  checkbox → stolen click pre-arms persistent auth. FIX: disable+guard Remember while inactive.
+- **MED (my C9)** — `authorize.js`/`bridge.js`: `decided` stops the poll before respond_auth succeeds; on
+  failure, buttons re-enable but poll never resumes → stale request falsely actionable. FIX: resume poll on
+  failure / don't latch decided until success.
+- **LOW/MED (my C9)** — `authorize.js`: overlapping polls — a delayed older active:false can overwrite a
+  newer active:true. FIX: sequence/guard stale poll results.
+
+### Round 1 · Chunk 6 (build/prebuild scripts) — REJECT  (mostly BUILD-TIME → lower runtime severity)
+- copy-bb.ts (C7 build): `:163-170` arrayBuffer before 64MiB check (chunked→OOM); `:175-191` verify→extract
+  TOCTOU (same-user swap of the temp archive); `:191-201` no expanded-size/member-type bound (gzip bomb /
+  symlink bb.exe followed); `:250` bare `xattr` shell exec (planted-PATH / shell-subst). Threat = build-machine.
+- **build-frontend.ts (my closeout)**: `:41-55` manifest omits build-recipe/tool-version → bundler-opt change
+  without source change passes the SHA guard; `:68-103` hash-time source-swap race. Threat = build-machine.
+- copy-bb resolver had NO provenance fail-open. download-bb.ts/check-windows-bb-pin.ts gone at HEAD.
+
+### Round 1 · Chunk 7 (release/publish CI) — REJECT  (all workflow_dispatch-gated → insider/CI threat)
+- release-accelerator.yml: `:40-53` multiline-version → $GITHUB_OUTPUT injection; `:734-740` preflight-fail
+  treated as skipped→acceptable (release created/deleted before AWS auth); `:109` auth_probe=true doesn't stop
+  build/sign/notarize/feed-sign; `:601` existing tag accepted without verifying it points to github.sha.
+- _publish-sdk.yml: `:148` tag create/push failures ignored → gh release on stale/auto-created tag (provenance).
+- release/_publish-sdk/publish-testnet/aztec-stable `:4`: unrestricted dispatch refs run unreviewed branch code
+  with signing keys / NPM_TOKEN / App key exposed (no protected environment).
+- INTACT: no mutable third-party action refs (F-015 holds); landing/playground --delete scoped (F-005 holds).
+
+### Round 1 · Chunk 8 (infra/OIDC/ruleset) — CONDITIONAL APPROVE
+- **HIGH (already tracked)** — `iam.tf:263,283`: legacy `aws_iam_role.ci` checks aud+sub but NOT `workflow`,
+  grants bucket-wide put/delete → any main-branch id-token workflow can assume it + clobber latest.json /
+  sibling objects, bypassing the 3 new roles. This IS the documented F-005 human-gated retirement (C5-runbook
+  R6: retire legacy role after cutover). NOT new. Infra otherwise SOUND.
+
+## ROUND 1 SYNTHESIS (all 8 chunks) — triage by ACTUAL threat model
+**A. Real RUNTIME bugs in the CLOSEOUT I just shipped (fix now — mine):**
+  C8: destructive re-enable rollback (disarm on prior_enabled); disarm-failure swallowed (disable/quit);
+  is_enabled()→false-on-unknown. C9 arbiter: promote-before-build race. C9 frontend: Remember unguarded;
+  decided-stops-poll-before-success; poll-overlap. win_acl (F-003 closeout): owner-SID not verified.
+**B. Real runtime findings in PRE-EXISTING campaign code (fixable; scope expansion):**
+  unbounded piggyback senders (C2 DoS); CWD cache fallback fail-open (C6); updater rollback-race (C4);
+  concurrent staging (C6); streaming size-cap + feed-DoS (C4); cert-rotation non-atomic (F-016);
+  update-prompt unverified version.
+**C. Threat-model / design calls (need USER decision — fixes have trade-offs / out of stated model):**
+  version-downgrade policy (bb version is local-SDK-driven); cache verify/exec TOCTOU (same-user, hard);
+  legacy-CA anchor retained (rotating breaks trust); Linux systemd supervision effectiveness.
+**D. Build-time / dispatch-gated (different threat model: build-machine or repo-write compromise):**
+  copy-bb build-time (buffering/TOCTOU/gzip-bomb/xattr-PATH); build-frontend manifest guard gaps; release/
+  publish CI (output-injection, auth_probe, tag≠sha, dispatch-ref secrets); legacy-role (F-005 tracked).


### PR DESCRIPTION
## What

Three F-005 leftovers recovered during worktree cleanup (written during the campaign, never committed — verified absent from PR #388's tip too), plus the standing feed monitor.

### 1. `update-feed-health.yml` — daily probe of the live updater feed

The feed was **silently dead ~6 weeks** after `deploy-landing`'s `s3 sync --delete` wiped `latest.json`; nothing reads the feed back after release day. Daily, credential-free (public URL + default token):

- HTTP 200 (the outage that actually happened — note: S3/CloudFront returns **403** for a missing key, so the check is `!= 200`, not `== 404`)
- valid JSON + `manifest` / `manifest_sig` / `version` / `platforms` present
- `manifest_sig` non-empty (F-004 envelope intact)
- **not stale**: `version` == latest stable GitHub release (a frozen feed 200s forever)
- all 4 platform artifacts resolve (1-byte range request)

Verified against the live feed (5/5 pass) and with 7 mutated-feed negative controls (7/7 caught).

### 2. `publish-testnet.yml` — `assert-main` gate

npm trusted publishing is **not ref-scoped** and `publish-sdk` runs before the AWS leg (which IS ref-scoped via OIDC `sub=main`). An off-main dispatch would publish to npm irreversibly, then fail at AWS. Now both side-effecting jobs `needs: assert-main`; `deploy-app` additionally checks `needs.assert-main.result == 'success'` explicitly because its `!cancelled()` overrides skipped-needs propagation.

### 3. `release-accelerator.yml` — main-ref assert + `--verify-tag`

- "Assert main ref" as the first step of `validate`, which all 17 jobs depend on transitively (verified by job-graph walk) — matches the release role's `sub=main` OIDC trust, and stops off-main dispatches **before** artifacts get signed with the production updater key.
- `--verify-tag` on both `gh release create` calls: without it, a skipped `tag` job lets the release step silently mint the tag from arbitrary HEAD. Refusal semantics probed safely (`--draft` + nonexistent tag → gh aborts).

### 4. Restore the whole-branch audit chunk log

`quality-audit-2026-07-24/README.md` (raw chunk-by-chunk codex findings) was uncommitted in a worktree; its sibling artifacts already landed.

## Test plan

- [x] actionlint clean
- [x] feed probe: live-feed pass + 7 negative controls
- [x] job-graph walk: no job escapes `validate`/`assert-main` gating
- [x] `--verify-tag` refusal probed against the repo (draft, no side effect)
- [ ] **Negative dispatch tests from THIS branch (pre-merge, below)**: both guarded workflows dispatched off-main must fail at the assert step with all side-effecting jobs skipped
- [ ] Post-merge: `update-feed-health` dispatch from main green; `release-accelerator` `auth_probe=true` from main passes the assert (positive path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
