### PR TITLE
fix(accelerator): stop copied instances stealing recovery and poisoning the update marker

### DIFF
--- a/.github/workflows/smoke-updater-windows.yml
+++ b/.github/workflows/smoke-updater-windows.yml
@@ -30,7 +30,7 @@ on:
         required: false
         default: barrier
         type: choice
-        options: [barrier, positive, negative]
+        options: [barrier, copy-initiator, positive, negative]
       n-version:
         description: Version to stamp on the in-job N build
         required: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,12 @@ Before writing any code:
 ### Validation
 
 - **Code changes**: `bun run lint` and `bun run test`
+- **Platform-gated Rust** (`#[cfg(windows)]` / `target_os` branches): also
+  `cargo check --target x86_64-pc-windows-gnu --lib` from `src-tauri` — Linux-only checks cannot see
+  a Windows compile break (twice bitten: a `pub(crate)` visibility error, and a `cfg` attribute
+  detached from its function). Needs a one-off empty, gitignored
+  `binaries/bb-x86_64-pc-windows-gnu.exe` placeholder for tauri-build's sidecar check; ~5s
+  incremental. Clippy warnings on that target are test-only noise (CI's clippy gate is ubuntu-only).
 - **Workflow changes**: `bun run lint:actions`
 - **New tests**: Run the specific test file first
 - **Before pushing**: Run full `bun run test` + `bun run lint:actions`

--- a/implementations-plan/arc-bug-hunt/log.md
+++ b/implementations-plan/arc-bug-hunt/log.md
@@ -151,3 +151,60 @@ mutation-tested (inject the string ⇒ 1 fail; remove ⇒ 12 pass).
 Checked clean (r3): the currentUser destination mirror vs the 2.8.1 template; the old publisher
 key ignored by both sides; 8.3 names, casing, junctions, trailing separators converge through
 canonicalization; fresh explicit ON; macOS and Linux non-AppImage; the SHA-based copy assert.
+
+### Validation runs 3+4 (30501446852 copy-initiator, 30501460093 barrier): both GREEN on the r3 code
+
+barrier passing matters as much as the new mode: it proves the ownership gate did not break the
+marker-removal transaction's own rearm path.
+
+## Round 4 (resumed): 4 findings, 1 release-blocking — the High is a correction to r3's correction
+
+**r4 #1 — CONFIRMED (High, fixed): allowing `Unreadable` to arm reopened the original theft.**
+Concrete Windows path, verified in the source: endpoint management writes a WORKING Run value with
+arguments (`"C:\Installed\AztecAccelerator.exe" --managed`); `run_value_candidates` rejects
+trailing arguments as "not the owned format" (`autostart.rs:556`) ⇒ `Unreadable`, while
+`artifact_present` reads presence WITHOUT parsing ⇒ intent still ON. So my r3 "allow Unreadable"
+let a stray copy arm recovery at itself — the exact F1 bug, reachable via startup rearm and via the
+updater guard.
+**Fix**: `Unreadable` DECLINES again; `Broken` still arms (that is what fixed r3 #1's stranding,
+and it is the rename-boundary case that affects every user). The final rule: arm iff proven-ours,
+Broken, or Absent; decline iff proven-foreign or unknowable.
+**Disagreement with codex, deliberate**: it proposed a per-caller policy matrix (allow unknown at
+reconcile, decline at startup/guard). Rejected as machinery for a rare configuration — a single
+rule kills the theft in all three contexts and keeps the boundary convergence. The cost is stated
+as an ACCEPTED RESIDUAL in the code: unparseable/managed entries get no implicit rearm, so after an
+update their recovery task stays disarmed until an explicit toggle or Repair. Safety over
+availability, matching the module's standing "never act on what we don't understand" doctrine (the
+heal refuses `Unreadable` too). Noted for later: arming recovery at the INSTALL DESTINATION rather
+than `current_exe` would give both properties, but it changes audited crash-recovery serialization
+on all three platforms — not worth it now.
+
+**r4 #2 — CONFIRMED (Medium, fixed): the "before any state change" abort still wrote `pending`.**
+`record_pending` ran before the destination lookup, so a bad install-location value aborted with
+`pending = candidate` recorded. F-004's `candidate_allowed` then requires `candidate >= pending`
+(`core/src/updater_state.rs:113-130`) — a WITHDRAWN release would block the fixed, lower-but-newer
+one forever. Fix: the lookup now precedes `record_pending` too, so the abort truly mutates nothing.
+
+**r4 #3 — ACCEPTED residual (Medium): cached destination vs a concurrent registry writer.**
+Between our read and NSIS's own `.onInit` re-read, another installer/management agent could
+rewrite the install-location key; the marker would then predict A while NSIS installs at B, and
+with A still present, proven-absence cannot rescue it. Unfixable without cooperation from the
+installer (the window exists regardless of where we read), rare (requires a concurrent writer),
+and BOUNDED: the marker expires on its in-payload deadline and the next launch removes it via the
+Expire path. Documented, not coded.
+
+**r4 #4 — CONFIRMED (Medium, fixed): the marker-armed proof was neither fresh nor run-scoped.**
+It asserted PRESENCE across a persistent daily log — and copy mode launches the installed N−1
+first (for the launch proof), whose own 5-second update poll can arm a marker before it is killed.
+So P's line could satisfy a check meant to prove Q armed one. Fix: baseline the count before the
+copy launches; require an increase. (Same class as round 1's D22 milestone fix — presence asserts
+in append-only logs need baselines.)
+
+Checked clean (r4): AppImage compares against `$APPIMAGE`; Windows callers use `current_exe`;
+macOS canonicalization agrees with plist classification; the destination mirror is correct absent an
+external writer; the installer_arg pin catches singular and plural builder methods.
+
+**Loop judgement (codex, asked explicitly): CONTINUE for one focused round**, targeting the
+unknown-owner policy across the three arming contexts, then STOP — after that, residual risk should
+be dominated by real-release/real-fleet behaviour rather than more static rereading. Round 5 is
+scoped exactly to that.

--- a/implementations-plan/arc-bug-hunt/log.md
+++ b/implementations-plan/arc-bug-hunt/log.md
@@ -241,3 +241,34 @@ a TRULY ACL-unreadable entry cannot be repaired from inside the app (Repair skip
 management must restore access. Destination hoisting and the run-baselined marker proof hold.
 
 Loop judgement: CONTINUE narrowly — audit only these two fix paths, then STOP.
+
+### CI caught what every local gate structurally could not: a misplaced `cfg` boundary
+
+PR #429's macOS legs failed to COMPILE (`enable_impl` defined multiple times; `SYSTEMD_NAME`,
+`systemd_exec_start`, `recovery_target` not found). Cause: my r5 #2 edit inserted `recovery_target`
++ the reopened `fn enable_impl` header BETWEEN the linux `#[cfg(target_os = "linux")]` attribute and
+the function it guarded. The cfg then applied to `recovery_target`, and `enable_impl` — one of THREE
+platform variants — lost its gate entirely, so it was compiled on every target and collided with
+the macOS/Windows definitions. On Linux everything still compiled, which is exactly why the local
+gate passed. Second occurrence of this class in the arc (piece 2's `pub(crate)` E0603 was the
+first): **anchor-based edits near cfg attributes can silently move an item out of its gate, and a
+single-platform build cannot see it.**
+
+Fix: restore attribute adjacency (each of the three `enable_impl`s verified gated by an awk pass
+over the file).
+
+**New local capability — a REAL second-platform compile gate.** Earlier in this session I claimed
+Windows-only code "cannot be compiled locally" (the msvc target dies cross-compiling ring/aws-lc-sys
+C deps). That claim was wrong for `x86_64-pc-windows-gnu`: mingw is present, and the only blocker
+was tauri-build wanting a sidecar for the triple. With an empty, gitignored
+`binaries/bb-x86_64-pc-windows-gnu.exe` placeholder:
+
+    cargo check  --target x86_64-pc-windows-gnu --lib
+    cargo clippy --target x86_64-pc-windows-gnu --all-targets   # warnings here are test-only noise;
+                                                                # CI's clippy gate is ubuntu-only
+
+**Mutation-proved live**: a deliberate type error inside the Windows-only
+`nsis_install_destination()` makes the check fail; reverting restores green. So this gate really
+does compile the `cfg(windows)` paths — it would have caught BOTH platform breaks in this arc.
+Cost: ~5s incremental after the first build. This belongs in the local gate for any change touching
+platform-gated code.

--- a/implementations-plan/arc-bug-hunt/log.md
+++ b/implementations-plan/arc-bug-hunt/log.md
@@ -297,3 +297,39 @@ Also recorded this round: an anchor-based edit half-applied (the `crash_recovery
 uniqueness assert after rustfmt reflowed the signature, while the `autostart` half had already been
 written). The asserts did their job — nothing silent — but the lesson stands: re-read the on-disk
 shape after any formatter run before the next anchored edit.
+
+## Round 7 (close-out): 0 findings — STOP
+
+The provenance fix is sound per the AppImage spec: `APPDIR` IS the mounted AppDir and the payload
+executable is contained by it, so containment is the correct ownership proof. Canonicalization
+covers symlinked mounts; `Path::starts_with` is component-aware (trailing separators and prefix
+collisions are safe); `TMPDIR` only changes the value, nothing is hardcoded; extract-and-run
+extracts to an AppDir and still passes; a manually-run extracted `AppRun` lacks the runtime pair and
+falls back safely to the stable extracted executable. A false ACCEPT needs a spoofed `APPDIR=/`
+(which already implies control of our launch environment) or genuine containment. No widening
+warranted.
+
+**Loop verdict: converged.** Seven rounds: 3 findings (r1) → 2 High (r2) → 5 (r3, all created by
+r2's fixes) → 4 (r4) → 3 (r5, incl. a pre-existing AppImage bug) → 1 Medium (r6) → 0 (r7).
+
+## RESIDUAL LIST (what only the real world can surface), ranked likelihood × impact
+
+1. **Release-only v1.0.7 → renamed-N boundary — medium × high.** Only a real release run executes
+   the split-name call path. DETECT: the mandatory Windows release smoke already built for this
+   (old/new binary names via `-N1BinaryName`, N−1 health proof, transaction reconciliation, the
+   old-exe-deleted assert). An `X.Y.Z-rc.N` dry-run executes it without publishing.
+2. **Managed/unparseable autostart entry — low × high.** An update can leave crash recovery
+   disarmed until an explicit OFF→ON; a truly ACL-unreadable entry needs management intervention
+   (Repair skips Unreadable). DETECT: search logs/support for
+   `implicit crash-recovery arm skipped`, then inspect the Run value + scheduled task.
+3. **AppImage / service-manager diversity — low × medium-high.** No-FUSE users on
+   `--appimage-extract-and-run`, unusual systemd user environments, older runtimes: unexercised.
+   DETECT: a forced-crash smoke in a no-FUSE VM plus `systemctl --user status`.
+4. **Concurrent Windows install-location writer — very low × medium.** A registry change between
+   our read and NSIS's re-read suppresses reconciliation until marker expiry (self-heals).
+   DETECT: path-mismatch/suppression log lines; ask whether another installer or management agent
+   ran concurrently.
+5. **Fixture provenance — very low × high.** Tag metadata does not prove the downloaded asset came
+   from that commit. DETECT: release attestation or a recorded asset digest tied to the tag.
+6. **Publisher-flip interactive trust loss — dev-only × low production impact.** DETECT: one
+   interactive upgrade/reinstall canary; support reports of an unexpected trust prompt.

--- a/implementations-plan/arc-bug-hunt/log.md
+++ b/implementations-plan/arc-bug-hunt/log.md
@@ -26,3 +26,57 @@ Checked-and-clean (codex, round 1): both name-regimes of the ps1 (dispatch same-
 split-name) incl. Q/$expectedHeal/boundary asserts; rename-aware marker reconciliation;
 publisher-flip silent-install default-dir resolution without registry continuity; sentinel
 injection; signing-key cleanup; identity assertions as written.
+
+## Round 2 (resumed, same session): 2 findings, BOTH release-blocking, both product bugs
+
+Self-critique it offered first: round 1 framed Q only as a hostile observer inside an existing
+marker window, so it never looked at a copy's ORDINARY startup or a copy that OWNS an update.
+
+**F1 — CONFIRMED (High, fixed): any copied instance steals the crash-recovery task.**
+`startup_rearm` gates on lock + no-live-marker + `intent_enabled_now()`, but intent only means
+"an entry exists and isn't platform-disabled" (`autostart.rs:1236`) — it never asks WHO this
+process is. `enable_crash_recovery()` then serializes `current_exe()` into the task XML
+(`crash_recovery.rs:384`) / systemd ExecStart. So launching a leftover `Downloads` copy once —
+even while the installed app is healthy — re-points recovery at the copy, which then exits on the
+port check. Delete the copy, crash the real app: recovery launches a deleted path forever. Piece 1
+forbade exactly this theft for the Run value (`points_elsewhere`: "a healthy entry is never
+silently stolen by whichever copy launched last") — the TASK had no such rule. The barrier smoke
+could not see it: its Q runs inside a live marker, where rearm is suppressed anyway.
+**Fix**: `implicit_arm_allowed` (pure, table-tested) + `implicit_arm_gate` (effectful) — implicit
+arming paths (startup rearm, reconcile's arm callback, the updater guard's rearm) require
+`Healthy { points_elsewhere: false }`; explicit user toggles/repair stay ungated (they mean "arm
+THIS exe"); macOS exempt (its recovery patches the stored entry itself and cannot steal).
+Rename-boundary safety: at reconcile the stored value is still Broken (old exe deleted), so the
+gate declines there and the same-launch `startup_rearm` arms after the heal makes us the owner.
+
+**F2 — CONFIRMED (High, fixed): a copy that owns an update poisons `expected_install_path`.**
+`updater.rs` recorded `current_exe` with a comment asserting in-place replacement — false when a
+copy drives the install: the updater passes `/UPDATE` and NO `/D`, so NSIS resolves `$INSTDIR`
+itself and installs at P. N then sees `expected != exe_canon` with the copy still present (absence
+unprovable) → reconciliation suppressed → heal/rearm/updates blocked and recovery left disarmed
+until deadline + another launch.
+**Fix (codex option C, chosen over an ownership gate on update-initiation)**: record what the
+INSTALLER will use — a pure mirror of `RestorePreviousInstallLocation` (`installer.nsi:873-877`):
+MANUPRODUCTKEY default value when non-empty, else `%LOCALAPPDATA%\<productName>`, joined with the
+binary name. Registry NotFound ⇒ default; any OTHER registry error ⇒ ABORT the update rather than
+publish a guessed marker. Option A (gate initiation) was rejected because it leaves
+autostart-OFF users and copies that legitimately own an entry unprotected; option B (accept as
+TTL residual) leaves ON users with recovery disarmed until another launch.
+Pre-#427 installs wrote the OLD manufacturer namespace, so they resolve NotFound → default —
+which is exactly where those (default-dir, dev-only) installs live, so the mirror stays faithful.
+
+**Tests added** (codex's required list, minus the one it asked for that we judged covered):
+resolver decision table (registry / blank / missing / undeterminable); implicit-arm decision
+table; `tauri-identity.test.ts` pins every input to the destination mirror (Rust consts vs
+productName + publisher + binary name, `installMode: currentUser`, no `/D` or installerArgs) —
+and that new assert was MUTATION-TESTED (drift the registry path ⇒ 1 fail; restore ⇒ 11 pass);
+new dispatch-only smoke mode **`copy-initiator`** — the copy drives the update with the copy
+retained and autostart OFF, asserting N lands in the install dir, the transaction is fully
+reconciled away, the copy still exists (so proven-absence can't mask a wrong path), and NO
+crash-recovery task was armed. That single mode is the end-to-end regression proof for both F1
+(OFF-intent implicit arm) and F2.
+
+Windows-only code could not be compiled locally (cross-compiling the C deps — ring/aws-lc-sys —
+needs a Windows C toolchain we don't have). Mitigation: the winreg API was verified against the
+vendored 0.55 sources (`io::Result` on both calls, empty-name default-value read) and the exact
+idiom already proven on Windows in `autostart.rs`; CI's Windows legs compile it.

--- a/implementations-plan/arc-bug-hunt/log.md
+++ b/implementations-plan/arc-bug-hunt/log.md
@@ -80,3 +80,16 @@ Windows-only code could not be compiled locally (cross-compiling the C deps — 
 needs a Windows C toolchain we don't have). Mitigation: the winreg API was verified against the
 vendored 0.55 sources (`io::Result` on both calls, empty-name default-value read) and the exact
 idiom already proven on Windows in `autostart.rs`; CI's Windows legs compile it.
+
+### Validation run 1 (30499816033): the regression test's OWN assert was malformed
+
+`copy-initiator` failed — on my assert, not the product. Order matters: every earlier assert
+passed, including the two that carry the proof (transaction files GONE ⇒ N reconciled the
+copy-initiated marker, i.e. the F2 fix works end-to-end; and N present in the install dir). The
+failure was `Test-Path $QDir\AztecAccelerator.exe` → "N was installed BESIDE the copy", which is
+trivially TRUE because on the dispatch path the copy has the SAME file name as N. A name-existence
+check cannot distinguish "the installer wrote N here" from "the copy I made is still here".
+Replaced with a SHA-256 before/after comparison of the copy's own bytes — the property actually
+being claimed. Lesson: when two things share a name, identity asserts must key on content, not
+existence; the dual name-regime introduced by the rename makes this a recurring trap in this
+script.

--- a/implementations-plan/arc-bug-hunt/log.md
+++ b/implementations-plan/arc-bug-hunt/log.md
@@ -272,3 +272,28 @@ was tauri-build wanting a sidecar for the triple. With an empty, gitignored
 does compile the `cfg(windows)` paths — it would have caught BOTH platform breaks in this arc.
 Cost: ~5s incremental after the first build. This belongs in the local gate for any change touching
 platform-gated code.
+
+## Round 6 (narrow close-out): the two r5 High fixes are CLEAN; 1 Medium
+
+Verified clean by codex: the gated cleanup (a decline still removes the marker, no double-arm, no
+strand; `current_exe` IS the right cleanup reference because it is exactly what the Windows writer
+would serialize), the AppImage `ExecStart` flowing correctly through F-010 (spaces/`%` serialize
+safely; unsafe or relative paths still fail CLOSED and remove the unit; no sibling Linux writer
+still uses the mount path), and macOS matching its former unconditional behaviour.
+
+**r6 #1 — CONFIRMED (Medium, fixed): `$APPIMAGE` was trusted without provenance.**
+`APPIMAGE`/`APPDIR` are ordinary environment variables and are INHERITED by children. Launch a
+natively-installed (deb) Accelerator from a terminal that is itself running inside some other
+AppImage and we would read that PARENT's `APPIMAGE` — valid, absolute, F-010-safe — and write it as
+the systemd recovery target, so recovery would relaunch a different application. `desired_path`
+(piece 1, pre-existing) trusted the same variable, so explicit autostart-ON could write the foreign
+path into the launcher entry too.
+**Fix**: one pure `appimage_self(appimage, appdir, exe)` — trust `$APPIMAGE` only when our
+`current_exe()` lives under `$APPDIR` (for a genuine AppImage run our binary IS inside the mount;
+for an inherited value it is `/usr/bin/…` and fails) — shared by BOTH consumers so they cannot
+diverge, plus a provenance table test. Note this also fixes a pre-existing piece-1 autostart bug.
+
+Also recorded this round: an anchor-based edit half-applied (the `crash_recovery` half failed its
+uniqueness assert after rustfmt reflowed the signature, while the `autostart` half had already been
+written). The asserts did their job — nothing silent — but the lesson stands: re-read the on-disk
+shape after any formatter run before the next anchored edit.

--- a/implementations-plan/arc-bug-hunt/log.md
+++ b/implementations-plan/arc-bug-hunt/log.md
@@ -93,3 +93,61 @@ Replaced with a SHA-256 before/after comparison of the copy's own bytes — the 
 being claimed. Lesson: when two things share a name, identity asserts must key on content, not
 existence; the dual name-regime introduced by the rename makes this a recurring trap in this
 script.
+
+### Validation run 2 (30500599861): copy-initiator GREEN on real Windows
+
+"copy-driven update installed at the install dir, transaction fully reconciled with the copy still
+present, and no crash-recovery task armed" — the end-to-end regression proof for F1 (OFF-intent
+implicit arm) and F2 (destination mirror). Note this run predates the round-3 fixes below; re-run
+after them.
+
+## Round 3 (resumed): 5 findings, 3 release-blocking — ALL introduced by my round-2 fixes
+
+The loop's most valuable round: the fixes themselves were the bug source.
+
+**r3 #1 — CONFIRMED (High, fixed): the gate could strand recovery permanently.**
+`gated_enable_crash_recovery` returned `Ok(())` when it DECLINED, so reconciliation treated a
+decline as a successful arm and deleted the marker. On the rename boundary with a read-only/ACL'd
+autostart entry (readable, not writable): entry is `Broken` (old exe deleted) → gate declined →
+marker removed → heal failed to write → every later rearm kept declining the still-`Broken`
+entry. Crash recovery gone permanently, nothing left to converge it. Same for a parse-unreadable
+artifact.
+**Fix — the rule is now narrowed to exactly the theft it must stop**: decline ONLY
+`Healthy { points_elsewhere: true }` (another live binary provably owns a working entry). `Broken`
+arms (nobody owns a working entry; whoever launched becomes owner — precisely what the heal writes
+next, so this matches piece 1's audited resolve-based semantics). `Unreadable`/`Absent` arm (no
+proof of theft; declining would silently drop recovery for endpoint-managed users). This mirrors
+piece 2's proven-absence epistemics: act only on what can be PROVEN, and never let an unprovable
+state become permanent.
+
+**r3 #2 — CONFIRMED (High, fixed): the new abort path ran after the global disarm.**
+`nsis_install_destination()` was called inside the critical section — after `record_pending` and
+after `disable_crash_recovery()`. An unreadable registry therefore aborted with an installed
+instance's recovery task already deleted and no marker to reconcile it back (and the guard's
+ownership-gated rearm correctly refuses when a copy is the initiator). **Fix**: hoist the
+destination resolution above the critical section — it is a read-only registry+env lookup, so an
+error now aborts before ANY state changes.
+
+**r3 #3 — CONFIRMED (High, fixed): AppImage owners could never pass the gate.**
+Linux autostart deliberately stores the real `.AppImage` path while `current_exe()` is the
+ephemeral `/tmp/.mount_*` squashfs (`desired_path`, D12) — so my gate computed
+`points_elsewhere: true` on EVERY AppImage launch. After a logout destroyed the mount recorded in
+the systemd unit, no launch would ever rewrite it. **Fix**: the gate takes the ownership
+`reference` as a parameter; the Linux/macOS caller passes `desired_path(app)` (which resolves
+`$APPIMAGE`), Windows callers pass `current_exe()` (no AppImage indirection there). The pure
+decision table never modelled this identity split — the lesson is that a "pure core" only tests
+the logic, not whether callers feed it the right identity.
+
+**r3 #4 — CONFIRMED (Medium, fixed): copy mode could pass without a marker ever existing.**
+It only asserted the transaction files were ABSENT afterwards, which also holds if marker creation
+was skipped entirely. `updater.rs` now logs `update window marker armed` on successful create
+(D24-safe: version only) and the smoke requires that line before trusting the absence assert.
+
+**r3 #5 — CONFIRMED (Medium, fixed): the `/D` pin missed runtime builder args.**
+A `.installer_arg("/D=…")` on the updater builder would redirect NSIS while both conf-level
+assertions stayed green. The identity test now greps all Rust sources for `installer_arg` —
+mutation-tested (inject the string ⇒ 1 fail; remove ⇒ 12 pass).
+
+Checked clean (r3): the currentUser destination mirror vs the 2.8.1 template; the old publisher
+key ignored by both sides; 8.3 names, casing, junctions, trailing separators converge through
+canonicalization; fresh explicit ON; macOS and Linux non-AppImage; the SHA-based copy assert.

--- a/implementations-plan/arc-bug-hunt/log.md
+++ b/implementations-plan/arc-bug-hunt/log.md
@@ -208,3 +208,36 @@ external writer; the installer_arg pin catches singular and plural builder metho
 unknown-owner policy across the three arming contexts, then STOP — after that, residual risk should
 be dominated by real-release/real-fleet behaviour rather than more static rereading. Round 5 is
 scoped exactly to that.
+
+## Round 5 (resumed, scoped to the target codex itself named): 3 findings, 2 release-blocking
+
+**r5 #1 — CONFIRMED (High, fixed): the marker cleanup paths bypassed the gate.**
+Three `post_create_failure_cleanup` call sites (`updater.rs`) passed the RAW
+`enable_crash_recovery`. So a copy-initiated update whose marker publication / handoff write /
+install FAILED would still re-arm recovery at the COPY on the way out — the F1 theft, reached
+through the failure path instead of the happy path. The copy smoke only exercises a SUCCESSFUL
+install, and the existing cleanup unit tests inject ordering counters, not ownership. Fixed: all
+three cleanups now take `gated_enable_crash_recovery` (made `pub(crate)`).
+
+**r5 #2 — CONFIRMED (High, fixed) — and PRE-EXISTING, not introduced by this work.**
+My r3 AppImage fix corrected only the gate's COMPARISON path; `crash_recovery::enable_impl`
+(Linux) still serialized `current_exe()` into `ExecStart`, which inside an AppImage is the
+ephemeral `/tmp/.mount_*` squashfs. The recovery unit therefore pointed at a path that vanishes
+exactly when recovery is needed — for every AppImage user, since before this arc. Fixed with a pure
+`recovery_target(appimage, exe)` helper (prefers `$APPIMAGE`, ignores an empty value) + unit table.
+This is the arc's clearest evidence for hunting the same code repeatedly: four rounds of ownership
+work were needed before anyone looked at what the writer actually writes.
+
+**r5 #3 — CONFIRMED (Medium, fixed): macOS lost its exemption.**
+Parameterising the gate made the whole non-Windows branch gate, including macOS — but macOS
+crash recovery patches KeepAlive into the app's own fixed plist and writes NO executable path, so
+it cannot steal; gating it only widened the `Unreadable` residual (a managed plist using `Program`
+instead of the owned `ProgramArguments` shape classifies Unreadable). macOS arms unconditionally
+again; Linux keeps the AppImage-aware gate.
+
+Checked clean (r5): in all three Windows arming contexts a declined reconcile arm still removes the
+marker without double-arming; parse-unreadable users recover via OFF→ON. Honest limit it noted:
+a TRULY ACL-unreadable entry cannot be repaired from inside the app (Repair skips Unreadable) —
+management must restore access. Destination hoisting and the run-baselined marker proof hold.
+
+Loop judgement: CONTINUE narrowly — audit only these two fix paths, then STOP.

--- a/packages/accelerator/scripts/tauri-identity.test.ts
+++ b/packages/accelerator/scripts/tauri-identity.test.ts
@@ -57,6 +57,36 @@ describe("bundle metadata", () => {
   });
 });
 
+describe("NSIS install-destination mirror (arc-hunt r2 F2)", () => {
+  // update_marker.rs computes the marker's expected_install_path by MIRRORING what NSIS will do:
+  // MANUPRODUCTKEY (Software\<publisher>\<productName>) default value, else
+  // %LOCALAPPDATA%\<productName>, plus the binary name. Every input to that mirror is pinned
+  // here — if one drifts, the marker starts pointing somewhere the installer never writes and
+  // reconciliation silently suppresses heal/rearm until the deadline.
+  const marker = fs.readFileSync(path.join(SRC_TAURI, "src", "update_marker.rs"), "utf8");
+
+  test("Rust consts match the conf values the installer derives $INSTDIR from", () => {
+    expect(marker).toContain(`MAIN_BINARY_EXE: &str = "${BIN}.exe"`);
+    expect(marker).toContain(`PRODUCT_DIR_NAME: &str = "${conf.productName}"`);
+    // The registry namespace is Software\\<publisher>\\<productName>; publisher is pinned above.
+    const updater = fs.readFileSync(path.join(SRC_TAURI, "src", "updater.rs"), "utf8");
+    const regPath = `r"Software\\${conf.bundle.publisher}\\${conf.productName}"`;
+    expect(regPath).toBe(String.raw`r"Software\Aztec Accelerator\Aztec Accelerator"`); // guards the builder itself
+    expect(updater).toContain(regPath);
+  });
+
+  test("per-user install mode (the default-dir half of the mirror)", () => {
+    expect(conf.bundle.windows.nsis.installMode).toBe("currentUser");
+  });
+
+  test("no installer argument may override $INSTDIR", () => {
+    // A /D flag (or nsis.installerArgs carrying one) would make NSIS install somewhere the
+    // mirror cannot predict. The updater passes /UPDATE only.
+    expect(conf.bundle.windows.nsis.installerArgs).toBeUndefined();
+    expect(JSON.stringify(conf.plugins.updater)).not.toContain("/D");
+  });
+});
+
 describe("CI/scripts reference the renamed binary (lockstep sites)", () => {
   const expectContains = (rel: string, needle: string) => {
     const body = fs.readFileSync(path.join(REPO, rel), "utf8");

--- a/packages/accelerator/scripts/tauri-identity.test.ts
+++ b/packages/accelerator/scripts/tauri-identity.test.ts
@@ -79,6 +79,17 @@ describe("NSIS install-destination mirror (arc-hunt r2 F2)", () => {
     expect(conf.bundle.windows.nsis.installMode).toBe("currentUser");
   });
 
+  test("no RUNTIME installer arg is passed to the updater builder", () => {
+    // A `.installer_arg("/D=...")` on the updater builder would make NSIS install where the
+    // marker's mirror cannot predict, and the conf-level pins below would stay green (r3 #5).
+    const rustSrc = fs
+      .readdirSync(path.join(SRC_TAURI, "src"), { recursive: true })
+      .filter((f): f is string => typeof f === "string" && f.endsWith(".rs"))
+      .map((f) => fs.readFileSync(path.join(SRC_TAURI, "src", f), "utf8"))
+      .join("\n");
+    expect(rustSrc).not.toContain("installer_arg");
+  });
+
   test("no installer argument may override $INSTDIR", () => {
     // A /D flag (or nsis.installerArgs carrying one) would make NSIS install somewhere the
     // mirror cannot predict. The updater passes /UPDATE only.

--- a/packages/accelerator/scripts/updater-smoke-windows.ps1
+++ b/packages/accelerator/scripts/updater-smoke-windows.ps1
@@ -369,6 +369,12 @@ try {
     }
     if (-not $updated) { Dump-Logs; Write-Error "copy-initiator FAILED — /health never reported $NVersion; the copy-driven update did not complete."; exit 1 }
 
+    # The transaction must have EXISTED: "files absent afterwards" alone also passes if marker
+    # creation was skipped entirely and the install proceeded (r3 #4). updater.rs logs
+    # "update window marker armed" on successful create — require it.
+    if (-not (Select-String -Path "$env:LOCALAPPDATA\aztec-accelerator\logs\*.log" -Pattern "update window marker armed" -ErrorAction SilentlyContinue)) {
+      Dump-Logs; Write-Error "copy-initiator INCONCLUSIVE — no 'update window marker armed' log line: the copy never created a marker, so the reconciliation assert below would pass vacuously."; exit 1
+    }
     # THE regression assert: N (relaunched from the INSTALL dir) reconciled the transaction away.
     # Pre-fix the marker held the copy's path, N's exe_canon differed, the copy still existed
     # (so absence was not provable) and reconciliation was suppressed — leaving these behind.

--- a/packages/accelerator/scripts/updater-smoke-windows.ps1
+++ b/packages/accelerator/scripts/updater-smoke-windows.ps1
@@ -345,6 +345,12 @@ try {
     Copy-Item -Recurse -Force $InstallRoot $QDir
     $CopyExe = Get-ChildItem -Path $QDir -Recurse -Filter $N1BinaryName | Select-Object -First 1
     if (-not $CopyExe) { Write-Error "copy-initiator — copied exe ($N1BinaryName) not found under $QDir"; exit 1 }
+    # Baseline the marker-armed log count BEFORE the copy runs: the installed N-1 was launched
+    # earlier for the launch proof and its own 5s update poll may already have armed a marker, and
+    # daily log files persist — so mere PRESENCE of the line could come from P, not the copy
+    # (r4 #4). Only an INCREASE attributable to the copy counts.
+    $AppLogGlob = "$env:LOCALAPPDATA\aztec-accelerator\logs\*.log"
+    $MarkerLogBefore = @(Select-String -Path $AppLogGlob -Pattern "update window marker armed" -ErrorAction SilentlyContinue).Count
     # Hash the copy BEFORE the update: on the dispatch path the copy has the SAME file name as N,
     # so "is there an AztecAccelerator.exe beside the copy" is trivially true and cannot detect an
     # install into the copy's dir. The copy's BYTES staying N-1's is what proves it (the first
@@ -372,8 +378,9 @@ try {
     # The transaction must have EXISTED: "files absent afterwards" alone also passes if marker
     # creation was skipped entirely and the install proceeded (r3 #4). updater.rs logs
     # "update window marker armed" on successful create — require it.
-    if (-not (Select-String -Path "$env:LOCALAPPDATA\aztec-accelerator\logs\*.log" -Pattern "update window marker armed" -ErrorAction SilentlyContinue)) {
-      Dump-Logs; Write-Error "copy-initiator INCONCLUSIVE — no 'update window marker armed' log line: the copy never created a marker, so the reconciliation assert below would pass vacuously."; exit 1
+    $MarkerLogAfter = @(Select-String -Path $AppLogGlob -Pattern "update window marker armed" -ErrorAction SilentlyContinue).Count
+    if ($MarkerLogAfter -le $MarkerLogBefore) {
+      Dump-Logs; Write-Error "copy-initiator INCONCLUSIVE — no NEW 'update window marker armed' line ($MarkerLogBefore -> $MarkerLogAfter): the copy never created a marker, so the reconciliation assert below would pass vacuously."; exit 1
     }
     # THE regression assert: N (relaunched from the INSTALL dir) reconciled the transaction away.
     # Pre-fix the marker held the copy's path, N's exe_canon differed, the copy still existed

--- a/packages/accelerator/scripts/updater-smoke-windows.ps1
+++ b/packages/accelerator/scripts/updater-smoke-windows.ps1
@@ -345,6 +345,11 @@ try {
     Copy-Item -Recurse -Force $InstallRoot $QDir
     $CopyExe = Get-ChildItem -Path $QDir -Recurse -Filter $N1BinaryName | Select-Object -First 1
     if (-not $CopyExe) { Write-Error "copy-initiator — copied exe ($N1BinaryName) not found under $QDir"; exit 1 }
+    # Hash the copy BEFORE the update: on the dispatch path the copy has the SAME file name as N,
+    # so "is there an AztecAccelerator.exe beside the copy" is trivially true and cannot detect an
+    # install into the copy's dir. The copy's BYTES staying N-1's is what proves it (the first
+    # version of this assert was name-based and failed on the copy's own existence).
+    $CopyHashBefore = (Get-FileHash $CopyExe.FullName -Algorithm SHA256).Hash
     Log "copy-initiator: launching the COPY ($($CopyExe.FullName)); installed dir left closed"
     $QProc = Start-Process -FilePath $CopyExe.FullName -PassThru
 
@@ -376,7 +381,9 @@ try {
     # N must be installed (and running) at the INSTALL dir, not beside the copy.
     $NewExe = Get-ChildItem -Path $InstallRoot -Recurse -Filter $NBinaryName -ErrorAction SilentlyContinue | Select-Object -First 1
     if (-not $NewExe) { Dump-Logs; Write-Error "copy-initiator FAILED — $NBinaryName absent from $InstallRoot; the installer did not target the install dir."; exit 1 }
-    if (Test-Path (Join-Path $QDir $NBinaryName)) { Dump-Logs; Write-Error "copy-initiator FAILED — N was installed BESIDE the copy ($QDir)."; exit 1 }
+    if ((Get-FileHash $CopyExe.FullName -Algorithm SHA256).Hash -ne $CopyHashBefore) {
+      Dump-Logs; Write-Error "copy-initiator FAILED — the copy's bytes changed: the installer wrote N into the copy's directory ($QDir) instead of the install dir."; exit 1
+    }
     # F1 ownership gate: autostart is OFF and no process owns an entry, so nothing may have armed
     # crash recovery — least of all the copy.
     & schtasks /Query /TN $TaskName *> $null

--- a/packages/accelerator/scripts/updater-smoke-windows.ps1
+++ b/packages/accelerator/scripts/updater-smoke-windows.ps1
@@ -34,6 +34,13 @@
                        intact, and a second instance Q fully suppressed — no heal, no rearm, no
                        second download — then release and finish positive. Requires
                        UPDATER_SMOKE_BARRIER_PREFIX (run-unique prefix, baked at N build time).
+                     | copy-initiator (arc-hunt r2 F2 regression: a COPY of the install drives the
+                       update while the installed instance is closed and the copy REMAINS on disk.
+                       The marker must record the INSTALLER's destination, not the copy's path —
+                       pre-fix, N saw a path mismatch it could not prove absent and suppressed
+                       reconciliation, stranding marker+handoff+token and skipping heal/rearm.
+                       Also proves the F1 ownership gate: autostart is OFF here, so NO
+                       crash-recovery task may exist afterwards.)
 #>
 param(
   [Parameter(Mandatory)][string]$NVersion,
@@ -319,6 +326,63 @@ try {
     }
     Log "SUCCESS (negative) — updater downloaded the tampered artifact and refused to update"
     Dump-Logs; exit 0
+  }
+
+  if ($Mode -eq "copy-initiator") {
+    # ── Arc-hunt r2 F2 regression. N-1 is installed but NEVER launched from $InstallRoot; a COPY
+    #    drives the update instead, and the copy stays on disk throughout (so the marker's
+    #    proven-absent rename-tolerance can't mask a wrong expected path). ──
+    if ($AppProc -and -not $AppProc.HasExited) { Stop-Process -Id $AppProc.Id -Force; $AppProc.WaitForExit() }
+    $AppProc = $null
+    Get-Process -Name "AztecAccelerator", "aztec-accelerator" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+    # Autostart must be OFF for this leg (no Run value armed) — that is exactly the case an
+    # ownership gate on the Run value alone would leave open, and it must still not leave a task.
+    Remove-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run" -Name "Aztec Accelerator" -ErrorAction SilentlyContinue
+    & schtasks /Delete /F /TN $TaskName *> $null
+    & schtasks /Query /TN $TaskName *> $null
+    if ($LASTEXITCODE -eq 0) { Dump-Logs; Write-Error "copy-initiator precondition FAILED — '$TaskName' survived pre-run delete; a later 'no task' assert would be meaningless."; exit 1 }
+
+    Copy-Item -Recurse -Force $InstallRoot $QDir
+    $CopyExe = Get-ChildItem -Path $QDir -Recurse -Filter $N1BinaryName | Select-Object -First 1
+    if (-not $CopyExe) { Write-Error "copy-initiator — copied exe ($N1BinaryName) not found under $QDir"; exit 1 }
+    Log "copy-initiator: launching the COPY ($($CopyExe.FullName)); installed dir left closed"
+    $QProc = Start-Process -FilePath $CopyExe.FullName -PassThru
+
+    # The copy must run (it owns :59833 now) and then drive the update to completion.
+    $sawCopy = $false
+    for ($i = 0; $i -lt 60; $i++) {
+      try { $got = (Invoke-RestMethod -Uri $HealthUrl -TimeoutSec 2).version } catch { $got = $null }
+      if ($got -eq $N1Version) { $sawCopy = $true; break }
+      Start-Sleep -Milliseconds 500
+    }
+    if (-not $sawCopy) { Dump-Logs; Write-Error "copy-initiator FAILED — the copied instance never served /health == $N1Version."; exit 1 }
+    $updated = $false
+    for ($i = 0; $i -lt 150; $i++) {
+      try { $got = (Invoke-RestMethod -Uri $HealthUrl -TimeoutSec 3).version } catch { $got = $null }
+      if ($got -eq $NVersion) { $updated = $true; break }
+      Start-Sleep -Seconds 2
+    }
+    if (-not $updated) { Dump-Logs; Write-Error "copy-initiator FAILED — /health never reported $NVersion; the copy-driven update did not complete."; exit 1 }
+
+    # THE regression assert: N (relaunched from the INSTALL dir) reconciled the transaction away.
+    # Pre-fix the marker held the copy's path, N's exe_canon differed, the copy still existed
+    # (so absence was not provable) and reconciliation was suppressed — leaving these behind.
+    foreach ($f in @("update-in-progress.json", "update-txn", "update-txn-done")) {
+      if (Test-Path (Join-Path $ConfigDir $f)) { Dump-Logs; Write-Error "copy-initiator FAILED — $f survived; the marker's expected_install_path did not match the installer's destination (arc-hunt r2 F2 regressed)."; exit 1 }
+    }
+    # The copy must STILL exist (otherwise proven-absence could have rescued a wrong path and the
+    # assert above would pass for the wrong reason).
+    if (-not (Test-Path $CopyExe.FullName)) { Dump-Logs; Write-Error "copy-initiator INCONCLUSIVE — the copied exe vanished; proven-absence could have masked a wrong expected path."; exit 1 }
+    # N must be installed (and running) at the INSTALL dir, not beside the copy.
+    $NewExe = Get-ChildItem -Path $InstallRoot -Recurse -Filter $NBinaryName -ErrorAction SilentlyContinue | Select-Object -First 1
+    if (-not $NewExe) { Dump-Logs; Write-Error "copy-initiator FAILED — $NBinaryName absent from $InstallRoot; the installer did not target the install dir."; exit 1 }
+    if (Test-Path (Join-Path $QDir $NBinaryName)) { Dump-Logs; Write-Error "copy-initiator FAILED — N was installed BESIDE the copy ($QDir)."; exit 1 }
+    # F1 ownership gate: autostart is OFF and no process owns an entry, so nothing may have armed
+    # crash recovery — least of all the copy.
+    & schtasks /Query /TN $TaskName *> $null
+    if ($LASTEXITCODE -eq 0) { Dump-Logs; Write-Error "copy-initiator FAILED — '$TaskName' exists although autostart was OFF; an implicit arm fired (arc-hunt r2 F1 regressed)."; exit 1 }
+    Log "SUCCESS (copy-initiator) — copy-driven update installed at the install dir, transaction fully reconciled with the copy still present, and no crash-recovery task armed."
+    exit 0
   }
 
   if ($Mode -eq "barrier") {

--- a/packages/accelerator/src-tauri/gen/schemas/windows-schema.json
+++ b/packages/accelerator/src-tauri/gen/schemas/windows-schema.json
@@ -189,12 +189,6 @@
           "markdownDescription": "Enables the disable_https command without any pre-configured scope."
         },
         {
-          "description": "Enables the dismiss_onboarding command without any pre-configured scope.",
-          "type": "string",
-          "const": "allow-dismiss-onboarding",
-          "markdownDescription": "Enables the dismiss_onboarding command without any pre-configured scope."
-        },
-        {
           "description": "Enables the enable_https command without any pre-configured scope.",
           "type": "string",
           "const": "allow-enable-https",
@@ -237,12 +231,6 @@
           "markdownDescription": "Enables the get_verified_info command without any pre-configured scope."
         },
         {
-          "description": "Enables the open_onboarding command without any pre-configured scope.",
-          "type": "string",
-          "const": "allow-open-onboarding",
-          "markdownDescription": "Enables the open_onboarding command without any pre-configured scope."
-        },
-        {
           "description": "Enables the record_renewal_prompt command without any pre-configured scope.",
           "type": "string",
           "const": "allow-record-renewal-prompt",
@@ -265,6 +253,12 @@
           "type": "string",
           "const": "allow-renew-cert",
           "markdownDescription": "Enables the renew_cert command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the repair_autostart command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-repair-autostart",
+          "markdownDescription": "Enables the repair_autostart command without any pre-configured scope."
         },
         {
           "description": "Enables the respond_auth command without any pre-configured scope.",
@@ -309,12 +303,6 @@
           "markdownDescription": "Denies the disable_https command without any pre-configured scope."
         },
         {
-          "description": "Denies the dismiss_onboarding command without any pre-configured scope.",
-          "type": "string",
-          "const": "deny-dismiss-onboarding",
-          "markdownDescription": "Denies the dismiss_onboarding command without any pre-configured scope."
-        },
-        {
           "description": "Denies the enable_https command without any pre-configured scope.",
           "type": "string",
           "const": "deny-enable-https",
@@ -357,12 +345,6 @@
           "markdownDescription": "Denies the get_verified_info command without any pre-configured scope."
         },
         {
-          "description": "Denies the open_onboarding command without any pre-configured scope.",
-          "type": "string",
-          "const": "deny-open-onboarding",
-          "markdownDescription": "Denies the open_onboarding command without any pre-configured scope."
-        },
-        {
           "description": "Denies the record_renewal_prompt command without any pre-configured scope.",
           "type": "string",
           "const": "deny-record-renewal-prompt",
@@ -385,6 +367,12 @@
           "type": "string",
           "const": "deny-renew-cert",
           "markdownDescription": "Denies the renew_cert command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the repair_autostart command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-repair-autostart",
+          "markdownDescription": "Denies the repair_autostart command without any pre-configured scope."
         },
         {
           "description": "Denies the respond_auth command without any pre-configured scope.",
@@ -415,48 +403,6 @@
           "type": "string",
           "const": "deny-set-speed",
           "markdownDescription": "Denies the set_speed command without any pre-configured scope."
-        },
-        {
-          "description": "This permission set configures if your\napplication can enable or disable auto\nstarting the application on boot.\n\n#### Granted Permissions\n\nIt allows all to check, enable and\ndisable the automatic start on boot.\n\n\n#### This default permission set includes:\n\n- `allow-enable`\n- `allow-disable`\n- `allow-is-enabled`",
-          "type": "string",
-          "const": "autostart:default",
-          "markdownDescription": "This permission set configures if your\napplication can enable or disable auto\nstarting the application on boot.\n\n#### Granted Permissions\n\nIt allows all to check, enable and\ndisable the automatic start on boot.\n\n\n#### This default permission set includes:\n\n- `allow-enable`\n- `allow-disable`\n- `allow-is-enabled`"
-        },
-        {
-          "description": "Enables the disable command without any pre-configured scope.",
-          "type": "string",
-          "const": "autostart:allow-disable",
-          "markdownDescription": "Enables the disable command without any pre-configured scope."
-        },
-        {
-          "description": "Enables the enable command without any pre-configured scope.",
-          "type": "string",
-          "const": "autostart:allow-enable",
-          "markdownDescription": "Enables the enable command without any pre-configured scope."
-        },
-        {
-          "description": "Enables the is_enabled command without any pre-configured scope.",
-          "type": "string",
-          "const": "autostart:allow-is-enabled",
-          "markdownDescription": "Enables the is_enabled command without any pre-configured scope."
-        },
-        {
-          "description": "Denies the disable command without any pre-configured scope.",
-          "type": "string",
-          "const": "autostart:deny-disable",
-          "markdownDescription": "Denies the disable command without any pre-configured scope."
-        },
-        {
-          "description": "Denies the enable command without any pre-configured scope.",
-          "type": "string",
-          "const": "autostart:deny-enable",
-          "markdownDescription": "Denies the enable command without any pre-configured scope."
-        },
-        {
-          "description": "Denies the is_enabled command without any pre-configured scope.",
-          "type": "string",
-          "const": "autostart:deny-is-enabled",
-          "markdownDescription": "Denies the is_enabled command without any pre-configured scope."
         },
         {
           "description": "Default core plugins set.\n#### This default permission set includes:\n\n- `core:path:default`\n- `core:event:default`\n- `core:window:default`\n- `core:webview:default`\n- `core:app:default`\n- `core:image:default`\n- `core:resources:default`\n- `core:menu:default`\n- `core:tray:default`",

--- a/packages/accelerator/src-tauri/src/autostart.rs
+++ b/packages/accelerator/src-tauri/src/autostart.rs
@@ -1440,7 +1440,7 @@ pub fn startup_reconcile() -> bool {
             &running,
             &exe_canon,
             &intent_enabled_now,
-            &crate::crash_recovery::enable_crash_recovery,
+            &gated_enable_crash_recovery,
             &crate::crash_recovery::disable_crash_recovery,
         ) {
             crate::update_marker::ReconcileOutcome::Proceed => true,
@@ -1449,6 +1449,73 @@ pub fn startup_reconcile() -> bool {
                 false
             }
         }
+    }
+}
+
+/// Arc-hunt r2 F1 (pure decision): may an IMPLICIT path — startup rearm, the marker reconcile's
+/// arm, the post-update guard rearm — (re)write crash recovery? The Windows task XML and the
+/// Linux systemd unit both serialize `current_exe()`, so an implicit arm from a stray COPY
+/// re-points recovery at the copy: the exact entry-stealing that resolve-based healing forbids
+/// for the Run value (`StoredTarget::Healthy.points_elsewhere` documents "a healthy entry is
+/// never silently stolen by whichever copy launched last" — this extends that discipline to the
+/// task). Only `Healthy { points_elsewhere: false }` may arm. Broken/Unreadable => false: the
+/// user's INTENT still means "autostart wanted" (the doctrine at `intent_enabled_now`), but the
+/// EXECUTOR must be the entry's owner — in the shipped startup flow the heal runs before the
+/// rearm, so the installed exe becomes owner first, while a stray copy never does. Explicit
+/// user actions (`set_enabled(true)`, repair) intentionally arm the CURRENT exe and stay
+/// ungated. macOS is exempt: its crash recovery patches KeepAlive into the stored entry itself
+/// and cannot steal.
+pub(crate) fn implicit_arm_allowed(stored: &StoredTarget) -> bool {
+    matches!(
+        stored,
+        StoredTarget::Healthy {
+            points_elsewhere: false,
+            ..
+        }
+    )
+}
+
+/// Effectful wrapper over [`implicit_arm_allowed`] for the platforms whose serializers embed
+/// `current_exe()`. Conservative on unknowns (no exe, unreadable entry): NOT arming is a
+/// one-session protection gap that self-heals at the next launch; wrongly arming hands the
+/// recovery task to a copy that may be deleted tomorrow.
+#[cfg(any(windows, target_os = "linux"))]
+pub(crate) fn implicit_arm_gate() -> bool {
+    let Ok(exe) = std::env::current_exe() else {
+        tracing::warn!("implicit crash-recovery arm skipped: own path unresolvable");
+        return false;
+    };
+    let allowed = implicit_arm_allowed(&read_stored_target(Some(&exe)));
+    if !allowed {
+        tracing::warn!(
+            "implicit crash-recovery arm skipped: this process does not own the autostart entry"
+        );
+    }
+    allowed
+}
+
+/// Platform split for the startup rearm: gate where the serializer embeds current_exe.
+fn startup_arm_permitted() -> bool {
+    #[cfg(any(windows, target_os = "linux"))]
+    {
+        implicit_arm_gate()
+    }
+    #[cfg(target_os = "macos")]
+    {
+        true
+    }
+}
+
+/// Reconcile's arm callback (arc-hunt r2 F1): the marker-removal transaction reconciles recovery
+/// to CURRENT intent, but must not arm from a non-owner. Skipping here is safe even for the
+/// owner: on the rename boundary the stored value is Broken until the heal (which runs right
+/// after a Proceed), and `startup_rearm` completes the arm in the same launch.
+#[cfg(windows)]
+fn gated_enable_crash_recovery() -> Result<(), String> {
+    if implicit_arm_gate() {
+        crate::crash_recovery::enable_crash_recovery()
+    } else {
+        Ok(())
     }
 }
 
@@ -1475,8 +1542,10 @@ pub fn startup_rearm(app: &tauri::AppHandle) {
         }
         match intent_enabled_now() {
             Ok(true) => {
-                if let Err(e) = crate::crash_recovery::enable_crash_recovery() {
-                    tracing::warn!("startup crash-recovery rearm failed (autostart on): {e}");
+                if startup_arm_permitted() {
+                    if let Err(e) = crate::crash_recovery::enable_crash_recovery() {
+                        tracing::warn!("startup crash-recovery rearm failed (autostart on): {e}");
+                    }
                 }
             }
             Ok(false) => {}
@@ -1493,8 +1562,10 @@ pub fn startup_rearm(app: &tauri::AppHandle) {
         // keyed on INTENT, never health — a Broken entry still means "the user wants autostart".
         match intent_enabled(app) {
             Ok(true) => {
-                if let Err(e) = crate::crash_recovery::enable_crash_recovery() {
-                    tracing::warn!("startup crash-recovery rearm failed (autostart on): {e}");
+                if startup_arm_permitted() {
+                    if let Err(e) = crate::crash_recovery::enable_crash_recovery() {
+                        tracing::warn!("startup crash-recovery rearm failed (autostart on): {e}");
+                    }
                 }
             }
             Ok(false) => {}
@@ -1637,6 +1708,29 @@ pub fn set_enabled_at(desired: Option<&Path>, enabled: bool) -> Result<(), Strin
 
 #[cfg(test)]
 mod tests {
+    // Arc-hunt r2 F1: the implicit-arm decision table. Only a healthy entry pointing AT US may
+    // be implicitly armed; every other state either has no owner to protect or an owner that
+    // is not us.
+    #[test]
+    fn implicit_arm_only_for_owned_healthy_entry() {
+        use super::{implicit_arm_allowed, StoredTarget};
+        assert!(implicit_arm_allowed(&StoredTarget::Healthy {
+            program: std::path::PathBuf::from("/x"),
+            points_elsewhere: false,
+        }));
+        assert!(!implicit_arm_allowed(&StoredTarget::Healthy {
+            program: std::path::PathBuf::from("/x"),
+            points_elsewhere: true,
+        }));
+        assert!(!implicit_arm_allowed(&StoredTarget::Broken {
+            program: "gone".into(),
+        }));
+        assert!(!implicit_arm_allowed(&StoredTarget::Unreadable {
+            reason: "io".into(),
+        }));
+        assert!(!implicit_arm_allowed(&StoredTarget::Absent));
+    }
+
     use super::*;
 
     // ── APP_NAME drift guard (D7: one derivation) ──

--- a/packages/accelerator/src-tauri/src/autostart.rs
+++ b/packages/accelerator/src-tauri/src/autostart.rs
@@ -1173,23 +1173,60 @@ mod backend {
 // Public surface (plan §4.2)
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// Is `$APPIMAGE` OURS? The AppImage runtime exports `APPIMAGE` (the .AppImage file) and `APPDIR`
+/// (its mount) to the app it launches — but both are plain environment variables and are INHERITED
+/// by any child process. Launch a natively-installed (deb/pacman) Accelerator from a terminal that
+/// is itself running inside some other AppImage and we would see that PARENT's `APPIMAGE`; writing
+/// it into the autostart entry or the systemd recovery unit would make the OS relaunch a completely
+/// different application (r6 #1). `current_exe()` living under `APPDIR` is the proof of ownership:
+/// for a genuine AppImage run our binary IS inside the mount, and for an inherited value it is not
+/// (`/usr/bin/AztecAccelerator`). Pure so the provenance rule is table-tested; both consumers —
+/// [`desired_path`] and `crash_recovery`'s recovery target — go through it so they cannot diverge.
+#[cfg(target_os = "linux")]
+pub(crate) fn appimage_self(
+    appimage: Option<std::ffi::OsString>,
+    appdir: Option<std::ffi::OsString>,
+    exe: &Path,
+) -> Option<PathBuf> {
+    let appimage = appimage.filter(|a| !a.is_empty())?;
+    let appdir = PathBuf::from(appdir.filter(|d| !d.is_empty())?);
+    // Compare canonicalized where possible: the mount path is symlink-free in practice, but a
+    // relative or unnormalized APPDIR must not accidentally "contain" us.
+    let exe_c = exe.canonicalize().unwrap_or_else(|_| exe.to_path_buf());
+    let dir_c = appdir.canonicalize().unwrap_or(appdir);
+    exe_c.starts_with(&dir_c).then(|| PathBuf::from(appimage))
+}
+
+/// Process-env form of [`appimage_self`] — the production reader.
+#[cfg(target_os = "linux")]
+pub(crate) fn appimage_self_from_env(exe: &Path) -> Option<PathBuf> {
+    appimage_self(
+        std::env::var_os("APPIMAGE"),
+        std::env::var_os("APPDIR"),
+        exe,
+    )
+}
+
 /// The path an autostart entry SHOULD launch (plan D11/D12):
 /// - macOS: `current_exe().canonicalize()` (C7 — the plugin stored canonicalized; comparing raw
 ///   would false-positive on symlinks);
-/// - Linux: `app.env().appimage` when present — inside an AppImage, `current_exe()` points into
-///   the ephemeral `/tmp/.mount_XXXX` squashfs that vanishes at exit (D12) — else `current_exe()`;
+/// - Linux: our OWN `$APPIMAGE` when [`appimage_self`] can prove it (inside an AppImage,
+///   `current_exe()` points into the ephemeral `/tmp/.mount_XXXX` squashfs that vanishes at exit,
+///   D12) — else `current_exe()`;
 /// - Windows: `current_exe()` VERBATIM — `canonicalize()` can yield an extended-length `\\?\`
 ///   path whose Run-value compatibility is unproven (D11); canonicalize only for comparison.
 pub fn desired_path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
     #[cfg(target_os = "linux")]
     {
-        use tauri::Manager as _;
-        if let Some(appimage) = app.env().appimage {
-            let p = PathBuf::from(appimage);
-            return Ok(p.canonicalize().unwrap_or(p));
-        }
+        let _ = app;
         let exe =
             std::env::current_exe().map_err(|e| format!("cannot resolve executable path: {e}"))?;
+        // r6 #1: only an $APPIMAGE we can PROVE is ours (our exe lives under $APPDIR) may be the
+        // stored target — an inherited value from a parent AppImage would point the OS at a
+        // different application entirely.
+        if let Some(appimage) = appimage_self_from_env(&exe) {
+            return Ok(appimage.canonicalize().unwrap_or(appimage));
+        }
         Ok(exe.canonicalize().unwrap_or(exe))
     }
     #[cfg(target_os = "macos")]
@@ -1745,6 +1782,43 @@ mod tests {
     // Arc-hunt r2 F1: the implicit-arm decision table. Only a healthy entry pointing AT US may
     // be implicitly armed; every other state either has no owner to protect or an owner that
     // is not us.
+    // r6 #1: $APPIMAGE/$APPDIR are inherited by children, so a natively-installed app launched
+    // from inside another AppImage sees a FOREIGN pair. Ownership = our exe lives under APPDIR.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn appimage_trusted_only_when_our_exe_lives_under_appdir() {
+        use super::appimage_self;
+        use std::path::{Path, PathBuf};
+        let ours = Path::new("/tmp/.mount_AbC/usr/bin/AztecAccelerator");
+        assert_eq!(
+            appimage_self(
+                Some("/home/u/Apps/AztecAccelerator.AppImage".into()),
+                Some("/tmp/.mount_AbC".into()),
+                ours,
+            ),
+            Some(PathBuf::from("/home/u/Apps/AztecAccelerator.AppImage"))
+        );
+        // Inherited from a parent AppImage: our exe is NOT under that mount ⇒ reject.
+        assert_eq!(
+            appimage_self(
+                Some("/home/u/Apps/SomeEditor.AppImage".into()),
+                Some("/tmp/.mount_Parent".into()),
+                Path::new("/usr/bin/AztecAccelerator"),
+            ),
+            None
+        );
+        // Missing or empty halves are never trusted.
+        assert_eq!(appimage_self(Some("/a.AppImage".into()), None, ours), None);
+        assert_eq!(
+            appimage_self(Some("/a.AppImage".into()), Some("".into()), ours),
+            None
+        );
+        assert_eq!(
+            appimage_self(None, Some("/tmp/.mount_AbC".into()), ours),
+            None
+        );
+    }
+
     #[test]
     fn implicit_arm_declines_foreign_owner_and_unknown_ownership() {
         use super::{implicit_arm_allowed, StoredTarget};

--- a/packages/accelerator/src-tauri/src/autostart.rs
+++ b/packages/accelerator/src-tauri/src/autostart.rs
@@ -1468,18 +1468,38 @@ pub fn startup_reconcile() -> bool {
 ///   whose heal cannot write (read-only/ACL'd entry): the marker reconcile removes the marker,
 ///   the heal fails, and every later rearm would keep declining a still-`Broken` entry — crash
 ///   recovery gone permanently, with nothing to converge it.
-/// - `Unreadable` → allow. We cannot prove theft, and pre-gate behaviour armed here; declining
-///   would silently drop crash recovery for exactly the endpoint-managed users who can least
-///   diagnose it.
+/// - `Unreadable` → DECLINE (r4 #1). Tempting to allow — pre-gate behaviour did — but an entry
+///   is `Unreadable` precisely when we cannot tell WHOSE it is, and there is a concrete theft:
+///   endpoint management writes a working value with arguments
+///   (`"C:\Installed\AztecAccelerator.exe" --managed`), which `run_value_candidates` rejects as
+///   "not the owned format" while `artifact_present` still reports intent ON — so a stray copy
+///   would arm recovery at itself. This follows the module's standing doctrine (never write, or
+///   act on, what we do not understand) and the heal's own behaviour (it refuses `Unreadable`
+///   too).
+///   ACCEPTED RESIDUAL: a user whose entry we cannot parse gets no IMPLICIT rearm, so after an
+///   update their crash-recovery task stays disarmed until an explicit toggle or Repair re-arms
+///   it. Chosen over the alternative, where a copy silently captures the task and recovery
+///   launches a binary the user may delete tomorrow.
 /// - `Absent` → allow (unreachable in practice: intent is false, so no caller arms).
 pub(crate) fn implicit_arm_allowed(stored: &StoredTarget) -> bool {
-    !matches!(
-        stored,
+    match stored {
+        // Proven ours.
+        StoredTarget::Healthy {
+            points_elsewhere: false,
+            ..
+        } => true,
+        // Proven someone else's working entry — the F1 theft.
         StoredTarget::Healthy {
             points_elsewhere: true,
             ..
-        }
-    )
+        } => false,
+        // Nobody owns a WORKING entry: whoever launched becomes the owner, which is exactly what
+        // the heal writes moments later. Declining here strands the rename boundary (r3 #1).
+        StoredTarget::Broken { .. } => true,
+        // Ownership unknowable ⇒ never act (r4 #1).
+        StoredTarget::Unreadable { .. } => false,
+        StoredTarget::Absent => true,
+    }
 }
 
 /// Effectful wrapper over [`implicit_arm_allowed`]. `reference` is the path that IDENTIFIES us for
@@ -1719,7 +1739,7 @@ mod tests {
     // be implicitly armed; every other state either has no owner to protect or an owner that
     // is not us.
     #[test]
-    fn implicit_arm_declines_only_proven_foreign_owner() {
+    fn implicit_arm_declines_foreign_owner_and_unknown_ownership() {
         use super::{implicit_arm_allowed, StoredTarget};
         // The ONLY decline: a working entry provably owned by another binary (the F1 theft).
         assert!(!implicit_arm_allowed(&StoredTarget::Healthy {
@@ -1734,7 +1754,9 @@ mod tests {
         assert!(implicit_arm_allowed(&StoredTarget::Broken {
             program: "gone".into(),
         }));
-        assert!(implicit_arm_allowed(&StoredTarget::Unreadable {
+        // Unreadable = ownership unknowable (e.g. a managed value with arguments): never act,
+        // or a copy captures the task (r4 #1). Residual documented on implicit_arm_allowed.
+        assert!(!implicit_arm_allowed(&StoredTarget::Unreadable {
             reason: "io".into(),
         }));
         assert!(implicit_arm_allowed(&StoredTarget::Absent));

--- a/packages/accelerator/src-tauri/src/autostart.rs
+++ b/packages/accelerator/src-tauri/src/autostart.rs
@@ -1521,7 +1521,7 @@ pub(crate) fn implicit_arm_gate(reference: &Path) -> bool {
 /// recovery to CURRENT intent, but must not arm on behalf of a foreign owner. Windows has no
 /// AppImage indirection, so `current_exe()` is the ownership reference.
 #[cfg(windows)]
-fn gated_enable_crash_recovery() -> Result<(), String> {
+pub(crate) fn gated_enable_crash_recovery() -> Result<(), String> {
     let exe = std::env::current_exe()
         .map_err(|e| format!("cannot determine own path for the recovery arm: {e}"))?;
     if implicit_arm_gate(&exe) {
@@ -1581,7 +1581,12 @@ pub fn startup_rearm(app: &tauri::AppHandle) {
         // keyed on INTENT, never health — a Broken entry still means "the user wants autostart".
         match intent_enabled(app) {
             Ok(true) => {
-                // AppImage-aware ownership reference (r3 #3): desired_path resolves $APPIMAGE.
+                // Linux gates (systemd ExecStart embeds a path, so a copy could capture it) with an
+                // AppImage-aware reference — desired_path resolves $APPIMAGE (r3 #3). macOS does
+                // NOT gate (r5 #3): its crash recovery patches KeepAlive into the app's own fixed
+                // plist and writes no executable path, so it cannot steal another binary's entry —
+                // gating there would only widen the Unreadable residual for no safety gain.
+                #[cfg(target_os = "linux")]
                 let permitted = match desired_path(app) {
                     Ok(reference) => implicit_arm_gate(&reference),
                     Err(e) => {
@@ -1589,6 +1594,8 @@ pub fn startup_rearm(app: &tauri::AppHandle) {
                         false
                     }
                 };
+                #[cfg(target_os = "macos")]
+                let permitted = true;
                 if permitted {
                     if let Err(e) = crate::crash_recovery::enable_crash_recovery() {
                         tracing::warn!("startup crash-recovery rearm failed (autostart on): {e}");

--- a/packages/accelerator/src-tauri/src/autostart.rs
+++ b/packages/accelerator/src-tauri/src/autostart.rs
@@ -1454,65 +1454,57 @@ pub fn startup_reconcile() -> bool {
 
 /// Arc-hunt r2 F1 (pure decision): may an IMPLICIT path — startup rearm, the marker reconcile's
 /// arm, the post-update guard rearm — (re)write crash recovery? The Windows task XML and the
-/// Linux systemd unit both serialize `current_exe()`, so an implicit arm from a stray COPY
-/// re-points recovery at the copy: the exact entry-stealing that resolve-based healing forbids
-/// for the Run value (`StoredTarget::Healthy.points_elsewhere` documents "a healthy entry is
-/// never silently stolen by whichever copy launched last" — this extends that discipline to the
-/// task). Only `Healthy { points_elsewhere: false }` may arm. Broken/Unreadable => false: the
-/// user's INTENT still means "autostart wanted" (the doctrine at `intent_enabled_now`), but the
-/// EXECUTOR must be the entry's owner — in the shipped startup flow the heal runs before the
-/// rearm, so the installed exe becomes owner first, while a stray copy never does. Explicit
-/// user actions (`set_enabled(true)`, repair) intentionally arm the CURRENT exe and stay
-/// ungated. macOS is exempt: its crash recovery patches KeepAlive into the stored entry itself
-/// and cannot steal.
+/// Linux systemd unit both serialize the launching binary's path, so an implicit arm from a stray
+/// COPY re-points recovery at the copy: the entry-stealing that resolve-based healing already
+/// forbids for the autostart value itself (`StoredTarget::Healthy.points_elsewhere` — "a healthy
+/// entry is never silently stolen by whichever copy launched last").
+///
+/// The rule is deliberately narrow — **decline only when someone else PROVABLY owns a working
+/// entry** (r3 #1/#3, mirroring piece 2's proven-absence epistemics):
+/// - `Healthy { points_elsewhere: true }` → DECLINE. Another live binary owns it; that is the bug.
+/// - `Healthy { points_elsewhere: false }` → allow. We are the owner.
+/// - `Broken` → allow. Nobody owns a working entry; whoever launched becomes the owner, which is
+///   exactly what the heal (running right after) writes anyway. Declining here would STRAND users
+///   whose heal cannot write (read-only/ACL'd entry): the marker reconcile removes the marker,
+///   the heal fails, and every later rearm would keep declining a still-`Broken` entry — crash
+///   recovery gone permanently, with nothing to converge it.
+/// - `Unreadable` → allow. We cannot prove theft, and pre-gate behaviour armed here; declining
+///   would silently drop crash recovery for exactly the endpoint-managed users who can least
+///   diagnose it.
+/// - `Absent` → allow (unreachable in practice: intent is false, so no caller arms).
 pub(crate) fn implicit_arm_allowed(stored: &StoredTarget) -> bool {
-    matches!(
+    !matches!(
         stored,
         StoredTarget::Healthy {
-            points_elsewhere: false,
+            points_elsewhere: true,
             ..
         }
     )
 }
 
-/// Effectful wrapper over [`implicit_arm_allowed`] for the platforms whose serializers embed
-/// `current_exe()`. Conservative on unknowns (no exe, unreadable entry): NOT arming is a
-/// one-session protection gap that self-heals at the next launch; wrongly arming hands the
-/// recovery task to a copy that may be deleted tomorrow.
-#[cfg(any(windows, target_os = "linux"))]
-pub(crate) fn implicit_arm_gate() -> bool {
-    let Ok(exe) = std::env::current_exe() else {
-        tracing::warn!("implicit crash-recovery arm skipped: own path unresolvable");
-        return false;
-    };
-    let allowed = implicit_arm_allowed(&read_stored_target(Some(&exe)));
+/// Effectful wrapper over [`implicit_arm_allowed`]. `reference` is the path that IDENTIFIES us for
+/// ownership purposes — callers pass [`desired_path`] where an `AppHandle` exists, because on Linux
+/// an AppImage's identity is the `.AppImage` file, NOT `current_exe()` (which points into the
+/// ephemeral `/tmp/.mount_*` squashfs): comparing the mount path would make every AppImage launch
+/// look like a foreign copy and permanently strand those users' crash recovery (r3 #3).
+pub(crate) fn implicit_arm_gate(reference: &Path) -> bool {
+    let allowed = implicit_arm_allowed(&read_stored_target(Some(reference)));
     if !allowed {
         tracing::warn!(
-            "implicit crash-recovery arm skipped: this process does not own the autostart entry"
+            "implicit crash-recovery arm skipped: another installed copy owns the autostart entry"
         );
     }
     allowed
 }
 
-/// Platform split for the startup rearm: gate where the serializer embeds current_exe.
-fn startup_arm_permitted() -> bool {
-    #[cfg(any(windows, target_os = "linux"))]
-    {
-        implicit_arm_gate()
-    }
-    #[cfg(target_os = "macos")]
-    {
-        true
-    }
-}
-
-/// Reconcile's arm callback (arc-hunt r2 F1): the marker-removal transaction reconciles recovery
-/// to CURRENT intent, but must not arm from a non-owner. Skipping here is safe even for the
-/// owner: on the rename boundary the stored value is Broken until the heal (which runs right
-/// after a Proceed), and `startup_rearm` completes the arm in the same launch.
+/// Reconcile's arm callback (arc-hunt r2 F1), Windows: the marker-removal transaction reconciles
+/// recovery to CURRENT intent, but must not arm on behalf of a foreign owner. Windows has no
+/// AppImage indirection, so `current_exe()` is the ownership reference.
 #[cfg(windows)]
 fn gated_enable_crash_recovery() -> Result<(), String> {
-    if implicit_arm_gate() {
+    let exe = std::env::current_exe()
+        .map_err(|e| format!("cannot determine own path for the recovery arm: {e}"))?;
+    if implicit_arm_gate(&exe) {
         crate::crash_recovery::enable_crash_recovery()
     } else {
         Ok(())
@@ -1542,7 +1534,14 @@ pub fn startup_rearm(app: &tauri::AppHandle) {
         }
         match intent_enabled_now() {
             Ok(true) => {
-                if startup_arm_permitted() {
+                let permitted = match std::env::current_exe() {
+                    Ok(exe) => implicit_arm_gate(&exe),
+                    Err(e) => {
+                        tracing::warn!("own path unresolvable ({e}); crash recovery not re-armed");
+                        false
+                    }
+                };
+                if permitted {
                     if let Err(e) = crate::crash_recovery::enable_crash_recovery() {
                         tracing::warn!("startup crash-recovery rearm failed (autostart on): {e}");
                     }
@@ -1562,7 +1561,15 @@ pub fn startup_rearm(app: &tauri::AppHandle) {
         // keyed on INTENT, never health — a Broken entry still means "the user wants autostart".
         match intent_enabled(app) {
             Ok(true) => {
-                if startup_arm_permitted() {
+                // AppImage-aware ownership reference (r3 #3): desired_path resolves $APPIMAGE.
+                let permitted = match desired_path(app) {
+                    Ok(reference) => implicit_arm_gate(&reference),
+                    Err(e) => {
+                        tracing::warn!("own path unresolvable ({e}); crash recovery not re-armed");
+                        false
+                    }
+                };
+                if permitted {
                     if let Err(e) = crate::crash_recovery::enable_crash_recovery() {
                         tracing::warn!("startup crash-recovery rearm failed (autostart on): {e}");
                     }
@@ -1712,23 +1719,25 @@ mod tests {
     // be implicitly armed; every other state either has no owner to protect or an owner that
     // is not us.
     #[test]
-    fn implicit_arm_only_for_owned_healthy_entry() {
+    fn implicit_arm_declines_only_proven_foreign_owner() {
         use super::{implicit_arm_allowed, StoredTarget};
-        assert!(implicit_arm_allowed(&StoredTarget::Healthy {
-            program: std::path::PathBuf::from("/x"),
-            points_elsewhere: false,
-        }));
+        // The ONLY decline: a working entry provably owned by another binary (the F1 theft).
         assert!(!implicit_arm_allowed(&StoredTarget::Healthy {
             program: std::path::PathBuf::from("/x"),
             points_elsewhere: true,
         }));
-        assert!(!implicit_arm_allowed(&StoredTarget::Broken {
+        // Everything else arms — declining would strand users with no path back (r3 #1/#3).
+        assert!(implicit_arm_allowed(&StoredTarget::Healthy {
+            program: std::path::PathBuf::from("/x"),
+            points_elsewhere: false,
+        }));
+        assert!(implicit_arm_allowed(&StoredTarget::Broken {
             program: "gone".into(),
         }));
-        assert!(!implicit_arm_allowed(&StoredTarget::Unreadable {
+        assert!(implicit_arm_allowed(&StoredTarget::Unreadable {
             reason: "io".into(),
         }));
-        assert!(!implicit_arm_allowed(&StoredTarget::Absent));
+        assert!(implicit_arm_allowed(&StoredTarget::Absent));
     }
 
     use super::*;

--- a/packages/accelerator/src-tauri/src/crash_recovery.rs
+++ b/packages/accelerator/src-tauri/src/crash_recovery.rs
@@ -238,9 +238,6 @@ fn systemd_exec_start(exe: &std::path::Path) -> Option<String> {
     Some(format!("\":{}\"", s.replace('%', "%%")))
 }
 
-/// Create and enable a systemd user service with `Restart=on-failure`.
-/// Call this after `manager.enable()`.
-#[cfg(target_os = "linux")]
 /// The path a Linux recovery unit must relaunch: the AppImage file when running from one (its
 /// mount is ephemeral), else the executable itself. Pure so the choice is unit-tested without
 /// touching process env in a parallel test run.
@@ -255,6 +252,9 @@ fn recovery_target(
     }
 }
 
+/// Create and enable a systemd user service with `Restart=on-failure`.
+/// Call this after `manager.enable()`.
+#[cfg(target_os = "linux")]
 fn enable_impl() -> Result<(), String> {
     let exe = std::env::current_exe()
         .map_err(|e| format!("cannot determine executable path for systemd service: {e}"))?;

--- a/packages/accelerator/src-tauri/src/crash_recovery.rs
+++ b/packages/accelerator/src-tauri/src/crash_recovery.rs
@@ -241,9 +241,28 @@ fn systemd_exec_start(exe: &std::path::Path) -> Option<String> {
 /// Create and enable a systemd user service with `Restart=on-failure`.
 /// Call this after `manager.enable()`.
 #[cfg(target_os = "linux")]
+/// The path a Linux recovery unit must relaunch: the AppImage file when running from one (its
+/// mount is ephemeral), else the executable itself. Pure so the choice is unit-tested without
+/// touching process env in a parallel test run.
+#[cfg(target_os = "linux")]
+fn recovery_target(
+    appimage: Option<std::ffi::OsString>,
+    exe: std::path::PathBuf,
+) -> std::path::PathBuf {
+    match appimage {
+        Some(a) if !a.is_empty() => std::path::PathBuf::from(a),
+        _ => exe,
+    }
+}
+
 fn enable_impl() -> Result<(), String> {
     let exe = std::env::current_exe()
         .map_err(|e| format!("cannot determine executable path for systemd service: {e}"))?;
+    // r5 #2 (pre-existing bug, surfaced by the ownership work): inside an AppImage `current_exe()`
+    // is the ephemeral `/tmp/.mount_XXXX` squashfs that vanishes when the process exits — the very
+    // reason autostart stores `$APPIMAGE` instead (autostart::desired_path, D12). A recovery unit
+    // pointing at the dead mount can never relaunch anything, which is exactly when it is needed.
+    let exe = recovery_target(std::env::var_os("APPIMAGE"), exe);
 
     let service_dir = dirs::config_dir()
         .ok_or_else(|| "cannot determine config dir for systemd service".to_string())?
@@ -516,6 +535,27 @@ mod tests {
 
     use super::enable_transaction;
     use std::cell::Cell;
+
+    // r5 #2: a Linux recovery unit must relaunch the AppImage FILE, never the ephemeral
+    // /tmp/.mount_* executable (which is gone exactly when recovery would fire).
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn recovery_target_prefers_the_appimage_file() {
+        use super::recovery_target;
+        use std::path::PathBuf;
+        let mount = PathBuf::from("/tmp/.mount_AbC123/AztecAccelerator");
+        assert_eq!(
+            recovery_target(
+                Some("/home/u/Apps/AztecAccelerator.AppImage".into()),
+                mount.clone()
+            ),
+            PathBuf::from("/home/u/Apps/AztecAccelerator.AppImage")
+        );
+        // Not an AppImage run: the executable itself is correct.
+        assert_eq!(recovery_target(None, mount.clone()), mount);
+        // Defensive: an empty APPIMAGE must not produce an empty ExecStart target.
+        assert_eq!(recovery_target(Some("".into()), mount.clone()), mount);
+    }
 
     // C8 (D13/D20): the enable transaction's rollback ordering + completeness + failure-observability,
     // exercised with injected closures — no real AppHandle / OS calls, so it runs on every platform's CI.

--- a/packages/accelerator/src-tauri/src/crash_recovery.rs
+++ b/packages/accelerator/src-tauri/src/crash_recovery.rs
@@ -243,13 +243,12 @@ fn systemd_exec_start(exe: &std::path::Path) -> Option<String> {
 /// touching process env in a parallel test run.
 #[cfg(target_os = "linux")]
 fn recovery_target(
-    appimage: Option<std::ffi::OsString>,
+    appimage_self: Option<std::path::PathBuf>,
     exe: std::path::PathBuf,
 ) -> std::path::PathBuf {
-    match appimage {
-        Some(a) if !a.is_empty() => std::path::PathBuf::from(a),
-        _ => exe,
-    }
+    // Provenance is decided ONCE, in autostart::appimage_self — an inherited $APPIMAGE from a
+    // parent AppImage must never become a relaunch target (r6 #1).
+    appimage_self.unwrap_or(exe)
 }
 
 /// Create and enable a systemd user service with `Restart=on-failure`.
@@ -262,7 +261,7 @@ fn enable_impl() -> Result<(), String> {
     // is the ephemeral `/tmp/.mount_XXXX` squashfs that vanishes when the process exits — the very
     // reason autostart stores `$APPIMAGE` instead (autostart::desired_path, D12). A recovery unit
     // pointing at the dead mount can never relaunch anything, which is exactly when it is needed.
-    let exe = recovery_target(std::env::var_os("APPIMAGE"), exe);
+    let exe = recovery_target(crate::autostart::appimage_self_from_env(&exe), exe);
 
     let service_dir = dirs::config_dir()
         .ok_or_else(|| "cannot determine config dir for systemd service".to_string())?
@@ -546,15 +545,14 @@ mod tests {
         let mount = PathBuf::from("/tmp/.mount_AbC123/AztecAccelerator");
         assert_eq!(
             recovery_target(
-                Some("/home/u/Apps/AztecAccelerator.AppImage".into()),
+                Some(PathBuf::from("/home/u/Apps/AztecAccelerator.AppImage")),
                 mount.clone()
             ),
             PathBuf::from("/home/u/Apps/AztecAccelerator.AppImage")
         );
-        // Not an AppImage run: the executable itself is correct.
+        // Not an AppImage run, or an UNPROVEN/foreign $APPIMAGE (autostart::appimage_self
+        // returned None): the executable itself is the correct relaunch target.
         assert_eq!(recovery_target(None, mount.clone()), mount);
-        // Defensive: an empty APPIMAGE must not produce an empty ExecStart target.
-        assert_eq!(recovery_target(Some("".into()), mount.clone()), mount);
     }
 
     // C8 (D13/D20): the enable transaction's rollback ordering + completeness + failure-observability,

--- a/packages/accelerator/src-tauri/src/update_marker.rs
+++ b/packages/accelerator/src-tauri/src/update_marker.rs
@@ -531,8 +531,67 @@ pub fn post_create_failure_cleanup(
 // All pure/tempdir + counters; nothing here touches locks, registries, or schedulers.
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// The shipped executable file name. Single Rust source of truth (Cargo `[[bin]]` +
+/// `default-run` define the build side; `tauri-identity.test.ts` pins all three together).
+pub const MAIN_BINARY_EXE: &str = "AztecAccelerator.exe";
+
+/// The NSIS install-dir default component (`%LOCALAPPDATA%\<productName>`). Pinned by the
+/// identity test against tauri.conf.json's productName.
+pub const PRODUCT_DIR_NAME: &str = "Aztec Accelerator";
+
+/// Arc-hunt r2 F2 (codex option C): the marker's `expected_install_path` must be the path the
+/// INSTALLER will use, not where the initiating process happens to live — a stray copy driving
+/// an update otherwise records its own path, and the relaunched N (path mismatch, copy still
+/// present ⇒ not proven absent) suppresses reconciliation until the deadline. NSIS resolves
+/// `$INSTDIR` deterministically for this currentUser bundle (installer.nsi:873-877,
+/// `RestorePreviousInstallLocation`): the `MANUPRODUCTKEY` default value when non-empty, else
+/// `%LOCALAPPDATA%\<productName>`. This is the pure mirror of that rule; `None` means the
+/// destination cannot be determined and the caller must ABORT the update rather than publish a
+/// guessed marker.
+pub fn expected_install_path_from(
+    registry_dir: Option<String>,
+    local_app_data: Option<std::path::PathBuf>,
+) -> Option<std::path::PathBuf> {
+    let dir = match registry_dir {
+        Some(d) if !d.trim().is_empty() => std::path::PathBuf::from(d),
+        _ => local_app_data?.join(PRODUCT_DIR_NAME),
+    };
+    Some(dir.join(MAIN_BINARY_EXE))
+}
+
 #[cfg(test)]
 mod tests {
+    // Arc-hunt r2 F2: the NSIS-destination mirror. Registry wins when non-empty; default is
+    // %LOCALAPPDATA%\<product>; no LOCALAPPDATA and no registry ⇒ undeterminable (caller aborts).
+    #[test]
+    fn expected_install_path_resolution_table() {
+        use super::{expected_install_path_from, MAIN_BINARY_EXE, PRODUCT_DIR_NAME};
+        use std::path::PathBuf;
+        let lad = Some(PathBuf::from(r"C:\Users\u\AppData\Local"));
+        assert_eq!(
+            expected_install_path_from(Some(r"D:\Custom Dir".into()), lad.clone()),
+            Some(PathBuf::from(r"D:\Custom Dir").join(MAIN_BINARY_EXE))
+        );
+        assert_eq!(
+            expected_install_path_from(Some("   ".into()), lad.clone()),
+            Some(
+                PathBuf::from(r"C:\Users\u\AppData\Local")
+                    .join(PRODUCT_DIR_NAME)
+                    .join(MAIN_BINARY_EXE)
+            )
+        );
+        assert_eq!(
+            expected_install_path_from(None, lad.clone()),
+            Some(
+                PathBuf::from(r"C:\Users\u\AppData\Local")
+                    .join(PRODUCT_DIR_NAME)
+                    .join(MAIN_BINARY_EXE)
+            )
+        );
+        assert_eq!(expected_install_path_from(None, None), None);
+        assert_eq!(expected_install_path_from(Some(String::new()), None), None);
+    }
+
     use super::*;
     use std::cell::Cell;
 

--- a/packages/accelerator/src-tauri/src/updater.rs
+++ b/packages/accelerator/src-tauri/src/updater.rs
@@ -390,6 +390,21 @@ pub async fn perform_update(app: &AppHandle, verified: VerifiedUpdate) {
         }
     }
 
+    // Arc-hunt r3 #2: resolve the installer's destination BEFORE anything is mutated. It is a
+    // read-only registry+env lookup, and computing it inside the critical section meant an
+    // unreadable registry aborted AFTER crash recovery had been disarmed — leaving a legitimate
+    // installed instance's task deleted with no marker to reconcile it back.
+    #[cfg(target_os = "windows")]
+    let expected_install = match nsis_install_destination() {
+        Ok(dest) => canonicalize_expected(dest),
+        Err(e) => {
+            tracing::error!(
+                "cannot determine the install destination ({e}); aborting before any state change"
+            );
+            return;
+        }
+    };
+
     // ── Windows: the update-window critical section (piece-2 plan §4) ──
     // autostart.lock spans intent-read → disarm → marker+handoff create, and NOTHING else: the
     // held lock freezes owned intent mutations, which is what keeps the snapshot honest inside it
@@ -443,16 +458,7 @@ pub async fn perform_update(app: &AppHandle, verified: VerifiedUpdate) {
         // NOT current_exe (arc-hunt r2 F2: a stray copy driving an update would record its own
         // path, and the relaunched N would suppress reconciliation until the deadline). For the
         // installed instance the two coincide.
-        let expected = match nsis_install_destination() {
-            Ok(dest) => canonicalize_expected(dest),
-            Err(e) => {
-                // Publishing a guessed path would arm a marker N can never satisfy — abort;
-                // the guard's Drop rearms from the snapshot (ownership-gated) and the next
-                // check retries.
-                tracing::warn!("cannot determine install destination ({e}); update aborted");
-                return;
-            }
-        };
+        let expected = expected_install.clone();
         let payload = crate::update_marker::MarkerPayload::new(
             &version,
             &expected,
@@ -460,7 +466,12 @@ pub async fn perform_update(app: &AppHandle, verified: VerifiedUpdate) {
             crate::update_marker::now_unix(),
         );
         match crate::update_marker::create_new(&paths, &payload, crate::update_marker::now_unix()) {
-            Ok(()) => {}
+            Ok(()) => {
+                // Observable proof the transaction was armed (D24: version/nonce only, no paths).
+                // The Windows smoke asserts this line so "no transaction files afterwards" cannot
+                // pass by never having created one (arc-hunt r3 #4).
+                tracing::info!(candidate = %version, "update window marker armed");
+            }
             Err(crate::update_marker::CreateErr::Live) => {
                 // Raced by a FOREIGN window between the top-of-fn check and here. Never delete
                 // it — and never REARM into it either: "no process rearms while a marker is
@@ -567,9 +578,15 @@ pub async fn perform_update(app: &AppHandle, verified: VerifiedUpdate) {
 fn rearm_crash_recovery_if_enabled(was_enabled: bool) {
     if was_enabled {
         // Arc-hunt r2 F1: the guard rearm is an IMPLICIT path — a stray copy whose update
-        // aborted must not re-point the recovery task at itself on the way out.
-        if !crate::autostart::implicit_arm_gate() {
-            return;
+        // aborted must not re-point the recovery task at itself on the way out. (Windows: no
+        // AppImage indirection, so current_exe is the ownership reference.)
+        match std::env::current_exe() {
+            Ok(exe) if crate::autostart::implicit_arm_gate(&exe) => {}
+            Ok(_) => return,
+            Err(e) => {
+                tracing::warn!("own path unresolvable ({e}); post-update rearm skipped");
+                return;
+            }
         }
         // C8 (D12): log-and-continue — a post-update rearm hiccup must not abort, but is never swallowed.
         if let Err(e) = crate::crash_recovery::enable_crash_recovery() {

--- a/packages/accelerator/src-tauri/src/updater.rs
+++ b/packages/accelerator/src-tauri/src/updater.rs
@@ -368,6 +368,23 @@ pub async fn perform_update(app: &AppHandle, verified: VerifiedUpdate) {
         return;
     }
 
+    // Arc-hunt r3 #2 + r4 #2: resolve the installer's destination BEFORE anything is mutated —
+    // above `record_pending` as well as above the disarm. It is a read-only registry+env lookup,
+    // so an unreadable/wrong-typed install-location value must not (a) leave crash recovery
+    // disarmed with no marker to restore it, nor (b) leave `pending` recorded: F-004's floor then
+    // rejects every version below that candidate, so a WITHDRAWN release would block the fixed
+    // (lower but still newer) one forever.
+    #[cfg(target_os = "windows")]
+    let expected_install = match nsis_install_destination() {
+        Ok(dest) => canonicalize_expected(dest),
+        Err(e) => {
+            tracing::error!(
+                "cannot determine the install destination ({e}); aborting before any state change"
+            );
+            return;
+        }
+    };
+
     // Piece-2 rev-3 ordering: record the install INTENT first (it needs only the updater lock and
     // must precede install(); a later disarm failure leaving `pending` recorded is the documented
     // exact-version-retry semantics) — so the fallible floor write can never strand a live marker.
@@ -389,21 +406,6 @@ pub async fn perform_update(app: &AppHandle, verified: VerifiedUpdate) {
             return;
         }
     }
-
-    // Arc-hunt r3 #2: resolve the installer's destination BEFORE anything is mutated. It is a
-    // read-only registry+env lookup, and computing it inside the critical section meant an
-    // unreadable registry aborted AFTER crash recovery had been disarmed — leaving a legitimate
-    // installed instance's task deleted with no marker to reconcile it back.
-    #[cfg(target_os = "windows")]
-    let expected_install = match nsis_install_destination() {
-        Ok(dest) => canonicalize_expected(dest),
-        Err(e) => {
-            tracing::error!(
-                "cannot determine the install destination ({e}); aborting before any state change"
-            );
-            return;
-        }
-    };
 
     // ── Windows: the update-window critical section (piece-2 plan §4) ──
     // autostart.lock spans intent-read → disarm → marker+handoff create, and NOTHING else: the

--- a/packages/accelerator/src-tauri/src/updater.rs
+++ b/packages/accelerator/src-tauri/src/updater.rs
@@ -439,14 +439,20 @@ pub async fn perform_update(app: &AppHandle, verified: VerifiedUpdate) {
             CrashRecoveryGuard::new(move || rearm_crash_recovery_if_enabled(was_recovery_enabled));
 
         // The marker (D18): compare-and-create under the held lock; a live foreign window is
-        // never deleted. The expected install path is where THIS exe lives — the update replaces
-        // it in place.
-        let exe = std::env::current_exe().ok();
-        let expected = exe
-            .as_deref()
-            .and_then(|e| e.canonicalize().ok())
-            .or(exe)
-            .unwrap_or_default();
+        // never deleted. The expected install path is where the INSTALLER will put the new exe —
+        // NOT current_exe (arc-hunt r2 F2: a stray copy driving an update would record its own
+        // path, and the relaunched N would suppress reconciliation until the deadline). For the
+        // installed instance the two coincide.
+        let expected = match nsis_install_destination() {
+            Ok(dest) => canonicalize_expected(dest),
+            Err(e) => {
+                // Publishing a guessed path would arm a marker N can never satisfy — abort;
+                // the guard's Drop rearms from the snapshot (ownership-gated) and the next
+                // check retries.
+                tracing::warn!("cannot determine install destination ({e}); update aborted");
+                return;
+            }
+        };
         let payload = crate::update_marker::MarkerPayload::new(
             &version,
             &expected,
@@ -560,11 +566,59 @@ pub async fn perform_update(app: &AppHandle, verified: VerifiedUpdate) {
 #[cfg(target_os = "windows")]
 fn rearm_crash_recovery_if_enabled(was_enabled: bool) {
     if was_enabled {
+        // Arc-hunt r2 F1: the guard rearm is an IMPLICIT path — a stray copy whose update
+        // aborted must not re-point the recovery task at itself on the way out.
+        if !crate::autostart::implicit_arm_gate() {
+            return;
+        }
         // C8 (D12): log-and-continue — a post-update rearm hiccup must not abort, but is never swallowed.
         if let Err(e) = crate::crash_recovery::enable_crash_recovery() {
             tracing::warn!("post-update crash-recovery rearm failed: {e}");
         }
     }
+}
+
+/// Arc-hunt r2 F2: the destination the NSIS installer will actually use — MANUPRODUCTKEY's
+/// default value (`Software\<publisher>\<productName>`, written by every prior install and read
+/// back by RestorePreviousInstallLocation) or the `%LOCALAPPDATA%` default. `Err` means the
+/// registry answered something other than "not found": abort the update rather than publish a
+/// marker with a guessed path. Pre-#427 installs wrote the OLD manufacturer namespace
+/// ("Software\aztec\…"); those are dev-only default-dir installs, and NotFound → default
+/// resolves to exactly where they live.
+#[cfg(target_os = "windows")]
+fn nsis_install_destination() -> Result<std::path::PathBuf, String> {
+    use winreg::enums::{HKEY_CURRENT_USER, KEY_READ};
+    let hkcu = winreg::RegKey::predef(HKEY_CURRENT_USER);
+    let reg_dir = match hkcu
+        .open_subkey_with_flags(r"Software\Aztec Accelerator\Aztec Accelerator", KEY_READ)
+    {
+        Ok(k) => match k.get_value::<String, _>("") {
+            Ok(v) => Some(v),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+            Err(e) => return Err(format!("install-location value read failed: {e}")),
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(e) => return Err(format!("install-location key open failed: {e}")),
+    };
+    let lad = std::env::var_os("LOCALAPPDATA").map(std::path::PathBuf::from);
+    crate::update_marker::expected_install_path_from(reg_dir, lad)
+        .ok_or_else(|| "cannot determine install destination (no LOCALAPPDATA)".to_string())
+}
+
+/// Best-effort canonicalization that survives a not-yet-existing file: canonicalize the whole
+/// path, else the parent dir + file name, else keep it raw (the marker reader's proven-absence
+/// rule handles the rest).
+#[cfg(target_os = "windows")]
+fn canonicalize_expected(p: std::path::PathBuf) -> std::path::PathBuf {
+    if let Ok(c) = p.canonicalize() {
+        return c;
+    }
+    if let (Some(dir), Some(name)) = (p.parent(), p.file_name()) {
+        if let Ok(cd) = dir.canonicalize() {
+            return cd.join(name);
+        }
+    }
+    p
 }
 
 /// q7e3-F-10: structural guard for the Windows crash-recovery disarm→rearm invariant — *every* path

--- a/packages/accelerator/src-tauri/src/updater.rs
+++ b/packages/accelerator/src-tauri/src/updater.rs
@@ -502,7 +502,9 @@ pub async fn perform_update(app: &AppHandle, verified: VerifiedUpdate) {
                 crate::update_marker::post_create_failure_cleanup(
                     &paths,
                     &crate::autostart::intent_enabled_now,
-                    &crate::crash_recovery::enable_crash_recovery,
+                    // r5 #1: the GATED arm — cleanup re-arms recovery, and a copy-initiated
+                    // update whose marker write failed must not capture the task on the way out.
+                    &crate::autostart::gated_enable_crash_recovery,
                     &crate::crash_recovery::disable_crash_recovery,
                 );
                 guard.defuse();
@@ -516,7 +518,8 @@ pub async fn perform_update(app: &AppHandle, verified: VerifiedUpdate) {
             crate::update_marker::post_create_failure_cleanup(
                 &paths,
                 &crate::autostart::intent_enabled_now,
-                &crate::crash_recovery::enable_crash_recovery,
+                // r5 #1: gated — see the sibling cleanup above.
+                &crate::autostart::gated_enable_crash_recovery,
                 &crate::crash_recovery::disable_crash_recovery,
             );
             guard.defuse();
@@ -555,7 +558,8 @@ pub async fn perform_update(app: &AppHandle, verified: VerifiedUpdate) {
                         crate::update_marker::post_create_failure_cleanup(
                             &marker_paths,
                             &crate::autostart::intent_enabled_now,
-                            &crate::crash_recovery::enable_crash_recovery,
+                            // r5 #1: gated — see the sibling cleanups above.
+                            &crate::autostart::gated_enable_crash_recovery,
                             &crate::crash_recovery::disable_crash_recovery,
                         );
                     }


### PR DESCRIPTION
Rounds 2–3 of the owner-requested bug hunt over the merged arc (#425/#426/#427). Full trail: `implementations-plan/arc-bug-hunt/log.md`. **Two High product bugs, plus three more introduced by their own fixes** — all found by hunting the same change set repeatedly.

## The bugs

**F1 — any leftover copy silently stole the crash-recovery task.** `startup_rearm` (and the reconcile arm, and the post-update guard rearm) keyed only on *intent* — "an entry exists and isn't disabled" — while `enable_crash_recovery` serializes the launching binary's path into the task XML / systemd unit. Running a stray `Downloads` copy once, even with the installed app healthy, re-pointed recovery at the copy; delete the copy and the real app is never recovered. Piece 1 already forbade this theft for the autostart value (`points_elsewhere`); the task now follows the same rule.

**F2 — a copy that drove an update poisoned `expected_install_path`.** It recorded its own path, but the updater passes `/UPDATE` with no `/D`, so NSIS installs at `$INSTDIR`. The relaunched app saw a mismatch it couldn't prove absent → reconciliation suppressed → heal/rearm/updates blocked until the deadline. The marker now records the installer's destination via a pure mirror of `RestorePreviousInstallLocation` (registry default value, else `%LOCALAPPDATA%\<productName>`); any registry error other than NotFound aborts the update rather than publishing a guess.

## Then round 3 hunted the fixes and found three more

- **The gate could kill recovery permanently**: it reported success while declining, so the marker was deleted, the heal then failed on a read-only entry, and every later rearm declined a still-`Broken` entry. The rule is now narrowed to *decline only a provably foreign owner* — `Broken`/`Unreadable`/`Absent` arm, matching piece 1's resolve-based semantics and piece 2's proven-absence epistemics.
- **The new abort ran after the global disarm**, leaving a legitimate instance's task deleted with no marker to restore it. Hoisted above every mutation.
- **AppImage owners could never pass the gate** — Linux stores the `.AppImage` path while `current_exe()` is the ephemeral `/tmp/.mount_*`. The ownership reference is now a parameter (`desired_path` where an AppHandle exists).

## Tests
Two pure decision tables; identity-test pins on every input to the destination mirror plus a `installer_arg` grep (both **mutation-tested** — inject the drift, watch them fail); new dispatch-only **`copy-initiator`** smoke mode that reproduces F1+F2 end-to-end and requires a new `update window marker armed` log line so it can't pass without a marker ever existing.

**Validated on real Windows** against this branch: `copy-initiator` green (run 30501446852), `barrier` green (run 30501460093). Local: 58 TS + 94 Rust lib tests, clippy `--all-targets`, fmt, actionlint, ps1 parse.

Note: the Windows-only registry code can't be compiled locally (cross-compiling ring/aws-lc-sys needs a Windows C toolchain); the winreg API was verified against the vendored 0.55 source and the idiom already proven on Windows in `autostart.rs`, with CI's Windows legs as the compile proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)