### PR TITLE
docs(audit): fix the HTML report contradicting its own status callout

### DIFF
--- a/audit/security/2026-07-31-9c4cb0c/report.html
+++ b/audit/security/2026-07-31-9c4cb0c/report.html
@@ -174,7 +174,10 @@
     <li><strong>F-02 and F-04 confirmed as written</strong>, including the claim the verifier tried
       hardest to break.</li>
   </ul>
-  <p>Nothing here has been fixed — no code changes have been made from this audit.</p>
+  <p>
+    That verification pass ran before any remediation. Seven findings have been fixed since — see the
+    status note above; the finding entries below still describe the code as the audit found it.
+  </p>
 </div>
 
 <div class="callout">


### PR DESCRIPTION
Line 177 still read *"Nothing here has been fixed — no code changes have been made from this audit"*, directly beneath a callout listing seven fixes.

True when the verification pass was written; nobody revisited it while adding the status notes above it. Caught by reading the file end to end before republishing it, rather than trusting piecemeal edits.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)