### PR TITLE
ci: plain-english user-visible strings (no audit finding IDs in UI/logs)

### DIFF
--- a/.github/workflows/accelerator.yml
+++ b/.github/workflows/accelerator.yml
@@ -165,10 +165,10 @@ jobs:
           #    MUST reject (OuterMismatch). A pass here is a regression.
           jq '.version = "9.9.9"' "$work/signed.json" > "$work/tampered.json"
           if tool verify --feed "$work/tampered.json" --pubkey "$work/pubkey.b64"; then
-            echo "::error::version-splice feed VERIFIED but must have been rejected (F-004 regression)"
+            echo "::error::version-splice feed VERIFIED but must have been rejected — signed-manifest downgrade protection regressed"
             exit 1
           fi
-          echo "splice-reject OK (F-004 downgrade attack correctly refused)"
+          echo "splice-reject OK (downgrade attack correctly refused)"
 
   lint:
     name: Lint
@@ -190,7 +190,7 @@ jobs:
       - run: bun run lint
       - name: Unit-test build scripts (copy-bb supply-chain gate)
         run: bun run --cwd packages/accelerator test:unit
-      - name: Unit-test root scripts (download-bb F-007 cache-integrity gate)
+      - name: Unit-test root scripts (download-bb cache-integrity gate)
         run: bun run test:scripts
 
   smoke:

--- a/.github/workflows/release-accelerator.yml
+++ b/.github/workflows/release-accelerator.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       auth_probe:
-        description: "F-005: prove the release OIDC role assumes correctly, then STOP — only validate + the AWS trust preflight run (no build/e2e/tag/release/publish)"
+        description: "Probe only: verify the release AWS role still assumes correctly, then stop. Runs validate + the AWS trust preflight; skips build/e2e/tag/release/publish."
         required: false
         type: boolean
         default: false

--- a/.github/workflows/update-feed-health.yml
+++ b/.github/workflows/update-feed-health.yml
@@ -59,7 +59,7 @@ jobs:
           # 3. The F-004 signed envelope is actually present. An empty signature would mean
           #    clients fall back to trusting the plain feed body.
           if [ -z "$(jq -r '.manifest_sig // empty' feed.json)" ]; then
-            echo "::error::manifest_sig is empty — the F-004 signed-manifest envelope is broken"
+            echo "::error::manifest_sig is empty — the signed-manifest envelope is broken"
             exit 1
           fi
 


### PR DESCRIPTION
The `auth_probe` dispatch-UI description led with `F-005:` — audit finding IDs are meaningless noise to anyone at the dispatch form or reading logs. Rewrote all 5 user-visible occurrences (1 input description, 1 step name, 3 echo/error strings) in plain English; the ~51 comment-only references stay, as they're the traceability layer into `audit/` and `implementations-plan/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)