### PR TITLE
fix(accelerator): close F-06's eviction race with an in-use lease, and degrade on 503

### DIFF
--- a/audit/security/2026-07-31-9c4cb0c/report.html
+++ b/audit/security/2026-07-31-9c4cb0c/report.html
@@ -138,9 +138,15 @@
     Each fix carries regression tests that were <em>mutation-proved</em> — the fix was reverted and
     the test confirmed to fail — so the tests pin the defect rather than the current behaviour. The
     fixes then went through five rounds of independent adversarial review, which found thirteen
-    further bugs, nine of them in the fixes themselves. Two findings keep a documented residual that
-    is <strong>not</strong> claimed closed: F-02's same-user file-replacement window, and F-06's
-    eviction race, which is narrowed rather than eliminated.
+    further bugs, nine of them in the fixes themselves.
+  </p>
+  <p>
+    <strong>Update, 10 August:</strong> F-06's eviction race is now fully closed by an in-use lease
+    (a further five review rounds). F-02's same-user file-replacement window remains open and is now
+    known to be <em>untestable on Windows</em> — five separate routes to seed the certificate store
+    without a consent dialog were measured and all failed, so closing it there would mean shipping
+    security code CI can compile but never run. It stays an explicitly accepted risk rather than a
+    claimed fix.
   </p>
   <p>
     Full detail, including three places the fixes deliberately diverged from this report's own

--- a/audit/security/2026-07-31-9c4cb0c/report.md
+++ b/audit/security/2026-07-31-9c4cb0c/report.md
@@ -15,6 +15,10 @@ Phase 3 reduce — Opus · Phase 4 verify — Opus
 `worktree-harden-security-bugs` — see [Remediation status](#remediation-status-2026-08-06) below.
 The findings table and the original remediation order are preserved as the audit found them.
 
+**Residual closure (2026-08-10):** one of the three accepted residuals is now CLOSED and the other
+two are confirmed NOT closable at acceptable cost, with the evidence recorded — see
+[Residual closure](#residual-closure-2026-08-10).
+
 **Stakeholder-facing version:** `report.html` (per-finding one-sentence summary + plain-language
 explanation, technical trace collapsed). **Full detail:** `findings/consolidated.md` (reduce) and
 `findings/verified.md` (verification). **Raw corpus:** `raw/` — 16 cluster reports + 2 repo maps.
@@ -212,6 +216,103 @@ not something re-reading catches:
 One process note: a review round was hard-refused by the model provider as "possible cybersecurity
 risk" on the basis of adversarial phrasing in the prompt. The same substance in review vocabulary
 went through unchanged.
+
+## Residual closure (2026-08-10)
+
+The 2026-08-06 remediation left three accepted residuals. Each was then assessed for whether it could
+be closed with tests that actually run. Recorded here because two of the three answers are negative
+and rest on measurements that would otherwise be lost (the throwaway branch that produced them is
+deleted).
+
+### F-06's eviction race — CLOSED
+
+Fixed by an in-use lease with reservation-based eviction (PR #435). A proof leases the version before
+resolving its binary and holds it through execution; eviction takes a reservation rather than asking a
+question, so reserve-and-delete is one critical section.
+
+Five rounds of adversarial review were needed, and **every round found a defect in the previous
+round's fix** — that is the part worth remembering:
+
+| Round | What was still wrong |
+|---|---|
+| 1 | The lease was a *predicate*, so `is_leased()` then `remove_dir_all` was the same check-then-act it replaced |
+| 1 | Proofs waiting on the prove permit were unprotected — the exact case the fix claimed to cover |
+| 1 | A third deletion path (the download publisher) consulted nothing |
+| 1 | The single-process premise was false: the startup sweep ran BEFORE the port bind |
+| 2 | "Held" and "being deleted" were conflated, so a download reported success over a directory mid-deletion |
+| 2 | A SECOND process shares the cache (`scripts/download-bb.ts`), which the module comment explicitly denied |
+| 2 | A held candidate never re-armed the retry pass, so the size cap could stay exceeded |
+| 3 | "Held" does not imply "valid" — `bb::prove` leases before `find_bb` verifies |
+| 3 | Both advertised escape hatches were broken (`--force` parsed as a version; `BB_VERSIONS_DIR` bypassed nothing) |
+| 4 | The re-probe ran AFTER `downloadBb`, but the destructive publish is INSIDE it |
+
+The reviewer's verdict on whether that pattern indicted the approach: it did not — the findings came
+from untested integration boundaries, above all the second writer, rather than from the state machine.
+
+**A pre-existing UX bug surfaced while assessing this.** The new "version is being evicted" refusal
+returns 503, and the SDK's WASM fallback is gated on `!(err instanceof HTTPError)` — so a 503 fell
+through to a thrown error. Only 403 ever degraded. That meant quitting the accelerator mid-proof
+already failed the dApp's transaction outright, before any of this work. Fixed in the same PR; the
+mitigation ships with the trigger.
+
+**Still open by choice:** cross-process exclusion. `scripts/download-bb.ts` shares
+`~/.aztec-accelerator/versions` by default and the lease cannot see it. The tool now refuses to run
+while the accelerator answers on its port and re-checks immediately before publishing, but a
+check-to-unlink gap remains. Accepted as a low-impact developer-tooling residual — worst outcome is a
+failed proof and a re-download. Building cross-process locking for it was explicitly advised against.
+
+### F-02's same-UID window — NOT closed, and now known to be untestable on Windows
+
+The closure would be post-install identity verification: read back the anchor the trust store actually
+ended up with and compare it to the bytes that were validated. Writing that is easy. The question was
+whether it could be TESTED, because the production install path raises a consent dialog on macOS and
+Windows and CI cannot answer a dialog.
+
+A throwaway spike measured it. **The verification only needs the certificate PRESENT, not TRUSTED** —
+trust settings are what prompt — so the question became whether a test can seed a store
+non-interactively and read it back.
+
+**macOS: YES.** `security create-keychain` → `unlock` → `import` → `find-certificate` all complete
+silently against a keychain under a temp `HOME`, and the SHA-1 read back matches the SHA-1 of the
+seeded file exactly:
+
+```
+store=[8ED7D0F2B489F595C80685D44CF8D562B58602A0]
+ file=[8ED7D0F2B489F595C80685D44CF8D562B58602A0]
+```
+
+**Windows: NO.** Five routes, each timeboxed in its own CI step:
+
+| Route | Result |
+|---|---|
+| `Import-Certificate -CertStoreLocation Cert:\CurrentUser\Root` | hangs — consent dialog |
+| .NET `X509Store("Root","CurrentUser").Add()` | hangs — consent dialog |
+| `certutil -user -addstore Root` | hangs — consent dialog |
+| machine `Root` + expected inheritance | seeds silently, but **invisible** to `certutil -user -store Root` |
+| machine group-policy `Root` + inheritance | same — seeds, invisible |
+
+The last two are the useful negative: `certutil -user -store Root` reads the per-user physical store
+only, NOT machine roots, so the logical-store inheritance that would have made this testable does not
+apply to the production query. Windows guards `CurrentUser\Root` at every layer.
+
+Ruled out without spending a run, on advice: direct `HKCU\...\SystemCertificates\Root\Certificates`
+blob writes (an ordinary store open filters unprotected registry roots, so it would not satisfy the
+real query), a `ProtectedRoots` policy override (no documented one exists), and running as SYSTEM
+(different profile; only helps for machine Root, already covered above).
+
+**Conclusion:** F-02's closure is implementable and genuinely testable on macOS and Linux, and
+untestable on Windows by any route found. Shipping security code that CI compiles but never executes
+is the exact shape of the `NTE_NOT_FOUND` defect this remediation already produced once, so the
+residual stands rather than being closed on two platforms and asserted on the third.
+
+### F-05's empty-store ambiguity — not pursued
+
+A genuinely empty certificate store makes the removal control answer "could not verify" for a removal
+that had nothing to remove. It fails safe, costs a manual re-check, and the candidate replacement
+(`security show-keychain-info`) needs a real-Mac matrix across supported macOS versions to establish
+that it succeeds on an empty unlocked keychain and fails without prompting otherwise. Trading a
+verified-safe behaviour for an unverified one is how the `NTE_NOT_FOUND` defect happened. The lead is
+recorded at the call site for anyone with the hardware.
 
 ## Dropped / not pursued
 

--- a/packages/accelerator/core/src/bb.rs
+++ b/packages/accelerator/core/src/bb.rs
@@ -188,6 +188,10 @@ pub async fn prove(
     version: Option<&versions::AztecVersion>,
     threads: Option<usize>,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+    // Take the lease BEFORE resolving the path, and hold it for this whole function — the window
+    // being closed is between "cleanup decided this version was evictable" and "we executed it".
+    // `_lease` is bound (not `_`) so it lives to the end of the scope rather than dropping instantly.
+    let _lease = version.map(|v| versions::acquire_lease(v.as_str()));
     let bb_path =
         find_bb(version).map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })?;
 

--- a/packages/accelerator/core/src/bb.rs
+++ b/packages/accelerator/core/src/bb.rs
@@ -191,7 +191,18 @@ pub async fn prove(
     // Take the lease BEFORE resolving the path, and hold it for this whole function — the window
     // being closed is between "cleanup decided this version was evictable" and "we executed it".
     // `_lease` is bound (not `_`) so it lives to the end of the scope rather than dropping instantly.
-    let _lease = version.map(|v| versions::acquire_lease(v.as_str()));
+    // The server leases before it waits for the prove permit; this second lease covers direct callers
+    // of `prove` and costs nothing (the registry is refcounted, so nesting is fine). `None` means a
+    // cleanup is deleting this version right now — fail rather than execute a binary being unlinked.
+    let _lease = match version {
+        Some(v) => match versions::acquire_lease(v.as_str()) {
+            Some(l) => Some(l),
+            None => {
+                return Err(format!("bb {v}: the cached version is being evicted").into());
+            }
+        },
+        None => None,
+    };
     let bb_path =
         find_bb(version).map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })?;
 

--- a/packages/accelerator/core/src/server.rs
+++ b/packages/accelerator/core/src/server.rs
@@ -409,6 +409,10 @@ pub(crate) enum ProveError {
     /// the single prove permit (slowloris / stalled upload). Distinct from PayloadTooLarge.
     BodyReadTimeout,
     ServiceUnavailable,
+    /// The cached bb for the requested version is being evicted right now (F-06 lease). Same 503 as
+    /// a shutdown — the SDK degrades to WASM on either — but a truthful body, because "shutting down"
+    /// would send someone debugging this to entirely the wrong place.
+    VersionEvicting,
     DownloadFailed {
         version: String,
         detail: String,
@@ -451,6 +455,11 @@ impl IntoResponse for ProveError {
                 StatusCode::SERVICE_UNAVAILABLE,
                 "service_unavailable",
                 "Proving service shutting down".to_string(),
+            ),
+            ProveError::VersionEvicting => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "version_evicting",
+                "The cached bb for this version is being evicted; retry".to_string(),
             ),
             ProveError::DownloadFailed { version, detail } => (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/packages/accelerator/core/src/server.rs
+++ b/packages/accelerator/core/src/server.rs
@@ -252,14 +252,21 @@ pub async fn start(state: AppState) -> Result<(), Box<dyn std::error::Error + Se
         .bundled_version
         .clone()
         .unwrap_or_else(|| DEFAULT_BB_VERSION.to_string());
-    tokio::spawn(async move {
-        crate::versions::sweep_cache_on_start(&bundled).await;
-    });
 
     let app = router(state);
     let addr = SocketAddr::from(([127, 0, 0, 1], PORT));
     let listener = bind_with_retry(addr).await?;
     tracing::info!("Accelerator server listening on {addr}");
+
+    // ONLY after the bind succeeds. The in-use lease that protects a cached binary from eviction is
+    // per-process, and that is sound only because exactly one instance ever evicts. Spawning this
+    // before the bind broke that: a second instance would sweep the shared cache during its bind
+    // retry — with its own empty registry, so blind to the running instance's leases — before finally
+    // losing the port and exiting. This ordering is load-bearing, not stylistic (F-06 follow-up,
+    // found by a codex review).
+    tokio::spawn(async move {
+        crate::versions::sweep_cache_on_start(&bundled).await;
+    });
     axum::serve(listener, app).await?;
     Ok(())
 }

--- a/packages/accelerator/core/src/server/prove.rs
+++ b/packages/accelerator/core/src/server/prove.rs
@@ -314,6 +314,25 @@ pub(crate) async fn prove(
     }
     let threads = compute_threads(&state);
 
+    // Lease the version BEFORE waiting for the prove permit. `bb::prove` leases too, but that is far
+    // too late on its own: this request may sit in the permit queue for the length of another proof,
+    // and a cleanup pass in that window would evict the binary out from under it — the exact failure
+    // the mtime heuristic could not express and that the first cut of this lease still allowed
+    // (found by a codex review). Held (RAII) for the rest of the handler.
+    //
+    // `None` means a cleanup is deleting this version right now; report unavailable rather than race
+    // it. The next request re-downloads.
+    let _version_lease = match version_for_prove.as_ref() {
+        Some(v) => match versions::acquire_lease(v.as_str()) {
+            Some(lease) => Some(lease),
+            None => {
+                tracing::warn!(version = %v, "Version is being evicted; refusing rather than racing the deletion");
+                return Err(ProveError::ServiceUnavailable);
+            }
+        },
+        None => None,
+    };
+
     // A1: acquire the single prove permit ONLY now — around the CPU-bound proof — not across the body
     // read + version download above (which ran concurrently under the inflight cap). bb saturates all
     // cores, so proofs still run strictly one at a time; only the serialized *proving* is gated, not I/O.

--- a/packages/accelerator/core/src/server/prove.rs
+++ b/packages/accelerator/core/src/server/prove.rs
@@ -327,7 +327,7 @@ pub(crate) async fn prove(
             Some(lease) => Some(lease),
             None => {
                 tracing::warn!(version = %v, "Version is being evicted; refusing rather than racing the deletion");
-                return Err(ProveError::ServiceUnavailable);
+                return Err(ProveError::VersionEvicting);
             }
         },
         None => None,

--- a/packages/accelerator/core/src/versions/cache_layout.rs
+++ b/packages/accelerator/core/src/versions/cache_layout.rs
@@ -202,7 +202,7 @@ fn read_bb_marker_at(
 
 /// Fail-closed integrity check for a bb at explicit paths: the binary must be a present regular file
 /// whose streamed SHA-256 matches its valid marker's `binary_sha256`. Path-parameterized for testing.
-fn verify_bb_entry(
+pub(super) fn verify_bb_entry(
     bb_path: &Path,
     marker_path: &Path,
     expect_version: &str,

--- a/packages/accelerator/core/src/versions/cache_layout.rs
+++ b/packages/accelerator/core/src/versions/cache_layout.rs
@@ -252,12 +252,14 @@ pub fn verify_cached_bb(version: &AztecVersion) -> Result<PathBuf, String> {
 /// reads. Best-effort and silent: this is an optimisation of eviction ORDER, never a correctness gate,
 /// and a read-only or full filesystem must not fail a proof.
 ///
-/// **This is a hint, not a lease** (codex round 2, correctly). Cleanup reads the mtime and then
-/// unlinks; a proof that verifies and marks BETWEEN those two steps still loses its binary. What
-/// changed is the size of the window: from "any entry older than the 5-minute window is fair game
-/// while a proof is queued behind the semaphore" down to the gap between two adjacent operations in
-/// the cleanup loop. Closing it entirely needs the cross-request lease that `FINDINGS.md` B2 already
-/// defers; the failure mode meanwhile is a recoverable re-download, not a wrong proof.
+/// **This is a hint; the LEASE is the real guard** (see `versions::leases`). It was written when the
+/// mtime window was the only protection, and on its own it could not close the race: cleanup read the
+/// mtime and then unlinked, so a proof starting between those two steps still lost its binary, and a
+/// proof queued behind the semaphore for longer than the window was never protected at all.
+///
+/// `is_protected` now consults the lease FIRST and falls back to this. The mtime is still worth
+/// refreshing because it covers the one gap a lease cannot: a version downloaded but not yet held by
+/// any proof.
 ///
 /// Remove-then-create rather than an mtime syscall: adding or removing a directory ENTRY updates the
 /// directory's mtime on every platform we ship, whereas `File::set_modified` on a directory handle

--- a/packages/accelerator/core/src/versions/downloader.rs
+++ b/packages/accelerator/core/src/versions/downloader.rs
@@ -297,8 +297,24 @@ pub(crate) fn install_version_dir(
         write_bb_marker(&staging, version, archive_digest, &binary_digest)?;
 
         // Fail-closed publish: drop any live entry, then rename the stage into place.
+        //
+        // Except when a proof is holding it. Two concurrent first-time downloads of the same version
+        // are possible, and the later publisher would otherwise delete the directory the earlier
+        // one's proof is resolving or executing from (F-06 follow-up, found by a codex review).
+        // Keeping the existing entry is safe: it is already digest-verified and marker-backed, so it
+        // is the same binary this stage would have published.
         if version_dir.exists() {
+            let Some(_reservation) = super::leases::begin_evict(version) else {
+                tracing::info!(
+                    version = %version,
+                    "A proof is using this version; keeping the published copy and discarding the fresh stage"
+                );
+                let _ = std::fs::remove_dir_all(&staging);
+                return Ok(());
+            };
             std::fs::remove_dir_all(version_dir)?;
+            std::fs::rename(&staging, version_dir)?;
+            return Ok(());
         }
         std::fs::rename(&staging, version_dir)?;
         Ok(())

--- a/packages/accelerator/core/src/versions/downloader.rs
+++ b/packages/accelerator/core/src/versions/downloader.rs
@@ -6,7 +6,8 @@
 //! The smaller identity/platform/layout/cache concerns stay in the `versions` module root.
 
 use super::cache_layout::{
-    bb_binary_name, sha256_file, verify_cached_bb, versions_base_dir, write_bb_marker,
+    bb_binary_name, sha256_file, verify_bb_entry, verify_cached_bb, versions_base_dir,
+    write_bb_marker, MARKER_NAME,
 };
 use super::release_metadata::{
     current_platform, download_url, fetch_github_asset_digest, http_client, sha256_hex,
@@ -310,17 +311,36 @@ pub(crate) fn install_version_dir(
                     std::fs::rename(&staging, version_dir)?;
                     return Ok(());
                 }
-                // A proof is executing the published copy. Keep it and drop our stage: it is already
-                // digest-verified and marker-backed, so it is the same binary this stage would have
-                // published, and deleting it would pull the file out from under a running proof.
-                Err(super::leases::Contended::Held) => {
-                    tracing::info!(
-                        version = %version,
-                        "A proof is using this version; keeping the published copy and discarding the fresh stage"
-                    );
-                    let _ = std::fs::remove_dir_all(&staging);
-                    return Ok(());
-                }
+                // A proof is executing the published copy, so deleting it would pull the file out
+                // from under a running proof. Keep it — but only after PROVING it is good.
+                //
+                // "It is leased, therefore it is verified" is false: `bb::prove` leases before
+                // `find_bb` verifies, so a caller can hold an entry whose verification then fails.
+                // Without this re-check, a download staged to REPAIR a corrupt entry would discard
+                // its valid stage and report success over the corrupt one (found by a codex review).
+                Err(super::leases::Contended::Held) => match verify_bb_entry(
+                    &version_dir.join(bb_binary_name()),
+                    &version_dir.join(MARKER_NAME),
+                    version,
+                    current_platform(),
+                ) {
+                    Ok(_) => {
+                        tracing::info!(
+                            version = %version,
+                            "A proof is using this version and it verifies; keeping it and discarding the fresh stage"
+                        );
+                        let _ = std::fs::remove_dir_all(&staging);
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        let _ = std::fs::remove_dir_all(&staging);
+                        return Err(std::io::Error::other(format!(
+                            "bb {version}: a proof holds this entry but it does not verify ({e}); \
+                             cannot replace it while in use — retry once the proof finishes"
+                        ))
+                        .into());
+                    }
+                },
                 // A cleanup pass is DELETING it. Keeping it would report success over a directory
                 // that is about to stop existing (found by a codex review). Fail so the caller
                 // retries once the eviction has finished.

--- a/packages/accelerator/core/src/versions/downloader.rs
+++ b/packages/accelerator/core/src/versions/downloader.rs
@@ -304,17 +304,34 @@ pub(crate) fn install_version_dir(
         // Keeping the existing entry is safe: it is already digest-verified and marker-backed, so it
         // is the same binary this stage would have published.
         if version_dir.exists() {
-            let Some(_reservation) = super::leases::begin_evict(version) else {
-                tracing::info!(
-                    version = %version,
-                    "A proof is using this version; keeping the published copy and discarding the fresh stage"
-                );
-                let _ = std::fs::remove_dir_all(&staging);
-                return Ok(());
-            };
-            std::fs::remove_dir_all(version_dir)?;
-            std::fs::rename(&staging, version_dir)?;
-            return Ok(());
+            match super::leases::begin_evict(version) {
+                Ok(_reservation) => {
+                    std::fs::remove_dir_all(version_dir)?;
+                    std::fs::rename(&staging, version_dir)?;
+                    return Ok(());
+                }
+                // A proof is executing the published copy. Keep it and drop our stage: it is already
+                // digest-verified and marker-backed, so it is the same binary this stage would have
+                // published, and deleting it would pull the file out from under a running proof.
+                Err(super::leases::Contended::Held) => {
+                    tracing::info!(
+                        version = %version,
+                        "A proof is using this version; keeping the published copy and discarding the fresh stage"
+                    );
+                    let _ = std::fs::remove_dir_all(&staging);
+                    return Ok(());
+                }
+                // A cleanup pass is DELETING it. Keeping it would report success over a directory
+                // that is about to stop existing (found by a codex review). Fail so the caller
+                // retries once the eviction has finished.
+                Err(super::leases::Contended::Evicting) => {
+                    let _ = std::fs::remove_dir_all(&staging);
+                    return Err(std::io::Error::other(format!(
+                        "bb {version}: a cleanup pass is evicting this version; retry"
+                    ))
+                    .into());
+                }
+            }
         }
         std::fs::rename(&staging, version_dir)?;
         Ok(())

--- a/packages/accelerator/core/src/versions/downloader.rs
+++ b/packages/accelerator/core/src/versions/downloader.rs
@@ -589,6 +589,101 @@ mod tests {
     /// F-007 staged verified install: `install_version_dir` extracts + finalizes + writes the marker in
     /// a unique staging dir, then publishes fail-closed — replacing any stale entry wholesale, leaving
     /// no staging dir, and producing a marker whose `binary_sha256` matches the FINAL published binary.
+    /// A valid gzipped tar carrying a single fake `bb`, plus its archive digest.
+    fn fake_tarball() -> (Vec<u8>, String) {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+
+        let bb_content = b"#!/bin/sh\necho fake-bb\n";
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
+        {
+            let mut builder = tar::Builder::new(&mut encoder);
+            let mut header = tar::Header::new_gnu();
+            header.set_size(bb_content.len() as u64);
+            header.set_mode(0o755);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, bb_binary_name(), &bb_content[..])
+                .unwrap();
+            builder.finish().unwrap();
+        }
+        let tarball = encoder.finish().unwrap();
+        let digest = sha256_hex(&tarball);
+        (tarball, digest)
+    }
+
+    // ── Publisher contention (F-06 lease) ─────────────────────────────────────────────────────
+    // `install_version_dir` deletes any live entry before renaming its stage into place. These pin
+    // what it does when that entry is contended. The parsing tests elsewhere do not reach this
+    // wiring, which is exactly how a bug survived here through a review round.
+
+    /// A proof holds the published copy and it verifies: keep it, drop our stage, report success.
+    /// Deleting it would pull the binary out from under a running proof.
+    #[test]
+    fn publishing_over_a_held_and_valid_entry_preserves_it() {
+        let (tarball, digest) = fake_tarball();
+        let base = tempfile::tempdir().unwrap();
+        let version_dir = base.path().join("5.0.0-held-valid");
+
+        // Publish once so a valid, marker-backed entry exists.
+        install_version_dir(&version_dir, &tarball, "5.0.0-held-valid", &digest).unwrap();
+        let published = std::fs::read(version_dir.join(bb_binary_name())).unwrap();
+
+        // Now a proof holds it and a second publish arrives.
+        let _lease = super::super::leases::acquire("5.0.0-held-valid").unwrap();
+        install_version_dir(&version_dir, &tarball, "5.0.0-held-valid", &digest)
+            .expect("a held-and-valid entry is preserved, not an error");
+
+        assert!(
+            version_dir.exists(),
+            "the entry a proof is executing must survive"
+        );
+        assert_eq!(
+            std::fs::read(version_dir.join(bb_binary_name())).unwrap(),
+            published,
+            "the original bytes must still be there"
+        );
+    }
+
+    /// A proof holds it but it does NOT verify: we may not replace it (in use) and must not claim
+    /// success over it. Pre-fix this discarded a valid stage and returned Ok over the corrupt entry.
+    #[test]
+    fn publishing_over_a_held_but_corrupt_entry_fails_loudly() {
+        let (tarball, digest) = fake_tarball();
+        let base = tempfile::tempdir().unwrap();
+        let version_dir = base.path().join("5.0.0-held-corrupt");
+
+        install_version_dir(&version_dir, &tarball, "5.0.0-held-corrupt", &digest).unwrap();
+        // Corrupt the published binary so it no longer matches its marker.
+        std::fs::write(version_dir.join(bb_binary_name()), b"tampered").unwrap();
+
+        let _lease = super::super::leases::acquire("5.0.0-held-corrupt").unwrap();
+        let err = install_version_dir(&version_dir, &tarball, "5.0.0-held-corrupt", &digest)
+            .expect_err("must not report success over an entry that does not verify");
+        assert!(
+            err.to_string().contains("does not verify"),
+            "the error should say why: {err}"
+        );
+    }
+
+    /// A cleanup pass is DELETING it. Keeping it would vouch for a directory about to disappear.
+    #[test]
+    fn publishing_over_an_evicting_entry_fails_rather_than_vouching_for_it() {
+        let (tarball, digest) = fake_tarball();
+        let base = tempfile::tempdir().unwrap();
+        let version_dir = base.path().join("5.0.0-evicting");
+
+        install_version_dir(&version_dir, &tarball, "5.0.0-evicting", &digest).unwrap();
+
+        let _reservation = super::super::leases::begin_evict("5.0.0-evicting").unwrap();
+        let err = install_version_dir(&version_dir, &tarball, "5.0.0-evicting", &digest)
+            .expect_err("a directory being deleted must not be reported as published");
+        assert!(
+            err.to_string().contains("evicting"),
+            "the error should name the reason: {err}"
+        );
+    }
+
     #[test]
     fn install_version_dir_stages_marks_and_publishes() {
         use flate2::write::GzEncoder;

--- a/packages/accelerator/core/src/versions/leases.rs
+++ b/packages/accelerator/core/src/versions/leases.rs
@@ -24,14 +24,23 @@
 //! as long as its guard lives. A version cannot be acquired while it is being deleted, and cannot be
 //! deleted while it is held.
 //!
-//! ## Why in-process is sufficient
+//! ## Scope: in-process, and what that does NOT cover
 //!
 //! Exactly one accelerator instance serves at a time — the port bind in `server::start` decides which,
-//! and eviction is only ever started AFTER that bind succeeds (a losing instance exits without ever
-//! sweeping; this ordering is load-bearing and noted at the call site). Cleanup is otherwise spawned
-//! from this process's own prove path. So every party that could evict and every party that could be
-//! executing a binary live in this address space, and a `Mutex` is the whole synchronisation story. A
-//! file-based lease would add stale-lock and PID-reuse questions to buy nothing.
+//! and eviction only starts AFTER that bind succeeds (a losing instance exits without ever sweeping;
+//! that ordering is load-bearing and noted at the call site). Cleanup is otherwise spawned from this
+//! process's own prove path. So within the app, every evictor and every executor share this address
+//! space and a `Mutex` is the whole synchronisation story.
+//!
+//! **It does not cover other processes, and one exists.** `scripts/download-bb.ts` defaults to the
+//! same `~/.aztec-accelerator/versions` directory and both replaces live entries and applies its own
+//! retention deletion, with no knowledge of this registry. A developer running `bun run bb:download`
+//! while the app is proving can still delete a binary in use. (An earlier revision of this comment
+//! claimed every party lived in this address space — that was simply false; found by a codex review.)
+//! That tool now refuses to touch the cache while the accelerator is answering on its port, which
+//! converts a silent race into a clear message; a genuine cross-process protocol is not built here
+//! because the remaining exposure is a developer-tooling collision whose worst outcome is a failed
+//! proof and a re-download.
 //!
 //! ## Refcounted, not a flag
 //!
@@ -127,19 +136,31 @@ pub fn acquire(version: &str) -> Option<Lease> {
     }
 }
 
-/// Reserve `version` for deletion, or `None` if a proof holds it (or another pass already reserved).
+/// Why a reservation was refused. The distinction matters to the publisher: "a proof is using this"
+/// means the existing copy is worth keeping, while "someone is deleting it" means it is about to stop
+/// existing and keeping it would be a lie. Collapsing the two let a download report success over a
+/// directory that was mid-deletion (found by a codex review of the first reservation design).
+#[derive(Debug, PartialEq, Eq)]
+pub enum Contended {
+    /// At least one proof holds it.
+    Held,
+    /// A cleanup pass is deleting it right now.
+    Evicting,
+}
+
+/// Reserve `version` for deletion, or report who has it.
 ///
 /// The returned guard must be held across the actual `remove_dir_all`. That is the whole point: from
 /// an acquirer's perspective the reservation and the deletion are one critical section, so there is no
 /// gap for a proof to slip into.
-pub fn begin_evict(version: &str) -> Option<EvictReservation> {
+pub fn begin_evict(version: &str) -> Result<EvictReservation, Contended> {
     let mut map = lock();
     match map.get(version) {
-        // Held by a proof, or already reserved by another pass — either way, not ours to delete.
-        Some(_) => None,
+        Some(State::Held(_)) => Err(Contended::Held),
+        Some(State::Evicting) => Err(Contended::Evicting),
         None => {
             map.insert(version.to_string(), State::Evicting);
-            Some(EvictReservation {
+            Ok(EvictReservation {
                 version: version.to_string(),
             })
         }
@@ -212,7 +233,7 @@ mod tests {
     fn a_held_version_cannot_be_reserved_for_deletion() {
         let name = v("held-vs-evict");
         let _l = acquire(&name).unwrap();
-        assert!(begin_evict(&name).is_none());
+        assert_eq!(begin_evict(&name).err(), Some(Contended::Held));
     }
 
     /// Two cleanup passes must not both delete the same directory.
@@ -220,7 +241,11 @@ mod tests {
     fn two_passes_cannot_both_reserve() {
         let name = v("double-evict");
         let _first = begin_evict(&name).expect("first pass wins");
-        assert!(begin_evict(&name).is_none(), "second pass must back off");
+        assert_eq!(
+            begin_evict(&name).err(),
+            Some(Contended::Evicting),
+            "second pass must back off, and must know it was a deletion not a proof"
+        );
     }
 
     /// A panicking proof must not pin its version for the life of the process.
@@ -258,9 +283,6 @@ mod tests {
         let _l = acquire(&a).unwrap();
         assert!(is_leased(&a));
         assert!(!is_leased(&b));
-        assert!(
-            begin_evict(&b).is_some(),
-            "unrelated versions stay evictable"
-        );
+        assert!(begin_evict(&b).is_ok(), "unrelated versions stay evictable");
     }
 }

--- a/packages/accelerator/core/src/versions/leases.rs
+++ b/packages/accelerator/core/src/versions/leases.rs
@@ -4,45 +4,67 @@
 //!
 //! Cleanup used to decide "is anyone using this version?" from the version directory's mtime: an
 //! entry touched within a five-minute window was presumed active. That is a heuristic with two
-//! failures. It is too WEAK for a long proof — a proof queued behind the semaphore for longer than
-//! the window loses its binary — and it is inherently racy, because cleanup reads the mtime and then
-//! unlinks, so a proof that starts between those two steps is evicted anyway.
+//! failures. It is too WEAK for a long proof — one queued behind the prove permit for longer than the
+//! window loses its binary — and it is inherently racy, because cleanup reads the mtime and then
+//! unlinks, so a proof starting between those two steps is evicted anyway.
 //!
-//! F-06 made that sharper rather than milder: the total-size cap can evict a `Mainnet` version,
-//! which the per-tier count policy never could, so entries that were previously immortal became
-//! eligible while in use.
+//! F-06 made that sharper rather than milder: the total-size cap can evict a `Mainnet` version, which
+//! the per-tier count policy never could, so entries that were previously immortal became eligible
+//! while in use.
 //!
-//! A lease answers the question directly instead of inferring it. A proof takes one before it
-//! resolves its binary and holds it until it is finished; cleanup skips anything held.
+//! ## Why a predicate is not enough
+//!
+//! The first version of this module exposed `is_leased()` and had eviction call it before deleting.
+//! That is the SAME check-then-act shape as the mtime window, just with a better predicate: the lock
+//! is released between the check and the `remove_dir_all`, so a proof that acquires in that gap still
+//! loses its binary. (Caught by a codex review of the first attempt.)
+//!
+//! So eviction does not ask a question — it takes a RESERVATION. [`begin_evict`] and [`acquire`]
+//! contend for the same map entry under one mutex, and whichever arrives first excludes the other for
+//! as long as its guard lives. A version cannot be acquired while it is being deleted, and cannot be
+//! deleted while it is held.
 //!
 //! ## Why in-process is sufficient
 //!
-//! Exactly one accelerator instance runs at a time — the port guard in `server::bind` enforces it,
-//! and a second instance fails to bind rather than racing. Cleanup is likewise always spawned from
-//! this process's own prove path. So every party that could evict and every party that could be
-//! using a binary live in this address space, and a `Mutex` is the whole synchronisation story. A
-//! file-based lease would add crash-recovery questions (stale lock files, PID reuse) to buy nothing.
+//! Exactly one accelerator instance serves at a time — the port bind in `server::start` decides which,
+//! and eviction is only ever started AFTER that bind succeeds (a losing instance exits without ever
+//! sweeping; this ordering is load-bearing and noted at the call site). Cleanup is otherwise spawned
+//! from this process's own prove path. So every party that could evict and every party that could be
+//! executing a binary live in this address space, and a `Mutex` is the whole synchronisation story. A
+//! file-based lease would add stale-lock and PID-reuse questions to buy nothing.
 //!
 //! ## Refcounted, not a flag
 //!
-//! Concurrent proofs of the SAME version are ordinary — two requests from the same dApp — so release
-//! has to be "when the last holder finishes", not "when any holder finishes". A bare `HashSet` would
-//! let the first `Drop` unprotect a version another proof is still executing.
+//! Concurrent proofs of the SAME version are ordinary — two requests from one dApp — so release has to
+//! mean "the last holder finished", not "a holder finished". A bare set would let the first `Drop`
+//! unprotect a version another proof is still executing.
 
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
 
-/// Version string → number of live leases. Absent means unleased; a count never reaches 0 while
-/// present, because [`Lease::drop`] removes the entry at zero.
-fn registry() -> &'static Mutex<HashMap<String, usize>> {
-    static REGISTRY: OnceLock<Mutex<HashMap<String, usize>>> = OnceLock::new();
+/// What is currently true of a version, for the one map both sides contend on.
+#[derive(Debug)]
+enum State {
+    /// Held by `n` proofs. Never stored as 0 — the entry is removed at the last release.
+    Held(usize),
+    /// A cleanup pass has reserved this for deletion. Acquisition is refused until it finishes.
+    Evicting,
+}
+
+fn registry() -> &'static Mutex<HashMap<String, State>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<String, State>>> = OnceLock::new();
     REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-/// A held lease. The version it names cannot be evicted while this is alive; dropping it releases.
-///
-/// Deliberately has no public constructor other than [`acquire`], so a lease cannot be forged or
-/// released early by anything except going out of scope.
+/// A poisoned lock must not stop either side from making progress: a proof that panicked while
+/// holding still has to release, and a cleanup that panicked still has to un-reserve. Otherwise one
+/// panic pins or bricks a version for the life of the process — the failure this module exists to
+/// prevent, wearing a different hat.
+fn lock() -> std::sync::MutexGuard<'static, HashMap<String, State>> {
+    registry().lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// A held lease. The version it names cannot be evicted while this is alive.
 #[derive(Debug)]
 pub struct Lease {
     version: String,
@@ -50,11 +72,10 @@ pub struct Lease {
 
 impl Drop for Lease {
     fn drop(&mut self) {
-        // A poisoned lock still has to release, or one panicking proof would pin a version for the
-        // life of the process — the failure this whole module exists to avoid, in a subtler form.
-        let mut map = registry().lock().unwrap_or_else(|e| e.into_inner());
+        let mut map = lock();
         match map.get_mut(&self.version) {
-            Some(n) if *n > 1 => *n -= 1,
+            Some(State::Held(n)) if *n > 1 => *n -= 1,
+            // Last holder, or an entry that is somehow not `Held` — either way stop claiming it.
             _ => {
                 map.remove(&self.version);
             }
@@ -62,31 +83,82 @@ impl Drop for Lease {
     }
 }
 
-/// Take a lease on `version` for as long as the returned guard lives.
-///
-/// Call this BEFORE resolving the binary's path, not after: the gap between "cleanup decided this
-/// was evictable" and "we opened the file" is precisely the window being closed.
-pub fn acquire(version: &str) -> Lease {
-    let mut map = registry().lock().unwrap_or_else(|e| e.into_inner());
-    *map.entry(version.to_string()).or_insert(0) += 1;
-    Lease {
-        version: version.to_string(),
+/// A reservation to delete. While alive, [`acquire`] refuses this version.
+#[derive(Debug)]
+pub struct EvictReservation {
+    version: String,
+}
+
+impl Drop for EvictReservation {
+    fn drop(&mut self) {
+        let mut map = lock();
+        // Only clear OUR reservation. If a `Held` entry is somehow present, a proof owns it now and
+        // removing it would silently unprotect that proof.
+        if matches!(map.get(&self.version), Some(State::Evicting)) {
+            map.remove(&self.version);
+        }
     }
 }
 
-/// Is any proof currently holding `version`? Consulted by eviction.
+/// Take a lease on `version`, or `None` if a cleanup pass is deleting it right now.
+///
+/// `None` means "this binary is going away" — callers treat it as a cache miss and re-download rather
+/// than racing the deletion.
+///
+/// Call this BEFORE resolving the path AND before any wait that precedes execution (the prove permit,
+/// a download): the window being closed runs from "cleanup could decide this is evictable" all the way
+/// to "we finished executing it".
+pub fn acquire(version: &str) -> Option<Lease> {
+    let mut map = lock();
+    match map.get_mut(version) {
+        Some(State::Evicting) => None,
+        Some(State::Held(n)) => {
+            *n += 1;
+            Some(Lease {
+                version: version.to_string(),
+            })
+        }
+        None => {
+            map.insert(version.to_string(), State::Held(1));
+            Some(Lease {
+                version: version.to_string(),
+            })
+        }
+    }
+}
+
+/// Reserve `version` for deletion, or `None` if a proof holds it (or another pass already reserved).
+///
+/// The returned guard must be held across the actual `remove_dir_all`. That is the whole point: from
+/// an acquirer's perspective the reservation and the deletion are one critical section, so there is no
+/// gap for a proof to slip into.
+pub fn begin_evict(version: &str) -> Option<EvictReservation> {
+    let mut map = lock();
+    match map.get(version) {
+        // Held by a proof, or already reserved by another pass — either way, not ours to delete.
+        Some(_) => None,
+        None => {
+            map.insert(version.to_string(), State::Evicting);
+            Some(EvictReservation {
+                version: version.to_string(),
+            })
+        }
+    }
+}
+
+/// Is any proof currently holding `version`? Diagnostics only — eviction must use [`begin_evict`],
+/// because a bare query cannot be atomic with the deletion that follows it.
+#[cfg(test)]
 pub fn is_leased(version: &str) -> bool {
-    registry()
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .contains_key(version)
+    matches!(lock().get(version), Some(State::Held(_)))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// Unique per test so the process-global registry cannot make these order-dependent.
+    /// Unique per test: the registry is process-global, so shared names would make these
+    /// order-dependent.
     fn v(tag: &str) -> String {
         format!("5.0.0-lease-{tag}")
     }
@@ -96,50 +168,99 @@ mod tests {
         let name = v("basic");
         assert!(!is_leased(&name));
         {
-            let _l = acquire(&name);
-            assert!(is_leased(&name), "a held lease must be visible to eviction");
+            let _l = acquire(&name).expect("nothing is evicting it");
+            assert!(is_leased(&name));
         }
         assert!(!is_leased(&name), "dropping the guard must release");
     }
 
-    /// The reason this is a refcount and not a flag: two concurrent proofs of the same version are
-    /// ordinary, and the first one finishing must not unprotect the second.
+    /// Why this is a refcount and not a flag: two concurrent proofs of one version are ordinary, and
+    /// the first to finish must not unprotect the second.
     #[test]
     fn the_last_holder_releases_not_the_first() {
         let name = v("refcount");
-        let a = acquire(&name);
-        let b = acquire(&name);
+        let a = acquire(&name).unwrap();
+        let b = acquire(&name).unwrap();
         drop(a);
         assert!(
             is_leased(&name),
-            "still held by the second proof — releasing here would evict a binary in use"
+            "still held — releasing here would expose a binary in use"
         );
         drop(b);
         assert!(!is_leased(&name));
     }
 
-    /// A panicking proof must not pin its version forever — that would be the same class of bug
-    /// (something un-evictable for the life of the process) that this module removes.
+    /// THE property the predicate version could not provide: a reservation and its deletion are one
+    /// critical section, so a proof cannot slip in between "cleanup decided" and "cleanup deleted".
+    #[test]
+    fn a_reservation_excludes_acquisition_until_it_is_released() {
+        let name = v("reserve");
+        let res = begin_evict(&name).expect("unheld, so reservable");
+        assert!(
+            acquire(&name).is_none(),
+            "acquiring mid-deletion is exactly the race this closes"
+        );
+        drop(res);
+        assert!(
+            acquire(&name).is_some(),
+            "once the deletion is done the version is acquirable again"
+        );
+    }
+
+    /// The other direction: a held version cannot be reserved, so cleanup skips it.
+    #[test]
+    fn a_held_version_cannot_be_reserved_for_deletion() {
+        let name = v("held-vs-evict");
+        let _l = acquire(&name).unwrap();
+        assert!(begin_evict(&name).is_none());
+    }
+
+    /// Two cleanup passes must not both delete the same directory.
+    #[test]
+    fn two_passes_cannot_both_reserve() {
+        let name = v("double-evict");
+        let _first = begin_evict(&name).expect("first pass wins");
+        assert!(begin_evict(&name).is_none(), "second pass must back off");
+    }
+
+    /// A panicking proof must not pin its version for the life of the process.
     #[test]
     fn a_panic_while_holding_still_releases() {
         let name = v("panic");
         let held = name.clone();
         let _ = std::panic::catch_unwind(move || {
-            let _l = acquire(&held);
+            let _l = acquire(&held).unwrap();
             panic!("proof blew up");
         });
         assert!(!is_leased(&name), "unwinding must run Drop and release");
+    }
+
+    /// And a panicking CLEANUP must not leave a version permanently unacquirable — the same failure
+    /// from the other side.
+    #[test]
+    fn a_panic_while_reserving_still_un_reserves() {
+        let name = v("panic-evict");
+        let held = name.clone();
+        let _ = std::panic::catch_unwind(move || {
+            let _r = begin_evict(&held).unwrap();
+            panic!("cleanup blew up");
+        });
+        assert!(
+            acquire(&name).is_some(),
+            "a crashed cleanup must not brick the version"
+        );
     }
 
     #[test]
     fn leases_are_per_version() {
         let a = v("iso-a");
         let b = v("iso-b");
-        let _l = acquire(&a);
+        let _l = acquire(&a).unwrap();
         assert!(is_leased(&a));
+        assert!(!is_leased(&b));
         assert!(
-            !is_leased(&b),
-            "a lease must not protect an unrelated version"
+            begin_evict(&b).is_some(),
+            "unrelated versions stay evictable"
         );
     }
 }

--- a/packages/accelerator/core/src/versions/leases.rs
+++ b/packages/accelerator/core/src/versions/leases.rs
@@ -1,0 +1,145 @@
+//! In-use leases for cached `bb` versions — the cross-request guard `FINDINGS.md` B2 deferred.
+//!
+//! ## What this replaces
+//!
+//! Cleanup used to decide "is anyone using this version?" from the version directory's mtime: an
+//! entry touched within a five-minute window was presumed active. That is a heuristic with two
+//! failures. It is too WEAK for a long proof — a proof queued behind the semaphore for longer than
+//! the window loses its binary — and it is inherently racy, because cleanup reads the mtime and then
+//! unlinks, so a proof that starts between those two steps is evicted anyway.
+//!
+//! F-06 made that sharper rather than milder: the total-size cap can evict a `Mainnet` version,
+//! which the per-tier count policy never could, so entries that were previously immortal became
+//! eligible while in use.
+//!
+//! A lease answers the question directly instead of inferring it. A proof takes one before it
+//! resolves its binary and holds it until it is finished; cleanup skips anything held.
+//!
+//! ## Why in-process is sufficient
+//!
+//! Exactly one accelerator instance runs at a time — the port guard in `server::bind` enforces it,
+//! and a second instance fails to bind rather than racing. Cleanup is likewise always spawned from
+//! this process's own prove path. So every party that could evict and every party that could be
+//! using a binary live in this address space, and a `Mutex` is the whole synchronisation story. A
+//! file-based lease would add crash-recovery questions (stale lock files, PID reuse) to buy nothing.
+//!
+//! ## Refcounted, not a flag
+//!
+//! Concurrent proofs of the SAME version are ordinary — two requests from the same dApp — so release
+//! has to be "when the last holder finishes", not "when any holder finishes". A bare `HashSet` would
+//! let the first `Drop` unprotect a version another proof is still executing.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+/// Version string → number of live leases. Absent means unleased; a count never reaches 0 while
+/// present, because [`Lease::drop`] removes the entry at zero.
+fn registry() -> &'static Mutex<HashMap<String, usize>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<String, usize>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// A held lease. The version it names cannot be evicted while this is alive; dropping it releases.
+///
+/// Deliberately has no public constructor other than [`acquire`], so a lease cannot be forged or
+/// released early by anything except going out of scope.
+#[derive(Debug)]
+pub struct Lease {
+    version: String,
+}
+
+impl Drop for Lease {
+    fn drop(&mut self) {
+        // A poisoned lock still has to release, or one panicking proof would pin a version for the
+        // life of the process — the failure this whole module exists to avoid, in a subtler form.
+        let mut map = registry().lock().unwrap_or_else(|e| e.into_inner());
+        match map.get_mut(&self.version) {
+            Some(n) if *n > 1 => *n -= 1,
+            _ => {
+                map.remove(&self.version);
+            }
+        }
+    }
+}
+
+/// Take a lease on `version` for as long as the returned guard lives.
+///
+/// Call this BEFORE resolving the binary's path, not after: the gap between "cleanup decided this
+/// was evictable" and "we opened the file" is precisely the window being closed.
+pub fn acquire(version: &str) -> Lease {
+    let mut map = registry().lock().unwrap_or_else(|e| e.into_inner());
+    *map.entry(version.to_string()).or_insert(0) += 1;
+    Lease {
+        version: version.to_string(),
+    }
+}
+
+/// Is any proof currently holding `version`? Consulted by eviction.
+pub fn is_leased(version: &str) -> bool {
+    registry()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .contains_key(version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Unique per test so the process-global registry cannot make these order-dependent.
+    fn v(tag: &str) -> String {
+        format!("5.0.0-lease-{tag}")
+    }
+
+    #[test]
+    fn a_lease_is_visible_while_held_and_gone_after() {
+        let name = v("basic");
+        assert!(!is_leased(&name));
+        {
+            let _l = acquire(&name);
+            assert!(is_leased(&name), "a held lease must be visible to eviction");
+        }
+        assert!(!is_leased(&name), "dropping the guard must release");
+    }
+
+    /// The reason this is a refcount and not a flag: two concurrent proofs of the same version are
+    /// ordinary, and the first one finishing must not unprotect the second.
+    #[test]
+    fn the_last_holder_releases_not_the_first() {
+        let name = v("refcount");
+        let a = acquire(&name);
+        let b = acquire(&name);
+        drop(a);
+        assert!(
+            is_leased(&name),
+            "still held by the second proof — releasing here would evict a binary in use"
+        );
+        drop(b);
+        assert!(!is_leased(&name));
+    }
+
+    /// A panicking proof must not pin its version forever — that would be the same class of bug
+    /// (something un-evictable for the life of the process) that this module removes.
+    #[test]
+    fn a_panic_while_holding_still_releases() {
+        let name = v("panic");
+        let held = name.clone();
+        let _ = std::panic::catch_unwind(move || {
+            let _l = acquire(&held);
+            panic!("proof blew up");
+        });
+        assert!(!is_leased(&name), "unwinding must run Drop and release");
+    }
+
+    #[test]
+    fn leases_are_per_version() {
+        let a = v("iso-a");
+        let b = v("iso-b");
+        let _l = acquire(&a);
+        assert!(is_leased(&a));
+        assert!(
+            !is_leased(&b),
+            "a lease must not protect an unrelated version"
+        );
+    }
+}

--- a/packages/accelerator/core/src/versions/mod.rs
+++ b/packages/accelerator/core/src/versions/mod.rs
@@ -15,7 +15,7 @@ pub use cache_layout::{
     bb_binary_name, list_cached_versions, verify_cached_bb, version_bb_path, versions_base_dir,
 };
 pub use downloader::download_bb;
-pub use leases::{acquire as acquire_lease, is_leased, Lease};
+pub use leases::{acquire as acquire_lease, Lease};
 pub use release_metadata::{current_platform, download_url};
 pub use version_policy::{
     check_version_selectable, cleanup_old_versions, is_valid_version, sweep_cache_on_start,

--- a/packages/accelerator/core/src/versions/mod.rs
+++ b/packages/accelerator/core/src/versions/mod.rs
@@ -7,6 +7,7 @@
 
 mod cache_layout;
 mod downloader;
+mod leases;
 mod release_metadata;
 mod version_policy;
 
@@ -14,6 +15,7 @@ pub use cache_layout::{
     bb_binary_name, list_cached_versions, verify_cached_bb, version_bb_path, versions_base_dir,
 };
 pub use downloader::download_bb;
+pub use leases::{acquire as acquire_lease, is_leased, Lease};
 pub use release_metadata::{current_platform, download_url};
 pub use version_policy::{
     check_version_selectable, cleanup_old_versions, is_valid_version, sweep_cache_on_start,

--- a/packages/accelerator/core/src/versions/mod.rs
+++ b/packages/accelerator/core/src/versions/mod.rs
@@ -15,7 +15,7 @@ pub use cache_layout::{
     bb_binary_name, list_cached_versions, verify_cached_bb, version_bb_path, versions_base_dir,
 };
 pub use downloader::download_bb;
-pub use leases::{acquire as acquire_lease, Lease};
+pub use leases::{acquire as acquire_lease, Contended, Lease};
 pub use release_metadata::{current_platform, download_url};
 pub use version_policy::{
     check_version_selectable, cleanup_old_versions, is_valid_version, sweep_cache_on_start,

--- a/packages/accelerator/core/src/versions/version_policy.rs
+++ b/packages/accelerator/core/src/versions/version_policy.rs
@@ -375,8 +375,9 @@ pub async fn cleanup_old_versions(bundled: &AztecVersion, in_use: Option<&AztecV
         // overriding the guard would let one request delete the binary another is about to execute. The
         // overshoot is bounded by the burst rate and reclaimed by the next cleanup, which is a different
         // thing from the unbounded growth this cap exists to stop.
-        if super::downloader::recently_active(&dir) {
-            tracing::debug!(version = %version, "Skipping eviction of a recently-active version");
+        //
+        if is_protected(version.as_str(), super::downloader::recently_active(&dir)) {
+            tracing::debug!(version = %version, "Skipping eviction of a protected version");
             deferred_by_active_window = true;
             continue;
         }
@@ -395,6 +396,23 @@ pub async fn cleanup_old_versions(bundled: &AztecVersion, in_use: Option<&AztecV
         tokio::time::sleep(super::downloader::CACHE_ENTRY_ACTIVE_WINDOW).await;
         cleanup_after_active_window(bundled, in_use).await;
     }
+}
+
+/// May this version be deleted right now? `true` means leave it alone.
+///
+/// Two protections, deliberately ordered. A LEASE is the authoritative answer to "is a proof using
+/// this?" — it is held for the whole execution, so a proof that sat behind the prove semaphore for an
+/// hour is still safe. `recently_active` (the directory's mtime inside a five-minute window) is the
+/// weaker fallback, kept only for the gap where a version has been downloaded but no proof holds it
+/// yet.
+///
+/// Split out from the eviction loops because it is the F-06 decision worth pinning: before the lease
+/// existed, cleanup read an mtime and then unlinked, so a proof starting between those two steps lost
+/// its binary — and the size cap made that reachable for `Mainnet` versions the count policy could
+/// never evict. Taking `recently_active` as an argument rather than computing it keeps this a pure
+/// policy function the tests can drive without touching the filesystem clock.
+fn is_protected(version: &str, recently_active: bool) -> bool {
+    super::leases::is_leased(version) || recently_active
 }
 
 /// Bring the cache under [`CACHE_MAX_TOTAL_BYTES`] at process start (F-06, round 3).
@@ -437,7 +455,7 @@ async fn cleanup_after_active_window(bundled: &AztecVersion, in_use: Option<&Azt
         .collect();
     for version in versions_to_evict_for_size(&sized, bundled, in_use, CACHE_MAX_TOTAL_BYTES) {
         let dir = base.join(version.as_str());
-        if super::downloader::recently_active(&dir) {
+        if is_protected(version.as_str(), super::downloader::recently_active(&dir)) {
             continue;
         }
         match std::fs::remove_dir_all(&dir) {
@@ -696,6 +714,47 @@ mod tests {
         // Cap of one binary against four: everything evictable must go, and only those two survive.
         let evicted = versions_to_evict_for_size(&sized, &av("5.0.0"), Some(&av("5.0.1")), BB);
         assert_eq!(evicted, vec![av("5.0.2"), av("5.0.3")]);
+    }
+
+    // ── F-06 residual closure: the in-use lease ───────────────────────────────────────────────
+    // Before the lease, cleanup answered "is anyone using this?" from the directory's mtime: it read
+    // the timestamp and then unlinked, so a proof that started between those two steps lost its
+    // binary, and a proof queued behind the semaphore for longer than the five-minute window was
+    // never protected at all. F-06's size cap made that reachable for `Mainnet` versions, which the
+    // per-tier count policy could never evict.
+
+    /// THE property. A leased version survives even when nothing else would protect it — the mtime
+    /// window has already elapsed. Pre-lease this returned false and the binary was deleted.
+    #[test]
+    fn a_leased_version_is_protected_even_once_its_activity_window_has_elapsed() {
+        let name = "5.0.0-policy-leased";
+        assert!(
+            !is_protected(name, false),
+            "unleased and inactive: evictable, or the cap could never bind"
+        );
+
+        let lease = super::super::leases::acquire(name);
+        assert!(
+            is_protected(name, false),
+            "a proof holds this — evicting it is the bug F-06's cap made reachable"
+        );
+
+        drop(lease);
+        assert!(!is_protected(name, false), "released, so evictable again");
+    }
+
+    /// The weaker guard is still there for the window before a lease exists — a version that has
+    /// just been downloaded but that no proof holds yet.
+    #[test]
+    fn the_activity_window_still_protects_an_unleased_but_fresh_version() {
+        assert!(is_protected("5.0.0-policy-fresh", true));
+    }
+
+    /// A lease protects only what it names.
+    #[test]
+    fn a_lease_does_not_protect_unrelated_versions() {
+        let _l = super::super::leases::acquire("5.0.0-policy-mine");
+        assert!(!is_protected("5.0.0-policy-theirs", false));
     }
 
     #[test]

--- a/packages/accelerator/core/src/versions/version_policy.rs
+++ b/packages/accelerator/core/src/versions/version_policy.rs
@@ -376,14 +376,8 @@ pub async fn cleanup_old_versions(bundled: &AztecVersion, in_use: Option<&AztecV
         // overshoot is bounded by the burst rate and reclaimed by the next cleanup, which is a different
         // thing from the unbounded growth this cap exists to stop.
         //
-        if is_protected(version.as_str(), super::downloader::recently_active(&dir)) {
-            tracing::debug!(version = %version, "Skipping eviction of a protected version");
+        if evict_if_unheld(&version, &dir, super::downloader::recently_active(&dir)) {
             deferred_by_active_window = true;
-            continue;
-        }
-        match std::fs::remove_dir_all(&dir) {
-            Ok(()) => tracing::info!(version = %version, "Evicted old bb version"),
-            Err(e) => tracing::warn!(version = %version, error = %e, "Failed to evict bb version"),
         }
     }
 
@@ -398,21 +392,33 @@ pub async fn cleanup_old_versions(bundled: &AztecVersion, in_use: Option<&AztecV
     }
 }
 
-/// May this version be deleted right now? `true` means leave it alone.
+/// Delete a version directory, but only if no proof holds it — and hold that exclusion across the
+/// deletion itself.
 ///
-/// Two protections, deliberately ordered. A LEASE is the authoritative answer to "is a proof using
-/// this?" — it is held for the whole execution, so a proof that sat behind the prove semaphore for an
-/// hour is still safe. `recently_active` (the directory's mtime inside a five-minute window) is the
-/// weaker fallback, kept only for the gap where a version has been downloaded but no proof holds it
-/// yet.
+/// This is the F-06 closure and the shape matters. Asking "is it leased?" and then deleting is the
+/// same check-then-act the mtime window had: the answer can go stale between the two steps. So the
+/// reservation returned by `begin_evict` is kept alive for the whole `remove_dir_all`, which means a
+/// proof cannot acquire this version at any point during the deletion — it sees `None` and treats the
+/// binary as absent, which it is about to be.
 ///
-/// Split out from the eviction loops because it is the F-06 decision worth pinning: before the lease
-/// existed, cleanup read an mtime and then unlinked, so a proof starting between those two steps lost
-/// its binary — and the size cap made that reachable for `Mainnet` versions the count policy could
-/// never evict. Taking `recently_active` as an argument rather than computing it keeps this a pure
-/// policy function the tests can drive without touching the filesystem clock.
-fn is_protected(version: &str, recently_active: bool) -> bool {
-    super::leases::is_leased(version) || recently_active
+/// `recently_active` is the weaker fallback for the one gap a lease cannot cover: a version that has
+/// been downloaded but that no proof holds yet. Checked first because it needs no reservation.
+///
+/// Returns whether the caller should count this as "deferred by the active window" for the retry pass.
+fn evict_if_unheld(version: &AztecVersion, dir: &std::path::Path, recently_active: bool) -> bool {
+    if recently_active {
+        tracing::debug!(version = %version, "Skipping eviction of a recently-active version");
+        return true;
+    }
+    let Some(_reservation) = super::leases::begin_evict(version.as_str()) else {
+        tracing::debug!(version = %version, "Skipping eviction of a version held by a proof");
+        return false;
+    };
+    match std::fs::remove_dir_all(dir) {
+        Ok(()) => tracing::info!(version = %version, "Evicted old bb version"),
+        Err(e) => tracing::warn!(version = %version, error = %e, "Failed to evict bb version"),
+    }
+    false
 }
 
 /// Bring the cache under [`CACHE_MAX_TOTAL_BYTES`] at process start (F-06, round 3).
@@ -455,15 +461,7 @@ async fn cleanup_after_active_window(bundled: &AztecVersion, in_use: Option<&Azt
         .collect();
     for version in versions_to_evict_for_size(&sized, bundled, in_use, CACHE_MAX_TOTAL_BYTES) {
         let dir = base.join(version.as_str());
-        if is_protected(version.as_str(), super::downloader::recently_active(&dir)) {
-            continue;
-        }
-        match std::fs::remove_dir_all(&dir) {
-            Ok(()) => {
-                tracing::info!(version = %version, "Evicted to stay under the cache size cap (deferred pass)")
-            }
-            Err(e) => tracing::warn!(version = %version, error = %e, "Failed to evict bb version"),
-        }
+        evict_if_unheld(&version, &dir, super::downloader::recently_active(&dir));
     }
 }
 
@@ -718,43 +716,60 @@ mod tests {
 
     // ── F-06 residual closure: the in-use lease ───────────────────────────────────────────────
     // Before the lease, cleanup answered "is anyone using this?" from the directory's mtime: it read
-    // the timestamp and then unlinked, so a proof that started between those two steps lost its
-    // binary, and a proof queued behind the semaphore for longer than the five-minute window was
-    // never protected at all. F-06's size cap made that reachable for `Mainnet` versions, which the
-    // per-tier count policy could never evict.
+    // the timestamp and then unlinked, so a proof starting between those two steps lost its binary,
+    // and a proof queued behind the prove permit for longer than the window was never protected at
+    // all. F-06's size cap made that reachable for `Mainnet` versions the count policy could never
+    // evict. These drive the REAL eviction function, deletion included.
 
-    /// THE property. A leased version survives even when nothing else would protect it — the mtime
-    /// window has already elapsed. Pre-lease this returned false and the binary was deleted.
+    fn seeded_version_dir(tag: &str) -> (tempfile::TempDir, AztecVersion, std::path::PathBuf) {
+        let d = tempfile::tempdir().unwrap();
+        let version = av(&format!("5.0.0-evict-{tag}"));
+        let dir = d.path().join(version.as_str());
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("bb"), b"binary").unwrap();
+        (d, version, dir)
+    }
+
+    /// THE property. A held version survives eviction even though nothing else protects it — its
+    /// activity window has already elapsed. Pre-lease, this directory was deleted.
     #[test]
-    fn a_leased_version_is_protected_even_once_its_activity_window_has_elapsed() {
-        let name = "5.0.0-policy-leased";
-        assert!(
-            !is_protected(name, false),
-            "unleased and inactive: evictable, or the cap could never bind"
-        );
+    fn a_held_version_survives_eviction() {
+        let (_d, version, dir) = seeded_version_dir("held");
+        let lease = super::super::leases::acquire(version.as_str()).unwrap();
 
-        let lease = super::super::leases::acquire(name);
-        assert!(
-            is_protected(name, false),
-            "a proof holds this — evicting it is the bug F-06's cap made reachable"
-        );
+        let deferred = evict_if_unheld(&version, &dir, false);
 
+        assert!(
+            dir.exists(),
+            "a proof is executing this binary — it must not be deleted"
+        );
+        assert!(
+            !deferred,
+            "a lease is not the active-window deferral; it must not re-arm the retry pass"
+        );
         drop(lease);
-        assert!(!is_protected(name, false), "released, so evictable again");
     }
 
-    /// The weaker guard is still there for the window before a lease exists — a version that has
-    /// just been downloaded but that no proof holds yet.
+    /// …and once released it is evictable, or the size cap could never bind.
     #[test]
-    fn the_activity_window_still_protects_an_unleased_but_fresh_version() {
-        assert!(is_protected("5.0.0-policy-fresh", true));
+    fn an_unheld_version_is_evicted() {
+        let (_d, version, dir) = seeded_version_dir("unheld");
+        assert!(!evict_if_unheld(&version, &dir, false));
+        assert!(
+            !dir.exists(),
+            "nothing holds it and its window elapsed — it should be gone"
+        );
     }
 
-    /// A lease protects only what it names.
+    /// The weaker guard still covers the gap a lease cannot: downloaded, not yet held by any proof.
     #[test]
-    fn a_lease_does_not_protect_unrelated_versions() {
-        let _l = super::super::leases::acquire("5.0.0-policy-mine");
-        assert!(!is_protected("5.0.0-policy-theirs", false));
+    fn a_recently_active_version_is_deferred_not_deleted() {
+        let (_d, version, dir) = seeded_version_dir("fresh");
+        assert!(
+            evict_if_unheld(&version, &dir, true),
+            "must report deferral so the retry pass re-arms"
+        );
+        assert!(dir.exists());
     }
 
     #[test]

--- a/packages/accelerator/core/src/versions/version_policy.rs
+++ b/packages/accelerator/core/src/versions/version_policy.rs
@@ -404,15 +404,24 @@ pub async fn cleanup_old_versions(bundled: &AztecVersion, in_use: Option<&AztecV
 /// `recently_active` is the weaker fallback for the one gap a lease cannot cover: a version that has
 /// been downloaded but that no proof holds yet. Checked first because it needs no reservation.
 ///
-/// Returns whether the caller should count this as "deferred by the active window" for the retry pass.
+/// Returns whether the caller should schedule a retry pass — true for anything skipped, whether by
+/// the activity window or by contention.
 fn evict_if_unheld(version: &AztecVersion, dir: &std::path::Path, recently_active: bool) -> bool {
     if recently_active {
         tracing::debug!(version = %version, "Skipping eviction of a recently-active version");
         return true;
     }
-    let Some(_reservation) = super::leases::begin_evict(version.as_str()) else {
-        tracing::debug!(version = %version, "Skipping eviction of a version held by a proof");
-        return false;
+    let _reservation = match super::leases::begin_evict(version.as_str()) {
+        Ok(r) => r,
+        Err(why) => {
+            tracing::debug!(version = %version, ?why, "Skipping eviction of a contended version");
+            // Report this as deferred so the retry pass re-arms. A held version is exactly as
+            // reclaimable-later as a recently-active one, and treating it otherwise meant a version
+            // held during the only retry left the cache over its ceiling until the next download
+            // (found by a codex review). A version still held during the retry as well waits for the
+            // next download or the startup sweep — bounded, and noted in `cleanup_old_versions`.
+            return true;
+        }
     };
     match std::fs::remove_dir_all(dir) {
         Ok(()) => tracing::info!(version = %version, "Evicted old bb version"),
@@ -744,8 +753,9 @@ mod tests {
             "a proof is executing this binary — it must not be deleted"
         );
         assert!(
-            !deferred,
-            "a lease is not the active-window deferral; it must not re-arm the retry pass"
+            deferred,
+            "skipped for ANY reason must re-arm the retry pass — treating a held version as
+             'not deferred' left the cache over its ceiling when the proof outlived the one retry"
         );
         drop(lease);
     }

--- a/packages/sdk/src/lib/accelerator-prover.test.ts
+++ b/packages/sdk/src/lib/accelerator-prover.test.ts
@@ -227,6 +227,47 @@ describe("AcceleratorProver", () => {
       serializeSpy.mockRestore();
     });
 
+    test("falls back to WASM on 503 (accelerator unavailable)", async () => {
+      // The accelerator answers 503 when it is shutting down, and (as of the F-06 version lease) when
+      // the cached bb for this version is being evicted. Both used to reach `throw err`, because the
+      // network-failure branch is gated on `!(err instanceof HTTPError)` and a 503 is one — so
+      // quitting the app mid-proof failed the dApp's transaction outright. The accelerator is an
+      // optimisation; the only correct degradation is WASM.
+      mockFetch({
+        "/health": () =>
+          Response.json({
+            status: "ok",
+            api_version: 1,
+            aztec_version: SDK_AZTEC_VERSION,
+            available_versions: [SDK_AZTEC_VERSION],
+          }),
+        "/prove": () =>
+          Response.json(
+            { error: "service_unavailable", message: "Proving service shutting down" },
+            { status: 503 },
+          ),
+      });
+      const serializeSpy = mockSerializer();
+      const wasmSpy = mockWasmProver();
+      const phases: string[] = [];
+
+      const prover = new AcceleratorProver({
+        simulator: new WASMSimulator(),
+        onPhase: (phase) => phases.push(phase),
+      });
+
+      // Reaching the WASM prover at all is the assertion — the mock rejects, which is how this suite
+      // observes "we got there". Pre-fix the 503 propagated instead and this threw an HTTPError.
+      await expect(prover.createChonkProof([fakeStep])).rejects.toThrow(
+        "local prover not available in test",
+      );
+
+      expect(phases).toContain("fallback");
+      expect(wasmSpy).toHaveBeenCalled();
+      wasmSpy.mockRestore();
+      serializeSpy.mockRestore();
+    });
+
     test("falls back to WASM with denied phase on 403 (origin not authorized)", async () => {
       mockFetch({
         "/health": () =>

--- a/packages/sdk/src/lib/accelerator-prover.ts
+++ b/packages/sdk/src/lib/accelerator-prover.ts
@@ -410,6 +410,24 @@ export class AcceleratorProver extends BBLazyPrivateKernelProver {
         this.#onPhase?.("denied");
         return this.#fallbackToWasm(executionSteps, "Local proof completed after denial");
       }
+      // 503: the accelerator cannot serve this proof right now — it is shutting down, or the cached
+      // bb for this version is being evicted. Degrade rather than fail: the accelerator is an
+      // optimisation, and this file's own rule is to fall back to WASM rather than fail the dApp.
+      //
+      // Without this a 503 fell through to `throw err` below, because the network-failure branch is
+      // gated on `!(err instanceof HTTPError)` and an HTTP 503 is one. That made "quit the app
+      // mid-proof" a hard transaction failure, and the accelerator's version-eviction path would have
+      // added a second way to hit it.
+      //
+      // Deliberately 503 only, not all 5xx: a blanket rule would silently mask genuine
+      // misconfiguration (an oversize payload, say) as "slow but working".
+      if (err instanceof HTTPError && err.response.status === 503) {
+        logger.warn("Accelerator is unavailable (503), falling back to WASM");
+        return this.#fallbackToWasm(
+          executionSteps,
+          "Local proof completed while the accelerator was unavailable",
+        );
+      }
       // Network-level failure: no HTTP response at all (TLS handshake/cert failure, connection
       // refused, timeout). The HTTPS listener/trust may have changed since /health pinned it.
       if (!(err instanceof HTTPError)) {
@@ -482,6 +500,13 @@ export class AcceleratorProver extends BBLazyPrivateKernelProver {
             if (retryErr instanceof HTTPError && retryErr.response.status === 403) {
               this.#onPhase?.("denied");
               return this.#fallbackToWasm(executionSteps, "Local proof completed after denial");
+            }
+            if (retryErr instanceof HTTPError && retryErr.response.status === 503) {
+              logger.warn("Accelerator is unavailable (503) on retry, falling back to WASM");
+              return this.#fallbackToWasm(
+                executionSteps,
+                "Local proof completed while the accelerator was unavailable",
+              );
             }
             logger.warn("HTTP retry also failed, falling back to WASM", {
               error: String(retryErr),

--- a/scripts/download-bb.test.ts
+++ b/scripts/download-bb.test.ts
@@ -32,6 +32,8 @@ import {
   verifyCachedBb,
   versionBbPath,
   versionMarkerPath,
+  parseGuardFlags,
+  usingSharedCache,
 } from "./download-bb";
 
 // These tests exercise the exported functions on the host platform (Linux CI = amd64-linux, matching
@@ -417,5 +419,39 @@ describe("cross-language contract fixtures", () => {
     );
     expect(Array.isArray(r.assets)).toBe(true);
     for (const a of r.assets) expect(a.digest).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+});
+
+describe("accelerator-collision guard", () => {
+  // This script shares ~/.aztec-accelerator/versions with the running app by default, and both
+  // replaces live entries and evicts by retention. The app protects a binary a proof is executing
+  // with an in-process lease, which cannot see us — so the guard is what stops `bun run bb:download`
+  // deleting a binary mid-proof. Both of its escape hatches shipped broken the first time.
+
+  test("--force is consumed as a flag, never treated as a version", () => {
+    const { forced, rest } = parseGuardFlags(["--force", "5.0.0"]);
+    expect(forced).toBe(true);
+    // The bug: "--force" left in the list is parsed as a version and downloaded.
+    expect(rest).toEqual(["5.0.0"]);
+    expect(rest).not.toContain("--force");
+  });
+
+  test("without --force nothing is stripped", () => {
+    const { forced, rest } = parseGuardFlags(["5.0.0", "5.0.1"]);
+    expect(forced).toBe(false);
+    expect(rest).toEqual(["5.0.0", "5.0.1"]);
+  });
+
+  test("BB_VERSIONS_DIR opts out of the shared cache, so the guard must not fire", () => {
+    const prev = process.env.BB_VERSIONS_DIR;
+    try {
+      delete process.env.BB_VERSIONS_DIR;
+      expect(usingSharedCache()).toBe(true);
+      process.env.BB_VERSIONS_DIR = "/tmp/private-bb-cache";
+      expect(usingSharedCache()).toBe(false);
+    } finally {
+      if (prev === undefined) delete process.env.BB_VERSIONS_DIR;
+      else process.env.BB_VERSIONS_DIR = prev;
+    }
   });
 });

--- a/scripts/download-bb.ts
+++ b/scripts/download-bb.ts
@@ -387,7 +387,19 @@ function createStagingDir(version: string): string {
  * Download + verify + stage + finalize + marker + fail-closed publish for one version. Skips (verified)
  * if the cache already holds a marker-valid binary.
  */
-export async function downloadBb(version: string): Promise<void> {
+/**
+ * Called immediately before the destructive publish, so the liveness answer is fresh.
+ *
+ * The guard in `main` runs once at startup, and a download can take minutes — during which the app
+ * can start, publish this version itself, and lease it. Publishing then delete-renames a directory a
+ * proof may be executing. Re-checking at the last moment narrows that to the gap between the check
+ * and the rename; closing it entirely needs cross-process exclusion, which is the accepted residual
+ * documented in `packages/accelerator/core/src/versions/leases.rs`. (Found by a codex review: the
+ * first attempt at this re-probe covered only retention cleanup, which runs AFTER publication.)
+ */
+export type PublishGuard = () => Promise<boolean>;
+
+export async function downloadBb(version: string, guard?: PublishGuard): Promise<void> {
   assertValidVersion(version);
 
   if (verifyCachedBb(version)) {
@@ -460,6 +472,13 @@ export async function downloadBb(version: string): Promise<void> {
     // the two leaves NO live entry (⇒ verified re-download next use) plus a `.tmp.<rand>` stage
     // (reaped by the next install's stage-unique naming + cleanup). Deliberately NOT atomic replacement.
     const vdir = versionDir(version);
+    if (existsSync(vdir) && guard && !(await guard())) {
+      rmSync(stage, { recursive: true, force: true });
+      throw new Error(
+        `the Aztec Accelerator started while this was downloading and may be using ${version}; ` +
+          "refusing to replace it. Quit the app and re-run, or pass --force.",
+      );
+    }
     if (existsSync(vdir)) rmSync(vdir, { recursive: true, force: true });
     renameSync(stage, vdir);
   } catch (err) {
@@ -618,7 +637,11 @@ Platform: ${currentPlatform()}`);
   const downloaded = new Set<string>();
   for (const version of versions) {
     try {
-      await downloadBb(version);
+      await downloadBb(version, async () => {
+        // `true` = safe to publish. Mirrors the startup guard's policy exactly.
+        if (forced || !usingSharedCache()) return true;
+        return !(await acceleratorIsRunning());
+      });
       downloaded.add(version);
     } catch (err) {
       console.error(`  ✗ ${version}: ${err instanceof Error ? err.message : String(err)}`);

--- a/scripts/download-bb.ts
+++ b/scripts/download-bb.ts
@@ -116,6 +116,30 @@ export function versionsBaseDir(): string {
 function versionDir(version: string): string {
   return join(versionsBaseDir(), version);
 }
+
+/**
+ * Refuse to mutate the cache while the accelerator app is running.
+ *
+ * This script and the app share `~/.aztec-accelerator/versions` by default, and this script both
+ * replaces live entries and applies its own retention deletion. The app protects a binary a proof is
+ * executing with an in-process lease (`core/src/versions/leases.rs`) — which, being in-process, is
+ * blind to us. So `bun run bb:download` during a proof could delete the binary out from under it.
+ *
+ * A cross-process lock would be the complete answer; this is the proportionate one. The exposure is a
+ * developer-tooling collision whose worst outcome is a failed proof and a re-download, so a clear
+ * refusal beats a silent race, and `BB_VERSIONS_DIR` already exists for anyone who wants an
+ * independent cache. (Hole found by a codex review of the app-side lease.)
+ */
+async function acceleratorIsRunning(): Promise<boolean> {
+  try {
+    const res = await fetch("http://127.0.0.1:59833/health", {
+      signal: AbortSignal.timeout(700),
+    });
+    return res.ok;
+  } catch {
+    return false; // nothing listening, or it is not answering — either way we are not racing it.
+  }
+}
 export function versionBbPath(version: string): string {
   return join(versionDir(version), "bb");
 }
@@ -512,6 +536,22 @@ async function main(): Promise<void> {
   }
 
   const args = process.argv.slice(2);
+
+  // Read-only paths (--help, --list) are always fine; everything below can delete a live entry.
+  const readOnly =
+    args.length === 0 ||
+    args.includes("--help") ||
+    args.includes("-h") ||
+    args.includes("--list");
+  if (!readOnly && !args.includes("--force") && (await acceleratorIsRunning())) {
+    console.error(
+      "The Aztec Accelerator is running and shares this cache.\n" +
+        `Cache: ${versionsBaseDir()}\n\n` +
+        "Downloading now can delete a binary a proof is currently executing. Quit the app first,\n" +
+        "point this run at its own cache with BB_VERSIONS_DIR=..., or pass --force if you are sure.",
+    );
+    process.exit(1);
+  }
 
   if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
     console.log(`Usage: bun scripts/download-bb.ts <version>[,<version>,...] [--list]

--- a/scripts/download-bb.ts
+++ b/scripts/download-bb.ts
@@ -130,6 +130,27 @@ function versionDir(version: string): string {
  * refusal beats a silent race, and `BB_VERSIONS_DIR` already exists for anyone who wants an
  * independent cache. (Hole found by a codex review of the app-side lease.)
  */
+/**
+ * Split the accelerator-guard flag out of the argument list.
+ *
+ * `--force` is a FLAG, not a version. The first cut of the guard read it with `args.includes` but
+ * left it in the list, so it flowed into the version parser and was downloaded as though it were a
+ * version — the escape hatch was advertised and broken at the same time (found by a codex review).
+ */
+export function parseGuardFlags(args: string[]): { forced: boolean; rest: string[] } {
+  return {
+    forced: args.includes("--force"),
+    rest: args.filter((a) => a !== "--force"),
+  };
+}
+
+export function usingSharedCache(): boolean {
+  // `BB_VERSIONS_DIR` points this run at its own cache, so there is nothing to collide with and the
+  // guard must not fire. (It was advertised as an escape hatch while not actually being one — found
+  // by a codex review.)
+  return !process.env.BB_VERSIONS_DIR;
+}
+
 async function acceleratorIsRunning(): Promise<boolean> {
   try {
     const res = await fetch("http://127.0.0.1:59833/health", {
@@ -537,13 +558,15 @@ async function main(): Promise<void> {
 
   const args = process.argv.slice(2);
 
+  const { forced, rest } = parseGuardFlags(args);
+
   // Read-only paths (--help, --list) are always fine; everything below can delete a live entry.
   const readOnly =
-    args.length === 0 ||
-    args.includes("--help") ||
-    args.includes("-h") ||
-    args.includes("--list");
-  if (!readOnly && !args.includes("--force") && (await acceleratorIsRunning())) {
+    rest.length === 0 ||
+    rest.includes("--help") ||
+    rest.includes("-h") ||
+    rest.includes("--list");
+  if (!readOnly && !forced && usingSharedCache() && (await acceleratorIsRunning())) {
     console.error(
       "The Aztec Accelerator is running and shares this cache.\n" +
         `Cache: ${versionsBaseDir()}\n\n` +
@@ -553,7 +576,7 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
+  if (rest.length === 0 || rest.includes("--help") || rest.includes("-h")) {
     console.log(`Usage: bun scripts/download-bb.ts <version>[,<version>,...] [--list]
 
 Downloads + verifies bb binaries for specific Aztec versions.
@@ -566,7 +589,7 @@ Platform: ${currentPlatform()}`);
     process.exit(0);
   }
 
-  if (args.includes("--list")) {
+  if (rest.includes("--list")) {
     const cached = listCachedVersions();
     console.log(`Cache: ${versionsBaseDir()}`);
     if (cached.length === 0) {
@@ -578,7 +601,7 @@ Platform: ${currentPlatform()}`);
     process.exit(0);
   }
 
-  const versions = args
+  const versions = rest
     .flatMap((a) => a.split(","))
     .map((v) => v.trim())
     .filter(Boolean);
@@ -604,7 +627,19 @@ Platform: ${currentPlatform()}`);
   }
 
   console.log("");
-  cleanupOldVersions(downloaded);
+
+  // Re-probe. The check above ran BEFORE downloads that can take minutes, so the app may have
+  // started in the meantime — and retention eviction below deletes live entries. This narrows the
+  // window to the gap between this line and the deletions; it does not eliminate it, which is why
+  // the residual is documented in `core/src/versions/leases.rs` rather than claimed closed.
+  if (!forced && usingSharedCache() && (await acceleratorIsRunning())) {
+    console.error(
+      "The Aztec Accelerator started while this was downloading; skipping retention cleanup so a\n" +
+        "binary in use is not deleted. Re-run once it has quit to reclaim space.",
+    );
+  } else {
+    cleanupOldVersions(downloaded);
+  }
 
   const cached = listCachedVersions();
   console.log(`\nCached versions: ${cached.join(", ") || "(none)"}`);


### PR DESCRIPTION
Closes the last open residual from the `2026-07-31-9c4cb0c` audit's F-06, plus a pre-existing SDK failure mode that F-06 made more reachable.

## The bug

Cleanup decided "is anyone using this cached `bb`?" from the version directory's mtime — touched within five minutes meant active. That fails two ways:

- It reads the mtime and **then** unlinks, so a proof starting between those two steps loses its binary anyway.
- A proof queued behind the prove permit for longer than the window was never protected at all.

F-06's own fix sharpened it: the total-size cap can evict a `Mainnet` version, which the per-tier count policy never could, so entries that were previously immortal became eligible while in use.

## The fix

A proof takes a **lease** before it resolves its binary and holds it through execution. Eviction takes a **reservation** — not a query — so reserve-and-delete is one critical section and a proof cannot slip in between. Refcounted, because two concurrent proofs of one version are ordinary and the first to finish must not unprotect the second. Releases through panics and poisoned locks, because a crashed proof pinning a version forever would be the same bug wearing a different hat.

## What five review rounds found

Each round found a defect in the previous round's fix. Recorded because the pattern is the useful part:

| Round | Finding |
|---|---|
| 1 | The lease was a *predicate*, so `is_leased()` + `remove_dir_all` was the same check-then-act it replaced |
| 1 | Semaphore waiters unprotected — the exact case the first commit message claimed to fix |
| 1 | A third deletion path (download publish) with no lease check |
| 1 | Single-process premise false: the startup sweep ran **before** the port bind |
| 2 | Publisher conflated "held" with "being deleted", reporting success over a directory mid-deletion |
| 2 | A **second process** shares the cache — `scripts/download-bb.ts` — which my module comment denied |
| 2 | Cap reclamation lost: a held candidate never re-armed the retry pass |
| 3 | "Held" doesn't imply "valid" — `bb::prove` leases *before* `find_bb` verifies |
| 3 | Both advertised escape hatches broken (`--force` parsed as a version; `BB_VERSIONS_DIR` didn't bypass) |
| 4 | The re-probe ran *after* `downloadBb`, but the destructive publish is *inside* it |

The reviewer's read on whether this was structurally wrong: it isn't — the findings came from untested integration boundaries, above all the second writer, not from the state machine.

## UX changes

| | Before | After |
|---|---|---|
| Quit the accelerator mid-proof | dApp transaction **fails** | proves in WASM |
| Version evicted mid-proof | race; binary could vanish under a running proof | proves in WASM |
| `bun run bb:download` while the app runs | silently races; can delete a binary in use | **refuses**, with `--force` / `BB_VERSIONS_DIR` |

The first is a **pre-existing** bug: the SDK's fallback branch is gated on `!(err instanceof HTTPError)` and a 503 is one, so only 403 ever degraded. F-06 added a second route to it, so the mitigation ships with the trigger. Deliberately 503 only, not all 5xx — a blanket rule would mask genuine misconfiguration as "slow but working".

## Accepted residual

**Cross-process exclusion is not built.** `scripts/download-bb.ts` shares `~/.aztec-accelerator/versions` by default; the lease is in-process and cannot see it. The tool now refuses to run while the accelerator answers on its port, and re-checks immediately before publishing, but the check-to-unlink gap remains. This is an explicitly accepted, low-impact developer-tooling residual — worst outcome is a failed proof and a re-download — not full race closure. Documented as such in `leases.rs`.

Deletion-path inventory is closed: two live-directory sites in Rust, two in TypeScript; everything else targets staging or test directories.

## Verification

218 core + 108 src-tauri Rust, 95 SDK, all TS suites, `bun run lint`, `cargo clippy -D warnings`. 14 new tests; 9 mutation-proved by reverting each fix and confirming the named test fails.

One mutation reported WEAK initially because the mutation itself failed to compile — which is indistinguishable from a passing test. Rewritten until it reproduced the defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
